### PR TITLE
🛡️ Sentinel: [HIGH] Fix TOCTOU vulnerability in content script injection

### DIFF
--- a/background.js
+++ b/background.js
@@ -647,6 +647,11 @@ async function ensureContentScript(tabId) {
   try {
     await chrome.tabs.sendMessage(tabId, { action: 'PING' })
   } catch {
+    // Double check origin immediately before injection to prevent TOCTOU
+    const currentTab = await chrome.tabs.get(tabId)
+    if (!currentTab.url || new URL(currentTab.url).origin !== JULES_ORIGIN) {
+      throw new Error('Security Error: Tab navigated away from Jules before script injection')
+    }
     await chrome.scripting.executeScript({
       target: { tabId },
       files: ['content.js']


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** A Time-of-Check to Time-of-Use (TOCTOU) vulnerability existed in `ensureContentScript` where the tab's origin was checked before an asynchronous `PING` operation, but the script was injected after the delay without re-verifying the origin. This meant the tab could navigate away to a different (potentially malicious) origin during the `PING` and the script would still be injected.
🎯 **Impact:** If exploited, this could inject the extension's content script into an unintended or malicious page, violating the origin constraints and potentially exposing internal extension APIs or logic to untrusted contexts.
🔧 **Fix:** Re-fetch the tab and verify its URL origin using `new URL(currentTab.url).origin === JULES_ORIGIN` immediately before calling `chrome.scripting.executeScript`.
✅ **Verification:** Ran the full test suite (`npm test`) and formatted the code (`npx @biomejs/biome check --write .`) to ensure no regressions were introduced. Evaluated via code review successfully. Recorded learning to Sentinel's journal.

---
*PR created automatically by Jules for task [8206189868161724517](https://jules.google.com/task/8206189868161724517) started by @n24q02m*