### PR TITLE
⚡ Bolt: [performance improvement] Execute PR checks concurrently

### DIFF
--- a/background.js
+++ b/background.js
@@ -199,23 +199,32 @@ async function processTab(tab, options) {
   const toArchive = []
   const toSkip = []
 
-  for (const r of repos) {
+  // ⚡ Bolt: Execute PR checks concurrently to avoid O(N) sequential blocking
+  const prChecks = repos.map(async (r) => {
     if (options.force) {
-      toArchive.push(r)
-      continue
+      return { r, action: 'archive', reason: 'force mode' }
     }
     const owner = r.owner || ghOwner || ''
     if (!owner) {
-      addLog(`  ${r.repo}: no owner configured, skipping PR check -> ARCHIVE`)
-      toArchive.push(r)
-      continue
+      return { r, action: 'archive', reason: 'no owner configured, skipping PR check' }
     }
     const count = await getOpenPRCount(owner, r.repo, ghToken)
-    addLog(`  ${r.repo}: ${count} open PRs ${count === 0 ? '-> ARCHIVE' : '-> SKIP'}`)
-    if (count === 0) {
-      toArchive.push(r)
+    return { r, count, action: count === 0 ? 'archive' : 'skip' }
+  })
+
+  const results = await Promise.all(prChecks)
+
+  for (const res of results) {
+    if (res.reason) {
+      addLog(`  ${res.r.repo}: ${res.reason} -> ARCHIVE`)
     } else {
-      toSkip.push(r)
+      addLog(`  ${res.r.repo}: ${res.count} open PRs -> ${res.action === 'archive' ? 'ARCHIVE' : 'SKIP'}`)
+    }
+
+    if (res.action === 'archive') {
+      toArchive.push(res.r)
+    } else {
+      toSkip.push(res.r)
     }
   }
 


### PR DESCRIPTION
💡 What: Replaced sequential `await` loop for GitHub API PR checks with an array of Promises and `Promise.all()`.
🎯 Why: Sequential network requests created an O(N) bottleneck, unnecessarily delaying the start of the archive operation when multiple repos needed to be checked.
📊 Impact: Reduces wait time for PR checks from O(N) to O(1), making the scanning phase nearly instant regardless of the number of repos.
🔬 Measurement: The total time to log "Checking open PRs..." and the subsequent "ARCHIVE"/"SKIP" decisions in the background worker log will be significantly faster when processing more than one repo.

---
*PR created automatically by Jules for task [4273123662375219893](https://jules.google.com/task/4273123662375219893) started by @n24q02m*