### PR TITLE
🎨 Palette: Improve accessibility for operation settings

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2025-04-03 - Progressive Disclosure for Multi-Mode UIs
 **Learning:** In a multi-mode UI (like Archive vs Suggestions), showing all settings at once creates cognitive overload, especially when settings like GitHub tokens are only relevant to one mode.
 **Action:** Use progressive disclosure in `popup.js` to hide mode-specific settings (like the `.settings` section and `force` checkbox) when they are not relevant to the currently selected mode, keeping the UI clean and focused.
+## 2024-05-15 - Segmented Control Focus Outline Clipping
+**Learning:** Containers with `overflow: hidden` (like the `.segmented` wrapper used to create pill-shaped button groups) will visually clip the default browser focus ring (`outline`) on child elements, rendering them invisible to keyboard users and violating accessibility guidelines.
+**Action:** Always verify focus rings on interactive elements within clipped containers. Use `outline-offset: -2px;` (or similar negative values) on the child elements' `:focus-visible` state to draw the outline inside the element's bounding box, preventing clipping.

--- a/popup.css
+++ b/popup.css
@@ -145,6 +145,10 @@ input:focus-visible {
   outline-offset: 2px;
 }
 
+.segmented button:focus-visible {
+  outline-offset: -2px;
+}
+
 button.primary {
   display: block;
   width: 100%;

--- a/popup.html
+++ b/popup.html
@@ -31,7 +31,7 @@
           <button type="button" data-value="suggestions" aria-pressed="false">Start Suggestions</button>
         </div>
       </div>
-      <div class="radio-group">
+      <div class="radio-group" role="radiogroup" aria-label="Execution Mode">
         <label><input type="radio" name="mode" value="dry" checked /> Dry Run</label>
         <label><input type="radio" name="mode" value="run" /> Run</label>
       </div>
@@ -39,7 +39,7 @@
         <input type="checkbox" id="force" />
         Force (skip PR check)
       </label>
-      <div class="radio-group">
+      <div class="radio-group" role="radiogroup" aria-label="Tab Scope">
         <label><input type="radio" name="scope" value="current" /> Current tab</label>
         <label><input type="radio" name="scope" value="all" checked /> All Jules tabs</label>
       </div>


### PR DESCRIPTION
### 💡 What
Added missing ARIA attributes (`role="radiogroup"` and `aria-label`) to the execution mode and tab scope setting groups. Also added a negative outline offset (`outline-offset: -2px`) to the segmented operation buttons for their `:focus-visible` state.

### 🎯 Why
- Screen reader users were previously unable to discern the context or grouping of the "Run/Dry Run" and "Current/All tabs" radio buttons.
- Keyboard-only users were unable to see the focus indicator on the "Archive Tasks" / "Start Suggestions" segmented buttons because the parent `.segmented` container uses `overflow: hidden`, which clips the default exterior focus ring.

### ♿ Accessibility
- Provides proper semantic grouping for screen readers interacting with the popup settings.
- Restores crucial visual feedback for keyboard navigation on primary operation controls.

### 📸 Before/After
*(Visuals unchanged for mouse users. Keyboard users now see a clear green focus ring inside the active segmented button instead of no feedback).*

---
*PR created automatically by Jules for task [13135145072788445157](https://jules.google.com/task/13135145072788445157) started by @n24q02m*