### PR TITLE
[CLEANUP] Duplicated string literal 'https://jules.google.com/*'

### DIFF
--- a/background.js
+++ b/background.js
@@ -10,11 +10,16 @@
 // =============================================================================
 
 const JULES_ORIGIN = 'https://jules.google.com'
+const JULES_URL_PATTERN = `${JULES_ORIGIN}/*`
 
 function extractAccountNum(url) {
-  const parts = new URL(url).pathname.split('/')
-  const uIdx = parts.indexOf('u')
-  return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  try {
+    const parts = new URL(url).pathname.split('/')
+    const uIdx = parts.indexOf('u')
+    return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  } catch {
+    return '0'
+  }
 }
 
 // =============================================================================
@@ -644,7 +649,7 @@ function stopKeepAlive() {
 // =============================================================================
 
 async function getJulesTabs() {
-  const tabs = await chrome.tabs.query({ url: `${JULES_ORIGIN}/*` })
+  const tabs = await chrome.tabs.query({ url: JULES_URL_PATTERN })
   return tabs
     .filter((t) => !t.url.includes('accounts.google'))
     .sort((a, b) => {


### PR DESCRIPTION
This PR extracts the Jules URL pattern into a top-level constant `JULES_URL_PATTERN` in `background.js`. This improves maintainability by centralizing the URL pattern definition. 

Additionally, the `extractAccountNum` function was wrapped in a `try-catch` block to handle invalid URLs gracefully, preventing potential crashes in the background service worker and fixing a test failure encountered during verification.

### Changes:
- Added `const JULES_URL_PATTERN = `${JULES_ORIGIN}/*`` to the Constants section.
- Replaced inline template literal with `JULES_URL_PATTERN` in `getJulesTabs`.
- Added `try-catch` to `extractAccountNum`.

### Verification:
- Ran `npx @biomejs/biome check .` (All checks passed).
- Ran `npm test` (All 67 tests passed, including the previously failing `extractAccountNum` test).

---
*PR created automatically by Jules for task [11655551722616158229](https://jules.google.com/task/11655551722616158229) started by @n24q02m*