### PR TITLE
[FIX] Insecure Storage of GitHub Token

### DIFF
--- a/background.js
+++ b/background.js
@@ -693,17 +693,7 @@ async function processTab(tab, options) {
 
   // Check PRs and decide which repos to archive
   const { ghOwner } = await chrome.storage.sync.get(['ghOwner'])
-  let { ghToken } = await chrome.storage.local.get(['ghToken'])
-
-  // Migrate token from sync to local if needed
-  if (!ghToken) {
-    const syncData = await chrome.storage.sync.get(['ghToken'])
-    if (syncData.ghToken) {
-      ghToken = syncData.ghToken
-      await chrome.storage.local.set({ ghToken })
-      await chrome.storage.sync.remove('ghToken')
-    }
-  }
+  const { ghToken } = await chrome.storage.local.get(['ghToken'])
 
   addLog(`\n[${label}] Checking open PRs...`)
   const toArchive = []

--- a/package.json
+++ b/package.json
@@ -6,5 +6,7 @@
   "scripts": {
     "test": "node --test"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "jsdom": "^29.0.1"
+  }
 }

--- a/popup.js
+++ b/popup.js
@@ -49,14 +49,6 @@ chrome.storage.sync.get(['ghOwner', 'opMode'], (syncData) => {
   chrome.storage.local.get(['ghToken'], (localData) => {
     if (localData.ghToken) {
       ghTokenInput.value = localData.ghToken
-    } else {
-      chrome.storage.sync.get(['ghToken'], (oldSync) => {
-        if (oldSync.ghToken) {
-          ghTokenInput.value = oldSync.ghToken
-          chrome.storage.local.set({ ghToken: oldSync.ghToken })
-          chrome.storage.sync.remove('ghToken')
-        }
-      })
     }
   })
 })

--- a/tests/security.test.js
+++ b/tests/security.test.js
@@ -1,0 +1,100 @@
+const { test, describe } = require('node:test')
+const assert = require('node:assert')
+const fs = require('node:fs')
+const { JSDOM } = require('jsdom')
+
+describe('Security: ghToken Storage', () => {
+  test('ghToken should never be saved to sync storage in popup.js', async () => {
+    const html = fs.readFileSync('popup.html', 'utf8')
+    const js = fs.readFileSync('popup.js', 'utf8')
+
+    let syncSetCalledWith = null
+    const dom = new JSDOM(html, {
+      runScripts: 'dangerously',
+      beforeParse(window) {
+        window.chrome = {
+          storage: {
+            sync: {
+              get: (_keys, cb) => {
+                if (cb) setTimeout(() => cb({}), 0)
+              },
+              set: (data, cb) => {
+                syncSetCalledWith = data
+                if (cb) setTimeout(cb, 0)
+              },
+              remove: (_keys, cb) => {
+                if (cb) setTimeout(cb, 0)
+              }
+            },
+            local: {
+              get: (_keys, cb) => {
+                if (cb) setTimeout(() => cb({}), 0)
+              },
+              set: (_data, cb) => {
+                if (cb) setTimeout(cb, 0)
+              }
+            },
+            session: {
+              get: (_keys) => Promise.resolve({}),
+              set: (_data) => Promise.resolve()
+            },
+            onChanged: {
+              addListener: () => {}
+            }
+          },
+          runtime: {
+            sendMessage: (_msg, cb) => {
+              if (cb) setTimeout(() => cb(null), 0)
+            },
+            onMessage: {
+              addListener: () => {}
+            }
+          },
+          tabs: {
+            query: () => Promise.resolve([{ id: 123 }])
+          },
+          scripting: {
+            executeScript: () => Promise.resolve()
+          }
+        }
+        // Mock document.querySelector for radio buttons if needed, but they are in HTML
+      }
+    })
+
+    const { window } = dom
+
+    // Manually execute the script in the window context
+    const scriptEl = window.document.createElement('script')
+    scriptEl.textContent = js
+    window.document.body.appendChild(scriptEl)
+
+    // Wait for any async initialization
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    // Find token input and start button
+    const ghTokenInput = window.document.getElementById('ghToken')
+    const startBtn = window.document.getElementById('startBtn')
+
+    assert.ok(ghTokenInput, 'ghToken input found')
+    assert.ok(startBtn, 'startBtn found')
+
+    ghTokenInput.value = 'ghp_test_token_123'
+
+    // Simulate click
+    startBtn.click()
+
+    // Wait for click handler (it is async)
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    // Verify sync storage call
+    assert.ok(syncSetCalledWith, 'chrome.storage.sync.set should have been called')
+    assert.strictEqual(syncSetCalledWith.ghToken, undefined, 'ghToken should NOT be in sync storage')
+    assert.ok(syncSetCalledWith.ghOwner !== undefined, 'ghOwner should be in sync storage')
+  })
+
+  test('background.js should not attempt to migrate ghToken from sync storage', async () => {
+    const js = fs.readFileSync('background.js', 'utf8')
+    assert.ok(!js.includes('await chrome.storage.sync.get(["ghToken"])'), 'Migration code should be removed')
+    assert.ok(!js.includes("await chrome.storage.sync.get(['ghToken'])"), 'Migration code should be removed')
+  })
+})


### PR DESCRIPTION
I have fixed the insecure storage of the GitHub token by removing all references to `chrome.storage.sync` for the `ghToken` field. 

Key changes:
- In `popup.js`: Removed the legacy migration block and ensured that the `ghToken` is only saved to `chrome.storage.local`.
- In `background.js`: Removed the `ghToken` migration block that attempted to read the token from `sync` and move it to `local`.
- Added a new test `tests/security.test.js` using JSDOM to simulate user interactions and verify that no sensitive data is sent to `chrome.storage.sync`.
- Verified the fix by running the full test suite (`npm test`).
- Applied Biome linting and formatting to all modified files.
- Recorded security learnings in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [7130677055545225618](https://jules.google.com/task/7130677055545225618) started by @n24q02m*