### PR TITLE
[FIX] Use URL API instead of Regex for account ID

### DIFF
--- a/background.js
+++ b/background.js
@@ -12,8 +12,9 @@
 const JULES_ORIGIN = 'https://jules.google.com'
 
 function extractAccountNum(url) {
-  const m = url.match(/\/u\/(\d+)/)
-  return m ? m[1] : '0'
+  const parts = new URL(url).pathname.split('/')
+  const uIdx = parts.indexOf('u')
+  return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
 }
 
 // =============================================================================

--- a/content.js
+++ b/content.js
@@ -48,11 +48,10 @@ function extractConfig() {
 }
 
 // Detect account from URL
-const ACCOUNT_RE = /\/u\/(\d+)/
-
 function getAccountNum() {
-  const m = location.href.match(ACCOUNT_RE)
-  return m ? m[1] : '0'
+  const parts = new URL(location.href).pathname.split('/')
+  const uIdx = parts.indexOf('u')
+  return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
 }
 
 function getAccountLabel() {

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -64,7 +64,8 @@ function setupEnvironment(initialStorage = {}) {
     URLSearchParams,
     Promise,
     console,
-    parseInt
+    parseInt,
+    URL
   }
 
   vm.createContext(sandbox)

--- a/tests/content.test.js
+++ b/tests/content.test.js
@@ -51,8 +51,9 @@ describe('content.js config extraction logic', () => {
 
   it('should parse account number from URL paths', () => {
     function getAccountNum(url) {
-      const m = url.match(/\/u\/(\d+)/)
-      return m ? m[1] : '0'
+      const parts = new URL(url).pathname.split('/')
+      const uIdx = parts.indexOf('u')
+      return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
     }
 
     assert.strictEqual(getAccountNum('https://jules.google.com/u/3/session'), '3')


### PR DESCRIPTION
This PR replaces the legacy regular expression used to extract account IDs from Google Jules URLs with the more robust and maintainable native URL API. The change affects both the content script (content.js) and the service worker (background.js). Tests have been updated to ensure parity and the test environment was adjusted to include the URL constructor in the sandbox.

---
*PR created automatically by Jules for task [1350171606706989368](https://jules.google.com/task/1350171606706989368) started by @n24q02m*