### PR TITLE
[FIX] Duplicate URL Regex in background.js

### DIFF
--- a/background.js
+++ b/background.js
@@ -589,22 +589,25 @@ function stopKeepAlive() {
 // Tab Management
 // =============================================================================
 
+function extractAccountNum(url) {
+  return url.match(/\/u\/(\d+)/)?.[1] || null
+}
+
 async function getJulesTabs() {
   const tabs = await chrome.tabs.query({ url: 'https://jules.google.com/*' })
   return tabs
     .filter((t) => !t.url.includes('accounts.google'))
     .sort((a, b) => {
-      const na = parseInt(a.url.match(/\/u\/(\d+)/)?.[1] || '0', 10)
-      const nb = parseInt(b.url.match(/\/u\/(\d+)/)?.[1] || '0', 10)
+      const na = parseInt(extractAccountNum(a.url) || '0', 10)
+      const nb = parseInt(extractAccountNum(b.url) || '0', 10)
       return na - nb
     })
 }
 
 function getTabLabel(tab) {
-  const m = tab.url.match(/\/u\/(\d+)/)
-  return m ? `u/${m[1]}` : 'default'
+  const account = extractAccountNum(tab.url)
+  return account ? `u/${account}` : 'default'
 }
-
 async function ensureContentScript(tabId) {
   const tab = await chrome.tabs.get(tabId)
   if (!tab.url?.startsWith('https://jules.google.com/')) {

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -77,6 +77,9 @@ function setupEnvironment(initialStorage = {}) {
     globalThis.test_updateState = updateState;
     globalThis.test_addLog = addLog;
     globalThis.test_buildBatchRequest = buildBatchRequest;
+    globalThis.test_extractAccountNum = extractAccountNum;
+    globalThis.test_getJulesTabs = getJulesTabs;
+    globalThis.test_getTabLabel = getTabLabel;
     globalThis.test_fixJsonControlChars = fixJsonControlChars;
     globalThis.test_findJsonEnd = findJsonEnd;
     globalThis.test_parseResponse = parseResponse;
@@ -493,5 +496,45 @@ describe('state management', () => {
     sandbox.test_updateState({ status: 'done', currentTab: 'u/0' })
     assert.strictEqual(sandbox.test_state().status, 'done')
     assert.strictEqual(sessionSetData.length, 1)
+  })
+})
+
+// =============================================================================
+// URL Parser Tests
+// =============================================================================
+
+describe('URL parsing logic', () => {
+  it('should extract account number from URL', () => {
+    const { sandbox } = setupEnvironment()
+    assert.strictEqual(sandbox.test_extractAccountNum('https://jules.google.com/u/0/session'), '0')
+    assert.strictEqual(sandbox.test_extractAccountNum('https://jules.google.com/u/15/some/path'), '15')
+  })
+
+  it('should return null when account number is missing', () => {
+    const { sandbox } = setupEnvironment()
+    assert.strictEqual(sandbox.test_extractAccountNum('https://jules.google.com/session'), null)
+    assert.strictEqual(sandbox.test_extractAccountNum('https://other.google.com/u/0'), '0')
+  })
+
+  it('should return correct tab label', () => {
+    const { sandbox } = setupEnvironment()
+    assert.strictEqual(sandbox.test_getTabLabel({ url: 'https://jules.google.com/u/2/chat' }), 'u/2')
+    assert.strictEqual(sandbox.test_getTabLabel({ url: 'https://jules.google.com/session' }), 'default')
+  })
+
+  it('should sort tabs by account number in getJulesTabs', async () => {
+    const { sandbox } = setupEnvironment()
+    sandbox.chrome.tabs.query = async () => [
+      { url: 'https://jules.google.com/u/10/x' },
+      { url: 'https://jules.google.com/u/2/x' },
+      { url: 'https://jules.google.com/u/0/x' },
+      { url: 'https://jules.google.com/accounts.google/x' }
+    ]
+
+    const tabs = await sandbox.test_getJulesTabs()
+    assert.strictEqual(tabs.length, 3)
+    assert.strictEqual(sandbox.test_extractAccountNum(tabs[0].url), '0')
+    assert.strictEqual(sandbox.test_extractAccountNum(tabs[1].url), '2')
+    assert.strictEqual(sandbox.test_extractAccountNum(tabs[2].url), '10')
   })
 })


### PR DESCRIPTION
The recurring regex `/\/u\/(\d+)/` for identifying Google account numbers in `background.js` was extracted into a shared `extractAccountNum(url)` helper function. Call sites in `getJulesTabs` and `getTabLabel` were refactored to use this helper, improving code maintainability. Unit tests were added to `tests/background.test.js` to verify the fix and handle various URL scenarios.

---
*PR created automatically by Jules for task [8304035162489273529](https://jules.google.com/task/8304035162489273529) started by @n24q02m*