### PR TITLE
🛡️ Sentinel: [HIGH] Fix TOCTOU vulnerability in tab script injection

### DIFF
--- a/background.js
+++ b/background.js
@@ -647,6 +647,12 @@ async function ensureContentScript(tabId) {
   try {
     await chrome.tabs.sendMessage(tabId, { action: 'PING' })
   } catch {
+    // Re-verify URL right before injection (prevent TOCTOU)
+    const currentTab = await chrome.tabs.get(tabId)
+    if (!currentTab.url?.startsWith(`${JULES_ORIGIN}/`)) {
+      throw new Error('Security Error: Tab navigated away before injection')
+    }
+
     await chrome.scripting.executeScript({
       target: { tabId },
       files: ['content.js']


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** A Time-of-Check to Time-of-Use (TOCTOU) vulnerability existed in `background.js` -> `ensureContentScript`. If the initial `PING` message failed or timed out, the extension would inject `content.js` without re-verifying the tab's URL. A user navigating to a malicious site during this async window could result in the extension script being injected into an untrusted origin.
🎯 **Impact:** Potential privilege escalation or exposure of extension internals to untrusted domains.
🔧 **Fix:** Added a secondary URL validation check immediately before the `chrome.scripting.executeScript` call.
✅ **Verification:** Run `npm test` to ensure core functionality works, and verify no regressions in background state/operations. Linters pass via `@biomejs/biome`.

---
*PR created automatically by Jules for task [2457957827871911311](https://jules.google.com/task/2457957827871911311) started by @n24q02m*