### PR TITLE
[FIX] Use URL API instead of Regex for account ID

### DIFF
--- a/content.js
+++ b/content.js
@@ -49,13 +49,15 @@ function extractConfig() {
 
 // Detect account number from URL
 function getAccountNum() {
-  const m = location.href.match(/\/u\/(\d+)/)
-  return m ? m[1] : '0'
+  const path = new URL(location.href).pathname
+  const parts = path.split('/')
+  const uIdx = parts.indexOf('u')
+  return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
 }
 
 function getAccountLabel() {
-  const m = location.href.match(/\/u\/(\d+)/)
-  return m ? `u/${m[1]}` : 'default'
+  const num = getAccountNum()
+  return num !== '0' ? `u/${num}` : 'default'
 }
 
 // Message handler

--- a/tests/content.test.js
+++ b/tests/content.test.js
@@ -51,8 +51,10 @@ describe('content.js config extraction logic', () => {
 
   it('should parse account number from URL paths', () => {
     function getAccountNum(url) {
-      const m = url.match(/\/u\/(\d+)/)
-      return m ? m[1] : '0'
+      const path = new URL(url).pathname
+      const parts = path.split('/')
+      const uIdx = parts.indexOf('u')
+      return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
     }
 
     assert.strictEqual(getAccountNum('https://jules.google.com/u/3/session'), '3')


### PR DESCRIPTION
This PR replaces the regex-based extraction of the Jules account ID from the URL with a more robust implementation using the native `URL` API.

Key changes:
- Updated `getAccountNum` and `getAccountLabel` in `content.js` to parse `location.href` using `new URL()`.
- Updated the corresponding unit tests in `tests/content.test.js` to reflect the logic change.
- Ensured all tests pass and code is correctly formatted via Biome.

---
*PR created automatically by Jules for task [18411715622571806103](https://jules.google.com/task/18411715622571806103) started by @n24q02m*