### PR TITLE
🔒 fix: prevent TOCTOU vulnerability in content script injection

### DIFF
--- a/background.js
+++ b/background.js
@@ -118,6 +118,10 @@ async function ensureContentScript(tabId) {
     await chrome.tabs.sendMessage(tabId, { action: 'PING' })
   } catch {
     // Content script not loaded — inject it programmatically
+    const currentTab = await chrome.tabs.get(tabId)
+    if (!currentTab.url?.startsWith('https://jules.google.com/')) {
+      throw new Error('Security Error: Tab navigated away from Jules before injection')
+    }
     await chrome.scripting.executeScript({
       target: { tabId },
       files: ['content.js']


### PR DESCRIPTION
🎯 **What:** The content script was injected based on `tabId` after waiting for a `sendMessage` ping to fail.
⚠️ **Risk:** A Time-of-Check to Time-of-Use (TOCTOU) vulnerability where the tab could navigate to a malicious URL between the initial URL check and the actual script injection. This could lead to injecting the extension's content script into an untrusted origin, potentially exposing extension privileges or sensitive data.
🛡️ **Solution:** Added an additional URL check immediately prior to calling `chrome.scripting.executeScript` to ensure the tab is still on the expected `https://jules.google.com/` domain.

---
*PR created automatically by Jules for task [9081888403704879314](https://jules.google.com/task/9081888403704879314) started by @n24q02m*