### PR TITLE
🧹 fix: Use robust polling instead of hardcoded setTimeout in ensureContentScript

### DIFF
--- a/background.js
+++ b/background.js
@@ -123,13 +123,14 @@ async function ensureContentScript(tabId) {
       files: ['content.js']
     })
     // Wait for script to initialize via polling
-    for (let i = 0; i < 10; i++) {
+    const startTime = Date.now()
+    while (Date.now() - startTime < 5000) {
       try {
-        await new Promise((r) => setTimeout(r, 50))
         await chrome.tabs.sendMessage(tabId, { action: 'PING' })
         break
       } catch {
         // Keep waiting
+        await new Promise((r) => setTimeout(r, 50))
       }
     }
   }


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Replaced the hardcoded polling mechanism (a loop sending a PING and waiting 50ms) in `ensureContentScript` with a more robust time-based polling approach.

💡 **Why:** How this improves maintainability
The previous implementation used a fixed `for` loop iteration with `setTimeout` which could either wait unnecessarily or not wait long enough under slower conditions. The new implementation uses a `while` loop that tries to send a PING immediately. It checks `Date.now() - startTime` to enforce a timeout of 5000ms, making it faster when the content script is ready instantly, and resilient to arbitrary wait counts.

✅ **Verification:** How you confirmed the change is safe
- Verified no syntax or logical errors.
- Ran formatting using `@biomejs/biome`.
- Executed `npm test`, ensuring that `background.js` state management behaves correctly. The `node:vm` tests passed.
- Maintained exact functionality for other parts of the service worker, only modifying `ensureContentScript`.

✨ **Result:** The improvement achieved
A more resilient and slightly faster content script injection process that does not rely on static delays.

---
*PR created automatically by Jules for task [14391082369598479638](https://jules.google.com/task/14391082369598479638) started by @n24q02m*