### PR TITLE
🔒 fix: prevent insecure content script injection into arbitrary tabs

### DIFF
--- a/background.js
+++ b/background.js
@@ -109,6 +109,11 @@ function getTabLabel(tab) {
 
 // --- Ensure content script is injected into a tab ---
 async function ensureContentScript(tabId) {
+  const tab = await chrome.tabs.get(tabId)
+  if (!tab.url?.startsWith('https://jules.google.com/')) {
+    throw new Error('Security Error: Cannot inject script into non-Jules tab')
+  }
+
   try {
     await chrome.tabs.sendMessage(tabId, { action: 'PING' })
   } catch {


### PR DESCRIPTION
🎯 **What:** The `ensureContentScript` function in `background.js` previously injected `content.js` into any tab specified by `tabId` if the content script wasn't already running. It did not verify the URL of the tab prior to injection.

⚠️ **Risk:** If an attacker somehow gained the ability to influence the `tabId` passed to `ensureContentScript` (e.g., through tab reuse, navigation, or another exploit), they could cause the extension to inject `content.js` into an attacker-controlled page. Since content scripts run with elevated privileges (relative to normal page scripts) and can interact with the background service worker, this could lead to information disclosure or further exploitation.

🛡️ **Solution:** The fix retrieves the tab information using `chrome.tabs.get(tabId)` and validates that its `url` property starts with `https://jules.google.com/` (with a trailing slash to prevent domain prefix spoofing, like `jules.google.com.attacker.com`). If the URL does not match or is missing, a security error is thrown, aborting the injection process.

*Note: Since there is no automated test suite, I verified this logic locally with an isolated unit test using node stubbing.*

---
*PR created automatically by Jules for task [8726921349670586438](https://jules.google.com/task/8726921349670586438) started by @n24q02m*