### PR TITLE
[SECURITY] Insecure Content Script Injection

### DIFF
--- a/background.js
+++ b/background.js
@@ -639,18 +639,34 @@ function getTabLabel(tab) {
 }
 
 async function ensureContentScript(tabId) {
-  const tab = await chrome.tabs.get(tabId)
-  if (!tab.url?.startsWith(`${JULES_ORIGIN}/`)) {
+  const checkOrigin = async () => {
+    const tab = await chrome.tabs.get(tabId)
+    if (!tab.url) return false
+    try {
+      const url = new URL(tab.url)
+      return url.origin === JULES_ORIGIN
+    } catch {
+      return false
+    }
+  }
+
+  if (!(await checkOrigin())) {
     throw new Error('Security Error: Cannot inject script into non-Jules tab')
   }
 
   try {
     await chrome.tabs.sendMessage(tabId, { action: 'PING' })
   } catch {
+    // Re-verify immediately before injection to prevent TOCTOU
+    if (!(await checkOrigin())) {
+      throw new Error('Security Error: Cannot inject script into non-Jules tab')
+    }
+
     await chrome.scripting.executeScript({
       target: { tabId },
       files: ['content.js']
     })
+
     const deadline = Date.now() + 3000
     while (Date.now() < deadline) {
       try {

--- a/background.js.diff
+++ b/background.js.diff
@@ -1,0 +1,71 @@
+<<<<<<< SEARCH
+async function ensureContentScript(tabId) {
+  const tab = await chrome.tabs.get(tabId)
+  if (!tab.url?.startsWith(`${JULES_ORIGIN}/`)) {
+    throw new Error('Security Error: Cannot inject script into non-Jules tab')
+  }
+
+  try {
+    await chrome.tabs.sendMessage(tabId, { action: 'PING' })
+  } catch {
+    await chrome.scripting.executeScript({
+      target: { tabId },
+      files: ['content.js']
+    })
+    const deadline = Date.now() + 3000
+    while (Date.now() < deadline) {
+      try {
+        await new Promise((r) => setTimeout(r, 100))
+        await chrome.tabs.sendMessage(tabId, { action: 'PING' })
+        return
+      } catch {
+        // Keep waiting
+      }
+    }
+    throw new Error('Content script failed to initialize within 3s')
+  }
+}
+=======
+async function ensureContentScript(tabId) {
+  const checkOrigin = async () => {
+    const tab = await chrome.tabs.get(tabId)
+    if (!tab.url) return false
+    try {
+      const url = new URL(tab.url)
+      return url.origin === JULES_ORIGIN
+    } catch {
+      return false
+    }
+  }
+
+  if (!(await checkOrigin())) {
+    throw new Error('Security Error: Cannot inject script into non-Jules tab')
+  }
+
+  try {
+    await chrome.tabs.sendMessage(tabId, { action: 'PING' })
+  } catch {
+    // Re-verify immediately before injection to prevent TOCTOU
+    if (!(await checkOrigin())) {
+      throw new Error('Security Error: Cannot inject script into non-Jules tab')
+    }
+
+    await chrome.scripting.executeScript({
+      target: { tabId },
+      files: ['content.js']
+    })
+
+    const deadline = Date.now() + 3000
+    while (Date.now() < deadline) {
+      try {
+        await new Promise((r) => setTimeout(r, 100))
+        await chrome.tabs.sendMessage(tabId, { action: 'PING' })
+        return
+      } catch {
+        // Keep waiting
+      }
+    }
+    throw new Error('Content script failed to initialize within 3s')
+  }
+}
+>>>>>>> REPLACE

--- a/tests/security.test.js
+++ b/tests/security.test.js
@@ -1,0 +1,117 @@
+const { describe, it } = require('node:test')
+const assert = require('node:assert')
+const fs = require('node:fs')
+const vm = require('node:vm')
+const path = require('node:path')
+
+const bgScriptPath = path.join(__dirname, '..', 'background.js')
+const bgScriptContent = fs.readFileSync(bgScriptPath, 'utf8')
+
+function setupEnvironment(initialTabs = {}) {
+  const chromeMock = {
+    storage: {
+      session: {
+        get: async () => ({}),
+        set: async () => {}
+      }
+    },
+    runtime: {
+      onMessage: { addListener: () => {} },
+      getPlatformInfo: async () => ({})
+    },
+    tabs: {
+      get: async (id) => {
+        if (initialTabs[id]) return initialTabs[id]
+        return { id, url: 'https://jules.google.com/u/0/' }
+      },
+      sendMessage: async (_tabId, message) => {
+        if (message.action === 'PING') {
+          // Simulate script not loaded by throwing
+          throw new Error('Could not establish connection. Receiving end does not exist.')
+        }
+        return {}
+      }
+    },
+    scripting: {
+      executeScript: async ({ target, files }) => {
+        chromeMock.scripting.lastCall = { target, files }
+      }
+    }
+  }
+
+  const sandbox = {
+    chrome: chromeMock,
+    fetch: async () => ({ ok: true, json: async () => [], text: async () => ")]}'\n\n4\n[[]]" }),
+    setTimeout,
+    Date,
+    Promise,
+    Error,
+    console,
+    URL,
+    URLSearchParams
+  }
+
+  vm.createContext(sandbox)
+
+  const scriptContent =
+    bgScriptContent +
+    `
+    globalThis.test_ensureContentScript = ensureContentScript;
+    globalThis.test_JULES_ORIGIN = JULES_ORIGIN;
+  `
+
+  vm.runInContext(scriptContent, sandbox)
+  return { sandbox, chromeMock }
+}
+
+describe('ensureContentScript Security', () => {
+  it('should block injection into non-Jules origin', async () => {
+    const { sandbox } = setupEnvironment({
+      123: { id: 123, url: 'https://evil.com/' }
+    })
+
+    await assert.rejects(sandbox.test_ensureContentScript(123), {
+      message: /Security Error: Cannot inject script into non-Jules tab/
+    })
+  })
+
+  it('should block injection if URL changes to non-Jules origin (TOCTOU)', async () => {
+    const { sandbox, chromeMock } = setupEnvironment()
+
+    let callCount = 0
+    chromeMock.tabs.get = async (id) => {
+      callCount++
+      if (callCount === 1) {
+        return { id, url: 'https://jules.google.com/u/0/' }
+      }
+      return { id, url: 'https://evil.com/' }
+    }
+
+    // This is expected to fail CURRENTLY because ensureContentScript doesn't re-check the URL
+    // We WANT it to fail to prove the vulnerability exists.
+    await assert.rejects(sandbox.test_ensureContentScript(123), {
+      message: /Security Error: Cannot inject script into non-Jules tab/
+    })
+  })
+
+  it('should allow injection into valid Jules origin', async () => {
+    const { sandbox, chromeMock } = setupEnvironment({
+      456: { id: 456, url: 'https://jules.google.com/u/1/' }
+    })
+
+    // Mock successful sendMessage after injection to stop the loop
+    let injected = false
+    chromeMock.tabs.sendMessage = async (_tabId, message) => {
+      if (message.action === 'PING') {
+        if (injected) return { status: 'ok' }
+        throw new Error('Not loaded')
+      }
+    }
+    chromeMock.scripting.executeScript = async () => {
+      injected = true
+    }
+
+    await sandbox.test_ensureContentScript(456)
+    assert.strictEqual(injected, true)
+  })
+})


### PR DESCRIPTION
This PR fixes a security vulnerability in `ensureContentScript` where content scripts could be injected into non-Jules tabs due to a Time-of-Check to Time-of-Use (TOCTOU) race condition and weak origin validation.

Key changes:
- Used the native `URL` API for robust origin matching against `JULES_ORIGIN`.
- Implemented a double-check pattern: re-verifying the tab's origin immediately before calling `chrome.scripting.executeScript`.
- Added `tests/security.test.js` to reproduce the vulnerability and verify the fix.
- Updated security journaling in `.jules/sentinel.md`.

All tests pass and linting is clean.

---
*PR created automatically by Jules for task [8747130302161112149](https://jules.google.com/task/8747130302161112149) started by @n24q02m*