### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix DoS vulnerability in URL parsing

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-04-04 - Unhandled Exceptions as DoS Vectors in Service Workers
+**Vulnerability:** The `extractAccountNum(url)` function in `background.js` used the native `URL` API to parse URLs without wrapping it in a try/catch block. If an invalid URL was provided (e.g. `""` from an uninitialized tab), it would throw `TypeError: ERR_INVALID_URL`.
+**Learning:** In Chrome Extension service workers, unhandled exceptions can crash the worker or prematurely terminate background processes, leading to Denial of Service for the extension's core functionalities.
+**Prevention:** Always wrap parsing logic, especially native APIs like `URL`, `JSON.parse`, and `decodeURIComponent`, in try/catch blocks. Fail securely by providing safe fallback values that allow the rest of the execution to continue without exposing stack traces or crashing the host process.

--- a/background.js
+++ b/background.js
@@ -12,9 +12,14 @@
 const JULES_ORIGIN = 'https://jules.google.com'
 
 function extractAccountNum(url) {
-  const parts = new URL(url).pathname.split('/')
-  const uIdx = parts.indexOf('u')
-  return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  try {
+    const parts = new URL(url).pathname.split('/')
+    const uIdx = parts.indexOf('u')
+    return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  } catch (error) {
+    // Fail securely: return default account 0 if URL is invalid (prevents DoS)
+    return '0'
+  }
 }
 
 // =============================================================================


### PR DESCRIPTION
🚨 **Severity**: MEDIUM
💡 **Vulnerability**: The `extractAccountNum` function in `background.js` used the native `URL` constructor without a `try...catch` block. If provided an invalid string (e.g., an empty string from an uninitialized tab), it threw an unhandled `TypeError`. In a Chrome Extension service worker, unhandled exceptions can crash the process or interrupt background operations.
🎯 **Impact**: Denial of Service (DoS). The background worker could be terminated, rendering the extension non-functional until manually restarted or the browser recovers the worker.
🔧 **Fix**: Wrapped the URL parsing logic in a `try...catch` block. It now "fails securely" by returning the default account `'0'` instead of crashing, preserving execution flow.
✅ **Verification**: Ran the test suite. The previously failing test `should return "0" for URLs without /u/X/ segment` now passes successfully alongside the rest of the tests.

---
*PR created automatically by Jules for task [5280861900874539029](https://jules.google.com/task/5280861900874539029) started by @n24q02m*