### PR TITLE
[FIX] Hardcoded setTimeout in ensureContentScript

### DIFF
--- a/background.js
+++ b/background.js
@@ -614,19 +614,33 @@ async function ensureContentScript(tabId) {
   try {
     await chrome.tabs.sendMessage(tabId, { action: 'PING' })
   } catch {
+    // Content script not responding - inject and wait for READY
+    const readyPromise = new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        chrome.runtime.onMessage.removeListener(handler)
+        // Fallback: try one last PING before giving up
+        chrome.tabs
+          .sendMessage(tabId, { action: 'PING' })
+          .then(() => resolve())
+          .catch(() => reject(new Error('Content script injection timed out')))
+      }, 5000)
+
+      const handler = (msg, sender) => {
+        if (msg.action === 'READY' && sender.tab?.id === tabId) {
+          chrome.runtime.onMessage.removeListener(handler)
+          clearTimeout(timeout)
+          resolve()
+        }
+      }
+      chrome.runtime.onMessage.addListener(handler)
+    })
+
     await chrome.scripting.executeScript({
       target: { tabId },
       files: ['content.js']
     })
-    for (let i = 0; i < 10; i++) {
-      try {
-        await new Promise((r) => setTimeout(r, 50))
-        await chrome.tabs.sendMessage(tabId, { action: 'PING' })
-        break
-      } catch {
-        // Keep waiting
-      }
-    }
+
+    await readyPromise
   }
 }
 

--- a/content.js
+++ b/content.js
@@ -6,76 +6,89 @@
  * Handles chrome.runtime messages from background/popup.
  */
 
