### PR TITLE
⚡ Bolt: Batch GitHub PR API checks concurrently

### DIFF
--- a/background.js
+++ b/background.js
@@ -199,23 +199,36 @@ async function processTab(tab, options) {
   const toArchive = []
   const toSkip = []
 
-  for (const r of repos) {
+  // ⚡ Bolt: Batch GitHub API calls to check PRs concurrently instead of sequentially
+  // This reduces wait time from O(N) to O(1) network round trips when a tab has multiple repos
+  const prChecks = repos.map(async (r) => {
     if (options.force) {
-      toArchive.push(r)
-      continue
+      return { repo: r, action: 'force' }
     }
     const owner = r.owner || ghOwner || ''
     if (!owner) {
-      addLog(`  ${r.repo}: no owner configured, skipping PR check -> ARCHIVE`)
-      toArchive.push(r)
-      continue
+      return { repo: r, action: 'no_owner' }
     }
     const count = await getOpenPRCount(owner, r.repo, ghToken)
-    addLog(`  ${r.repo}: ${count} open PRs ${count === 0 ? '-> ARCHIVE' : '-> SKIP'}`)
-    if (count === 0) {
+    return { repo: r, action: 'check', count }
+  })
+
+  const checkResults = await Promise.all(prChecks)
+
+  for (const result of checkResults) {
+    const { repo: r, action, count } = result
+    if (action === 'force') {
+      toArchive.push(r)
+    } else if (action === 'no_owner') {
+      addLog(`  ${r.repo}: no owner configured, skipping PR check -> ARCHIVE`)
       toArchive.push(r)
     } else {
-      toSkip.push(r)
+      addLog(`  ${r.repo}: ${count} open PRs ${count === 0 ? '-> ARCHIVE' : '-> SKIP'}`)
+      if (count === 0) {
+        toArchive.push(r)
+      } else {
+        toSkip.push(r)
+      }
     }
   }
 


### PR DESCRIPTION
💡 **What**: The optimization refactors the GitHub API polling logic in `background.js` from a sequential `for...of` loop with an `await` on every request, into an array of `.map` Promises resolved simultaneously with `Promise.all()`.

🎯 **Why**: When a tab contains multiple repositories (N), sequentially awaiting the GitHub API (which might take 200-500ms per request) causes the whole process to block for O(N) network round trips before it even starts archiving. 

📊 **Impact**: Reduces total API wait time from roughly `N * 300ms` down to roughly `1 * 300ms` per tab, making the "Checking open PRs..." phase drastically faster for users with many repos.

🔬 **Measurement**: In your test environment, run the extension on a tab with ~5 repos. The logs should appear nearly instantly for all repos at once, instead of staggering one by one. Tests in `tests/background.test.js` continue to pass.

---
*PR created automatically by Jules for task [3127032208378943683](https://jules.google.com/task/3127032208378943683) started by @n24q02m*