### PR TITLE
🎨 Palette: Progressive disclosure for operation modes

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-04-03 - Progressive Disclosure for Multi-Mode UIs
+**Learning:** In a multi-mode UI (like Archive vs Suggestions), showing all settings at once creates cognitive overload, especially when settings like GitHub tokens are only relevant to one mode.
+**Action:** Use progressive disclosure in `popup.js` to hide mode-specific settings (like the `.settings` section and `force` checkbox) when they are not relevant to the currently selected mode, keeping the UI clean and focused.

--- a/popup.js
+++ b/popup.js
@@ -30,6 +30,18 @@ function setActiveOpMode(value) {
     b.setAttribute('aria-pressed', String(isActive))
   })
   opMode = value
+
+  // Progressive disclosure: hide archive-specific settings
+  const isArchive = value === 'archive'
+  const settingsSection = document.querySelector('.settings')
+  const forceCheckboxContainer = forceCheckbox.parentElement
+
+  if (settingsSection) {
+    settingsSection.style.display = isArchive ? 'block' : 'none'
+  }
+  if (forceCheckboxContainer) {
+    forceCheckboxContainer.style.display = isArchive ? 'flex' : 'none'
+  }
 }
 
 document.querySelectorAll('#opMode button').forEach((btn) => {


### PR DESCRIPTION
💡 What: Added progressive disclosure to the `popup.js` operation mode toggler. It conditionally displays `.settings` and the `#force` checkbox only when 'archive' mode is active.
🎯 Why: Showing all settings at once creates cognitive overload, especially when settings like GitHub tokens are only relevant to the Archive mode.
📸 Before/After: Visual verification was done via a headless Playwright script asserting the visibilities.
♿ Accessibility: Reduces visual clutter and helps users focus on the relevant controls. Also added the `.Jules/palette.md` journal to track this learning.

---
*PR created automatically by Jules for task [13823567417531134625](https://jules.google.com/task/13823567417531134625) started by @n24q02m*