-// Store config extracted from MAIN world
-let cachedConfig = null
+// Prevent multiple initializations
+if (window.__JULES_ARCHIVER_LOADED__) {
+  // Still send READY message in case background is waiting for it
+  chrome.runtime.sendMessage({ action: 'READY' }).catch(() => {})
+} else {
+  window.__JULES_ARCHIVER_LOADED__ = true
 
-// Listen for messages from MAIN world script
-window.addEventListener('message', (event) => {
-  if (event.source !== window) return
-  if (event.data?.type === 'JULES_ARCHIVER_CONFIG') {
-    cachedConfig = event.data.config
-  }
-  if (event.data?.type === 'JULES_START_CONFIG') {
-    chrome.runtime.sendMessage({
-      action: 'CACHE_START_CONFIG',
-      config: event.data.config
+  // Store config extracted from MAIN world
+  let cachedConfig = null
+
+  // Listen for messages from MAIN world script
+  window.addEventListener('message', (event) => {
+    if (event.source !== window) return
+    if (event.data?.type === 'JULES_ARCHIVER_CONFIG') {
+      cachedConfig = event.data.config
+    }
+    if (event.data?.type === 'JULES_START_CONFIG') {
+      chrome.runtime
+        .sendMessage({
+          action: 'CACHE_START_CONFIG',
+          config: event.data.config
+        })
+        .catch(() => {})
+    }
+  })
+
+  // Request fresh config from MAIN world script
+  function extractConfig() {
+    // If already cached and fresh (less than 5 min old), return it
+    if (cachedConfig?.timestamp && Date.now() - cachedConfig.timestamp < 300000) {
+      return Promise.resolve(cachedConfig)
+    }
+
+    return new Promise((resolve) => {
+      // Ask main-world.js to re-broadcast config
+      window.postMessage({ type: 'JULES_REQUEST_CONFIG' }, '*')
+
+      const timeout = setTimeout(() => resolve(cachedConfig), 2000)
+      const handler = (event) => {
+        if (event.source !== window) return
+        if (event.data?.type !== 'JULES_ARCHIVER_CONFIG') return
+        window.removeEventListener('message', handler)
+        clearTimeout(timeout)
+        cachedConfig = event.data.config
+        resolve(cachedConfig)
+      }
+      window.addEventListener('message', handler)
     })
   }
-})
 
-// Request fresh config from MAIN world script
-function extractConfig() {
-  // If already cached and fresh (less than 5 min old), return it
-  if (cachedConfig?.timestamp && Date.now() - cachedConfig.timestamp < 300000) {
-    return Promise.resolve(cachedConfig)
+  // Detect account number from URL
+  function getAccountNum() {
+    const m = location.href.match(/\/u\/(\d+)/)
+    return m ? m[1] : '0'
   }
 
-  return new Promise((resolve) => {
-    // Ask main-world.js to re-broadcast config
-    window.postMessage({ type: 'JULES_REQUEST_CONFIG' }, '*')
+  function getAccountLabel() {
+    const m = location.href.match(/\/u\/(\d+)/)
+    return m ? `u/${m[1]}` : 'default'
+  }
 
-    const timeout = setTimeout(() => resolve(cachedConfig), 2000)
-    const handler = (event) => {
-      if (event.source !== window) return
-      if (event.data?.type !== 'JULES_ARCHIVER_CONFIG') return
-      window.removeEventListener('message', handler)
-      clearTimeout(timeout)
-      cachedConfig = event.data.config
-      resolve(cachedConfig)
-    }
-    window.addEventListener('message', handler)
-  })
-}
+  // Message handler
+  chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
+    switch (msg.action) {
+      case 'PING':
+        sendResponse({ ok: true, account: getAccountLabel() })
+        break
 
-// Detect account number from URL
-function getAccountNum() {
-  const m = location.href.match(/\/u\/(\d+)/)
-  return m ? m[1] : '0'
-}
-
-function getAccountLabel() {
-  const m = location.href.match(/\/u\/(\d+)/)
-  return m ? `u/${m[1]}` : 'default'
-}
-
-// Message handler
-chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
-  switch (msg.action) {
-    case 'PING':
-      sendResponse({ ok: true, account: getAccountLabel() })
-      break
-
-    case 'GET_CONFIG':
-      extractConfig().then((config) => {
-        sendResponse({
-          config,
-          accountNum: getAccountNum(),
-          account: getAccountLabel()
+      case 'GET_CONFIG':
+        extractConfig().then((config) => {
+          sendResponse({
+            config,
+            accountNum: getAccountNum(),
+            account: getAccountLabel()
+          })
         })
-      })
-      return true // async response
+        return true // async response
 
-    default:
-      sendResponse({ error: 'Unknown action' })
-  }
-})
+      default:
+        sendResponse({ error: 'Unknown action' })
+    }
+  })
+
+  // Signal readiness to background script
+  chrome.runtime.sendMessage({ action: 'READY' }).catch(() => {})
+}

--- a/tests/ensure_content_script.test.js
+++ b/tests/ensure_content_script.test.js
@@ -1,0 +1,144 @@
+const { describe, it } = require('node:test')
+const assert = require('node:assert')
+const fs = require('node:fs')
+const vm = require('node:vm')
+const path = require('node:path')
+
+const bgScriptPath = path.join(__dirname, '..', 'background.js')
+const bgScriptContent = fs.readFileSync(bgScriptPath, 'utf8')
+
+function setupEnvironment() {
+  const messageListeners = []
+  const chromeMock = {
+    runtime: {
+      onMessage: {
+        addListener: (fn) => messageListeners.push(fn),
+        removeListener: (fn) => {
+          const idx = messageListeners.indexOf(fn)
+          if (idx !== -1) messageListeners.splice(idx, 1)
+        }
+      },
+      getPlatformInfo: async () => ({})
+    },
+    storage: {
+      session: { get: async () => ({}), set: async () => {} },
+      sync: { get: async () => ({}) },
+      local: { get: async () => ({}) }
+    },
+    tabs: {
+      get: async (id) => ({ id, url: 'https://jules.google.com/u/0/session' }),
+      sendMessage: async (tabId, msg) => {
+        if (msg.action === 'PING' && chromeMock.tabs.shouldFailPing) {
+          return Promise.reject(new Error('Fail PING'))
+        }
+        return { ok: true }
+      }
+    },
+    scripting: {
+      executeScript: async () => {
+        chromeMock.scripting.calledExecuteScript = true
+        // Simulate content script sending READY message
+        setTimeout(() => {
+          messageListeners.forEach((fn) => {
+            fn({ action: 'READY' }, { tab: { id: 123 } }, () => {})
+          })
+        }, 10)
+      }
+    }
+  }
+
+  const sandbox = {
+    chrome: chromeMock,
+    setTimeout,
+    clearTimeout,
+    setInterval,
+    clearInterval,
+    Math,
+    Date,
+    JSON,
+    String,
+    Array,
+    Map,
+    Object,
+    Error,
+    Promise,
+    console,
+    parseInt
+  }
+
+  return { sandbox, chromeMock, messageListeners }
+}
+
+describe('ensureContentScript improved', () => {
+  it('should inject content script and wait for READY if PING fails', async () => {
+    const { sandbox, chromeMock } = setupEnvironment()
+    vm.createContext(sandbox)
+    new vm.Script(bgScriptContent).runInContext(sandbox)
+    chromeMock.tabs.shouldFailPing = true
+
+    const ensureContentScript = sandbox.ensureContentScript
+
+    await ensureContentScript(123)
+
+    assert.strictEqual(chromeMock.scripting.calledExecuteScript, true)
+  })
+
+  it('should timeout and fallback to PING if READY never arrives', async () => {
+    const { sandbox, chromeMock } = setupEnvironment()
+
+    // Override executeScript to NOT send READY
+    chromeMock.scripting.executeScript = async () => {
+      chromeMock.scripting.calledExecuteScript = true
+      // Don't send READY
+    }
+
+    const bgContentSpeedUp = bgScriptContent.replace('5000', '100')
+    vm.createContext(sandbox)
+    new vm.Script(bgContentSpeedUp).runInContext(sandbox)
+
+    const ensureContentScript = sandbox.ensureContentScript
+
+    // Initial PING should fail to trigger injection
+    chromeMock.tabs.shouldFailPing = true
+
+    // Make fallback PING succeed
+    const originalSendMessage = chromeMock.tabs.sendMessage
+    chromeMock.tabs.sendMessage = async (tabId, msg) => {
+      if (msg.action === 'PING') {
+        if (chromeMock.tabs.shouldFailPing) {
+          chromeMock.tabs.shouldFailPing = false
+          throw new Error('Fail PING')
+        }
+        return { ok: true }
+      }
+      return originalSendMessage(tabId, msg)
+    }
+
+    await ensureContentScript(123)
+    assert.strictEqual(chromeMock.scripting.calledExecuteScript, true)
+  })
+
+  it('should fail if READY never arrives and fallback PING fails', async () => {
+    const { sandbox, chromeMock } = setupEnvironment()
+
+    chromeMock.scripting.executeScript = async () => {
+      chromeMock.scripting.calledExecuteScript = true
+    }
+
+    const bgContentSpeedUp = bgScriptContent.replace('5000', '100')
+    vm.createContext(sandbox)
+    new vm.Script(bgContentSpeedUp).runInContext(sandbox)
+
+    const ensureContentScript = sandbox.ensureContentScript
+
+    // Initial PING fails
+    chromeMock.tabs.shouldFailPing = true
+
+    // Make fallback PING fail too
+    chromeMock.tabs.sendMessage = async () => {
+      throw new Error('Total failure')
+    }
+
+    await assert.rejects(ensureContentScript(123), /Content script injection timed out/)
+  })
+})


### PR DESCRIPTION
Replaced the hardcoded polling loop in \`ensureContentScript\` with a more robust mechanism. The content script now signals readiness via a \`READY\` message, and the background script waits for this signal using a Promise-based listener with a fail-safe timeout and a fallback PING check. This improves reliability and reduces race conditions during content script injection. Added a new test suite \`tests/ensure_content_script.test.js\` to verify the fix and updated \`.jules/bolt.md\` with the learning.

---
*PR created automatically by Jules for task [8890067027122458170](https://jules.google.com/task/8890067027122458170) started by @n24q02m*