### PR TITLE
[SECURITY] Missing Authorization Header Validation

### DIFF
--- a/background.js
+++ b/background.js
@@ -503,14 +503,13 @@ async function processSuggestionsForTab(tab, options) {
 const prCache = new Map()
 
 async function getOpenPRCount(owner, repo, token) {
-  const key = `${owner}/${repo}`
+  const key = `${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`
   if (prCache.has(key)) return prCache.get(key)
 
   try {
-    const url = `https://api.github.com/repos/${owner}/${repo}/pulls?state=open&per_page=100`
+    const url = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/pulls?state=open&per_page=100`
     const headers = { Accept: 'application/vnd.github+json' }
-    if (token) headers.Authorization = `token ${token}`
-
+    if (token && !/[\r\n]/.test(token)) headers.Authorization = `token ${token}`
     const res = await fetch(url, { headers })
     if (!res.ok) {
       addLog(`  WARNING: GitHub API ${res.status} for ${key}, assuming 0`)

--- a/tests/security.test.js
+++ b/tests/security.test.js
@@ -1,0 +1,88 @@
+const { describe, it } = require('node:test')
+const assert = require('node:assert')
+const fs = require('node:fs')
+const vm = require('node:vm')
+const path = require('node:path')
+
+const bgScriptPath = path.join(__dirname, '..', 'background.js')
+const bgScriptContent = fs.readFileSync(bgScriptPath, 'utf8')
+
+function setupEnvironment() {
+  let lastFetchUrl = null
+  let lastFetchOptions = null
+
+  const sandbox = {
+    chrome: {
+      storage: {
+        session: { get: async () => ({}), set: async () => {} },
+        sync: { get: async () => ({}) },
+        local: { get: async () => ({}) }
+      },
+      runtime: {
+        onMessage: { addListener: () => {} },
+        getPlatformInfo: async () => ({})
+      }
+    },
+    fetch: async (url, options) => {
+      lastFetchUrl = url
+      lastFetchOptions = options
+      return { ok: true, json: async () => [] }
+    },
+    addLog: () => {},
+    setTimeout,
+    setInterval,
+    clearInterval,
+    Math,
+    Date,
+    JSON,
+    String,
+    Array,
+    Map,
+    Object,
+    Error,
+    URLSearchParams,
+    Promise,
+    console,
+    parseInt,
+    encodeURIComponent
+  }
+
+  vm.createContext(sandbox)
+  const scriptContent = `${bgScriptContent}\n globalThis.test_getOpenPRCount = getOpenPRCount;`
+  const script = new vm.Script(scriptContent)
+  script.runInContext(sandbox)
+
+  return { sandbox, getLastFetch: () => ({ url: lastFetchUrl, options: lastFetchOptions }) }
+}
+
+describe('Security: getOpenPRCount', () => {
+  it('should encode owner and repo in URL', async () => {
+    const { sandbox, getLastFetch } = setupEnvironment()
+    const owner = 'bad/owner'
+    const repo = 'bad?repo'
+
+    await sandbox.test_getOpenPRCount(owner, repo, 'token')
+
+    const { url } = getLastFetch()
+    assert.ok(url.includes('bad%2Fowner'), 'Owner should be encoded')
+    assert.ok(url.includes('bad%3Frepo'), 'Repo should be encoded')
+  })
+
+  it('should prevent newline injection in Authorization header', async () => {
+    const { sandbox, getLastFetch } = setupEnvironment()
+    const malformedToken = 'valid\nInjected-Header: evil'
+
+    await sandbox.test_getOpenPRCount('owner', 'repo', malformedToken)
+
+    const { options } = getLastFetch()
+    const authHeader = options.headers.Authorization
+
+    if (authHeader) {
+      assert.ok(!authHeader.includes('\n'), 'Authorization header should not contain newlines')
+      assert.ok(!authHeader.includes('\r'), 'Authorization header should not contain carriage returns')
+    } else {
+      // If the token was rejected, that's also a valid fix.
+      assert.strictEqual(authHeader, undefined)
+    }
+  })
+})


### PR DESCRIPTION
This PR addresses a security vulnerability where 'owner' and 'repo' parameters were used directly to construct GitHub API URLs, and the GitHub token was used in the Authorization header without validation.

Changes:
- Encoded 'owner' and 'repo' using 'encodeURIComponent' in 'getOpenPRCount' to prevent URL manipulation.
- Added a check for newline characters in the 'token' before setting the Authorization header to prevent CRLF injection.
- Added comprehensive security regression tests in 'tests/security.test.js'.
- Documented the fix and prevention strategy in '.jules/sentinel.md'.

All tests passed, including existing ones and the new security suite. Biome check also passes.

---
*PR created automatically by Jules for task [5281904270435814780](https://jules.google.com/task/5281904270435814780) started by @n24q02m*