### PR TITLE
[TEST] Missing tests for GitHub API PR fetching

### DIFF
--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -89,6 +89,8 @@ function setupEnvironment(initialStorage = {}) {
     globalThis.test_SDETAIL = SDETAIL;
     globalThis.test_CATEGORY_CONFIG = CATEGORY_CONFIG;
     globalThis.test_DEFAULT_CATEGORY = DEFAULT_CATEGORY;
+    globalThis.test_getOpenPRCount = getOpenPRCount;
+    globalThis.test_prCache = prCache;
   `
 
   const script = new vm.Script(scriptContent)
@@ -493,5 +495,83 @@ describe('state management', () => {
     sandbox.test_updateState({ status: 'done', currentTab: 'u/0' })
     assert.strictEqual(sandbox.test_state().status, 'done')
     assert.strictEqual(sessionSetData.length, 1)
+  })
+})
+
+// =============================================================================
+// GitHub API Tests
+// =============================================================================
+
+describe('getOpenPRCount', () => {
+  it('should fetch PR count and cache it on success', async () => {
+    const { sandbox } = setupEnvironment()
+    let fetchCalled = 0
+    sandbox.fetch = async (url, _options) => {
+      fetchCalled++
+      assert.strictEqual(url, 'https://api.github.com/repos/owner/repo/pulls?state=open&per_page=100')
+      return {
+        ok: true,
+        json: async () => [{}, {}] // 2 PRs
+      }
+    }
+
+    const count = await sandbox.test_getOpenPRCount('owner', 'repo', null)
+    assert.strictEqual(count, 2)
+    assert.strictEqual(fetchCalled, 1)
+    assert.strictEqual(sandbox.test_prCache.get('owner/repo'), 2)
+  })
+
+  it('should return cached value and not fetch again', async () => {
+    const { sandbox } = setupEnvironment()
+    sandbox.test_prCache.set('owner/repo', 5)
+    let fetchCalled = 0
+    sandbox.fetch = async () => {
+      fetchCalled++
+      return { ok: true, json: async () => [] }
+    }
+
+    const count = await sandbox.test_getOpenPRCount('owner', 'repo', null)
+    assert.strictEqual(count, 5)
+    assert.strictEqual(fetchCalled, 0)
+  })
+
+  it('should return 0 and cache it on API error (e.g. 404)', async () => {
+    const { sandbox } = setupEnvironment()
+    let fetchCalled = 0
+    sandbox.fetch = async () => {
+      fetchCalled++
+      return { ok: false, status: 404 }
+    }
+
+    const count = await sandbox.test_getOpenPRCount('owner', 'repo', null)
+    assert.strictEqual(count, 0)
+    assert.strictEqual(fetchCalled, 1)
+    assert.strictEqual(sandbox.test_prCache.get('owner/repo'), 0)
+  })
+
+  it('should return 0 and cache it on network error', async () => {
+    const { sandbox } = setupEnvironment()
+    let fetchCalled = 0
+    sandbox.fetch = async () => {
+      fetchCalled++
+      throw new Error('Network error')
+    }
+
+    const count = await sandbox.test_getOpenPRCount('owner', 'repo', null)
+    assert.strictEqual(count, 0)
+    assert.strictEqual(fetchCalled, 1)
+    assert.strictEqual(sandbox.test_prCache.get('owner/repo'), 0)
+  })
+
+  it('should include Authorization header when token is provided', async () => {
+    const { sandbox } = setupEnvironment()
+    let capturedHeaders = null
+    sandbox.fetch = async (_url, options) => {
+      capturedHeaders = options.headers
+      return { ok: true, json: async () => [] }
+    }
+
+    await sandbox.test_getOpenPRCount('owner', 'repo', 'secret-token')
+    assert.strictEqual(capturedHeaders.Authorization, 'token secret-token')
   })
 })


### PR DESCRIPTION
This PR adds missing unit tests for the GitHub API PR fetching logic in `background.js`.

**Changes:**
- Modified `tests/background.test.js` to expose `getOpenPRCount` and `prCache` within the testing sandbox.
- Added a new `describe` block for `getOpenPRCount` with test cases for:
  - Successful API fetching and caching of results.
  - Efficient cache retrieval (no redundant network requests).
  - Robust handling of API errors (e.g., 404 Not Found).
  - Graceful recovery from network-level failures.
  - Proper inclusion of the `Authorization` header when a GitHub token is provided.
- Applied Biome linting fixes to maintain code health.

**Verification:**
- Ran `node --test tests/background.test.js` - all tests passed.
- Ran `npm test` - entire suite (38 tests) passed.
- Ran `npx @biomejs/biome check .` - no issues found.

---
*PR created automatically by Jules for task [15412655741068865050](https://jules.google.com/task/15412655741068865050) started by @n24q02m*