### PR TITLE
🔒 fix: Store GitHub token locally instead of in sync storage

### DIFF
--- a/.github/best_practices.md
+++ b/.github/best_practices.md
@@ -18,7 +18,7 @@ Chrome Extension (Manifest V3) with 3 layers:
 ## Security
 
 - No `innerHTML` — all DOM construction uses `textContent` + `createElement`
-- GitHub tokens stored in `chrome.storage.sync` (user choice: convenience vs security)
+- GitHub tokens stored in `chrome.storage.local` (security over convenience)
 - Only communicates with `jules.google.com` and `api.github.com`
 - All GitHub API responses treated as untrusted data
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,7 +17,7 @@ If you discover a security vulnerability, please report it responsibly:
 
 ## Security Considerations
 
-- **GitHub tokens** stored in `chrome.storage.sync` are synced across devices. Use a token with minimal permissions (`public_repo` scope only)
+- **GitHub tokens** are stored locally in `chrome.storage.local` to prevent syncing sensitive credentials across devices. However, you should still use a token with minimal permissions (`public_repo` scope only)
 - The extension only communicates with `jules.google.com` and `api.github.com`
 - No data is sent to any third-party servers
 - Content scripts run in an isolated world and cannot access page JavaScript variables

--- a/background.js
+++ b/background.js
@@ -169,7 +169,18 @@ async function processTab(tab, options) {
   }
 
   // Check PRs and decide which repos to archive
-  const { ghOwner, ghToken } = await chrome.storage.sync.get(['ghOwner', 'ghToken'])
+  const { ghOwner } = await chrome.storage.sync.get(['ghOwner'])
+  let { ghToken } = await chrome.storage.local.get(['ghToken'])
+
+  // Migrate token from sync to local if it exists in sync
+  if (!ghToken) {
+    const syncData = await chrome.storage.sync.get(['ghToken'])
+    if (syncData.ghToken) {
+      ghToken = syncData.ghToken
+      await chrome.storage.local.set({ ghToken })
+      await chrome.storage.sync.remove('ghToken')
+    }
+  }
 
   addLog(`\n[${label}] Checking open PRs...`)
   const toArchive = []

--- a/popup.js
+++ b/popup.js
@@ -20,9 +20,19 @@ const logPre = $('#log')
 const summaryDiv = $('#summary')
 
 // --- Load saved settings ---
-chrome.storage.sync.get(['ghOwner', 'ghToken'], (data) => {
-  if (data.ghOwner) ghOwnerInput.value = data.ghOwner
-  if (data.ghToken) ghTokenInput.value = data.ghToken
+chrome.storage.sync.get(['ghOwner', 'ghToken'], (syncData) => {
+  if (syncData.ghOwner) ghOwnerInput.value = syncData.ghOwner
+
+  chrome.storage.local.get(['ghToken'], (localData) => {
+    if (localData.ghToken) {
+      ghTokenInput.value = localData.ghToken
+      if (syncData.ghToken) chrome.storage.sync.remove('ghToken')
+    } else if (syncData.ghToken) {
+      ghTokenInput.value = syncData.ghToken
+      chrome.storage.local.set({ ghToken: syncData.ghToken })
+      chrome.storage.sync.remove('ghToken')
+    }
+  })
 })
 
 // --- Save settings on change ---
@@ -30,14 +40,16 @@ ghOwnerInput.addEventListener('change', () => {
   chrome.storage.sync.set({ ghOwner: ghOwnerInput.value.trim() })
 })
 ghTokenInput.addEventListener('change', () => {
-  chrome.storage.sync.set({ ghToken: ghTokenInput.value.trim() })
+  chrome.storage.local.set({ ghToken: ghTokenInput.value.trim() })
 })
 
 // --- Start archive ---
 startBtn.addEventListener('click', async () => {
   // Save settings first
   chrome.storage.sync.set({
-    ghOwner: ghOwnerInput.value.trim(),
+    ghOwner: ghOwnerInput.value.trim()
+  })
+  chrome.storage.local.set({
     ghToken: ghTokenInput.value.trim()
   })
 


### PR DESCRIPTION
🎯 **What:** The GitHub token is no longer saved to `chrome.storage.sync`. It's now stored in `chrome.storage.local`. Additionally, token migration logic was introduced to seamlessly switch existing users.
⚠️ **Risk:** Storing sensitive access tokens in sync storage exposes them across devices, which makes them vulnerable to potential token leaks.
🛡️ **Solution:** `popup.js` and `background.js` have been updated to securely store the token using `chrome.storage.local`, isolating it to the current device. Documentation (`SECURITY.md` and `.github/best_practices.md`) was updated to reflect this fix.

---
*PR created automatically by Jules for task [8818141614530459289](https://jules.google.com/task/8818141614530459289) started by @n24q02m*