### PR TITLE
⚡ Optimize GitHub PR fetching with Promise.all

### DIFF
--- a/background.js
+++ b/background.js
@@ -199,23 +199,33 @@ async function processTab(tab, options) {
   const toArchive = []
   const toSkip = []
 
-  for (const r of repos) {
+  const prPromises = repos.map(async (r) => {
     if (options.force) {
-      toArchive.push(r)
-      continue
+      return { r, type: 'ARCHIVE', reason: 'force' }
     }
     const owner = r.owner || ghOwner || ''
     if (!owner) {
-      addLog(`  ${r.repo}: no owner configured, skipping PR check -> ARCHIVE`)
-      toArchive.push(r)
-      continue
+      return { r, type: 'ARCHIVE', reason: 'no-owner' }
     }
     const count = await getOpenPRCount(owner, r.repo, ghToken)
-    addLog(`  ${r.repo}: ${count} open PRs ${count === 0 ? '-> ARCHIVE' : '-> SKIP'}`)
-    if (count === 0) {
-      toArchive.push(r)
+    return { r, type: count === 0 ? 'ARCHIVE' : 'SKIP', count }
+  })
+
+  const results = await Promise.all(prPromises)
+
+  for (const res of results) {
+    if (res.reason === 'force') {
+      toArchive.push(res.r)
+    } else if (res.reason === 'no-owner') {
+      addLog(`  ${res.r.repo}: no owner configured, skipping PR check -> ARCHIVE`)
+      toArchive.push(res.r)
     } else {
-      toSkip.push(r)
+      addLog(`  ${res.r.repo}: ${res.count} open PRs ${res.type === 'ARCHIVE' ? '-> ARCHIVE' : '-> SKIP'}`)
+      if (res.type === 'ARCHIVE') {
+        toArchive.push(res.r)
+      } else {
+        toSkip.push(res.r)
+      }
     }
   }
 

--- a/benchmark.js
+++ b/benchmark.js
@@ -1,0 +1,93 @@
+const fs = require('node:fs')
+const vm = require('node:vm')
+const path = require('node:path')
+const { performance } = require('node:perf_hooks')
+
+const bgScriptPath = path.join(__dirname, 'background.js')
+const bgScriptContent = fs.readFileSync(bgScriptPath, 'utf8')
+
+async function runBenchmark() {
+  const _sessionSetData = []
+  let currentStorage = {}
+
+  const chromeMock = {
+    storage: {
+      session: {
+        get: async (key) => (key ? { [key]: currentStorage[key] } : currentStorage),
+        set: async (data) => {
+          currentStorage = { ...currentStorage, ...data }
+        }
+      },
+      sync: {
+        get: async () => ({ ghOwner: 'test-owner' }),
+        remove: async () => {}
+      },
+      local: {
+        get: async () => ({ ghToken: 'test-token' }),
+        set: async () => {}
+      }
+    },
+    runtime: {
+      onMessage: { addListener: () => {} },
+      getPlatformInfo: async () => ({})
+    },
+    tabs: {
+      query: async () => [],
+      sendMessage: async (_tabId, msg) => {
+        if (msg.action === 'GET_REPOS') {
+          // generate 10 repos
+          return {
+            repos: Array.from({ length: 10 }, (_, i) => ({
+              name: `repo-${i}`,
+              repo: `repo-${i}`,
+              tasks: 1,
+              owner: 'test-owner'
+            }))
+          }
+        }
+        return {}
+      },
+      get: async () => ({ url: 'https://jules.google.com/' })
+    },
+    scripting: {
+      executeScript: async () => {}
+    }
+  }
+
+  const sandbox = {
+    chrome: chromeMock,
+    fetch: async () => {
+      await new Promise((r) => setTimeout(r, 100)) // 100ms delay
+      return { ok: true, json: async () => [] } // returns 0 PRs
+    },
+    setTimeout,
+    setInterval,
+    clearInterval,
+    console
+  }
+
+  vm.createContext(sandbox)
+
+  const scriptContent =
+    bgScriptContent +
+    `\n
+    globalThis.test_processTab = processTab;
+    globalThis.test_prCache = prCache;
+    globalThis.test_stateReadyPromise = stateReadyPromise;
+  `
+
+  const script = new vm.Script(scriptContent)
+  script.runInContext(sandbox)
+
+  await sandbox.test_stateReadyPromise
+
+  sandbox.test_prCache.clear()
+
+  const start = performance.now()
+  await sandbox.test_processTab({ id: 1, url: 'https://jules.google.com/u/0' }, { dryRun: true, force: false })
+  const end = performance.now()
+
+  console.log(`Execution time: ${(end - start).toFixed(2)}ms`)
+}
+
+runBenchmark().catch(console.error)


### PR DESCRIPTION
💡 **What:**
Replaced the sequential `for` loop that awaits `getOpenPRCount` one by one with a concurrent approach. Mapped the repositories array to an array of Promises (handling synchronously checked rules like `options.force` and `!owner`), executed them concurrently using `Promise.all`, and then sequentially processed the results to populate `toArchive`/`toSkip` arrays and maintain existing logging formats.

🎯 **Why:**
Fetching open Pull Request counts sequentially across multiple repositories inside `background.js` created a massive I/O bottleneck. Since these API queries do not depend on one another, they can be fired concurrently to drastically reduce the total operation duration, yielding a much more responsive user experience during the archive loop.

📊 **Measured Improvement:**
A dedicated benchmark script mimicking the browser environment and introducing an artificial 100ms API response delay was created.
- Baseline (Sequential): ~1008ms for 10 mock repositories.
- Optimized (Concurrent): ~102ms for 10 mock repositories.
This represents a ~90% decrease in execution time for I/O bound wait operations.

---
*PR created automatically by Jules for task [16714264193988179270](https://jules.google.com/task/16714264193988179270) started by @n24q02m*