### PR TITLE
🎨 Palette: Add keyboard focus states and screen reader progress tracking

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -201,3 +201,9 @@ button.secondary:hover {
 .summary .skipped {
   color: #fbbf24;
 }
+
+input:focus-visible,
+button:focus-visible {
+  outline: 2px solid #4ade80;
+  outline-offset: 2px;
+}

--- a/popup.html
+++ b/popup.html
@@ -41,10 +41,10 @@
     <button type="button" id="startBtn" class="primary">Start</button>
     <button type="button" id="resetBtn" class="secondary" style="display: none">Reset</button>
 
-    <section id="progressSection" style="display: none">
+    <section id="progressSection" style="display: none" aria-live="polite">
       <h2>Progress</h2>
       <div id="currentInfo" class="current-info"></div>
-      <div class="progress-bar">
+      <div class="progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
         <div id="progressFill" class="progress-fill"></div>
       </div>
       <pre id="log" class="log"></pre>

--- a/popup.js
+++ b/popup.js
@@ -81,6 +81,7 @@ startBtn.addEventListener('click', async () => {
   summarySection.style.display = 'none'
   currentInfo.textContent = 'Starting...'
   progressFill.style.width = '0%'
+  progressFill.parentElement.setAttribute('aria-valuenow', '0')
   logPre.textContent = ''
 
   chrome.runtime.sendMessage({ action: 'START', options })
@@ -123,6 +124,7 @@ function renderState(state) {
     if (state.progress?.total > 0) {
       const pct = Math.round(((state.progress.archived + state.progress.skipped) / state.progress.total) * 100)
       progressFill.style.width = `${pct}%`
+      progressFill.parentElement.setAttribute('aria-valuenow', pct.toString())
       currentInfo.textContent += ` [${state.progress.archived + state.progress.skipped}/${state.progress.total}]`
     }
   }
@@ -133,6 +135,7 @@ function renderState(state) {
     startBtn.textContent = 'Start'
     resetBtn.style.display = 'block'
     progressFill.style.width = '100%'
+    progressFill.parentElement.setAttribute('aria-valuenow', '100')
 
     if (state.status === 'done') {
       currentInfo.textContent = 'Complete'

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1,0 +1,34 @@
+from playwright.sync_api import sync_playwright
+
+def run_cuj(page):
+    page.goto("file:///app/popup.html")
+    page.wait_for_timeout(500)
+
+    # Test focus state on inputs
+    page.locator("#ghOwner").focus()
+    page.wait_for_timeout(500)
+
+    # Test focus state on buttons
+    page.locator("#startBtn").focus()
+    page.wait_for_timeout(500)
+
+    # Click start to see progress section
+    page.locator("#startBtn").click()
+    page.wait_for_timeout(500)
+
+    # Take screenshot
+    page.screenshot(path="/tmp/verification.png")
+    page.wait_for_timeout(1000)
+
+if __name__ == "__main__":
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        context = browser.new_context(
+            record_video_dir="/tmp/videos"
+        )
+        page = context.new_page()
+        try:
+            run_cuj(page)
+        finally:
+            context.close()
+            browser.close()


### PR DESCRIPTION
💡 **What:** Added keyboard focus states and screen reader support for the progress bar.
🎯 **Why:** To make the extension more accessible for users relying on keyboard navigation (clearer active states) and screen readers (announcing live progress updates).
♿ **Accessibility:**
- Added `outline` styles using `:focus-visible` for buttons and inputs.
- Converted visual `div` progress bar into a semantic `progressbar` role with dynamic `aria-valuenow` updates.
- Added `aria-live="polite"` to the progress section.

---
*PR created automatically by Jules for task [17511594498187468283](https://jules.google.com/task/17511594498187468283) started by @n24q02m*