### PR TITLE
[TEST] Untested tab label parsing logic

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-14 - Robust Tab Label Parsing
+**Vulnerability:** The 'extractAccountNum' function was directly calling 'new URL(url)' without error handling, which could lead to service worker crashes if an invalid URL (e.g. empty string or malformed data) was passed to 'getTabLabel'.
+**Learning:** In extension service workers, unhandled exceptions in utility functions can cause the background process to crash, resulting in a Denial of Service for the extension's operations.
+**Prevention:** Always wrap URL parsing and other potentially failing native API calls in try/catch blocks, especially when they process data from external or dynamic sources like tab objects, and provide safe fallback values.

--- a/background.js
+++ b/background.js
@@ -12,9 +12,13 @@
 const JULES_ORIGIN = 'https://jules.google.com'
 
 function extractAccountNum(url) {
-  const parts = new URL(url).pathname.split('/')
-  const uIdx = parts.indexOf('u')
-  return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  try {
+    const parts = new URL(url).pathname.split('/')
+    const uIdx = parts.indexOf('u')
+    return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  } catch {
+    return '0'
+  }
 }
 
 // =============================================================================

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -798,3 +798,44 @@ describe('getJulesTabs', () => {
     assert.strictEqual(sandbox.test_extractAccountNum(tabs[1].url), '1')
   })
 })
+
+describe('extractAccountNum (additional edge cases)', () => {
+  it('should return "0" for URLs with "u" but no account segment', () => {
+    const { sandbox } = setupEnvironment()
+    assert.strictEqual(sandbox.test_extractAccountNum('https://jules.google.com/u/'), '0')
+    assert.strictEqual(sandbox.test_extractAccountNum('https://jules.google.com/u'), '0')
+  })
+
+  it('should return "0" for non-string inputs', () => {
+    const { sandbox } = setupEnvironment()
+    assert.strictEqual(sandbox.test_extractAccountNum(null), '0')
+    assert.strictEqual(sandbox.test_extractAccountNum(undefined), '0')
+    assert.strictEqual(sandbox.test_extractAccountNum(123), '0')
+    assert.strictEqual(sandbox.test_extractAccountNum({}), '0')
+  })
+
+  it('should handle multiple "u" segments by picking the first one followed by a value', () => {
+    const { sandbox } = setupEnvironment()
+    // In "/a/u/b/u/1", it should find the first "u".
+    // parts = ["", "a", "u", "b", "u", "1"]
+    // uIdx = 2, parts[3] = "b"
+    assert.strictEqual(sandbox.test_extractAccountNum('https://jules.google.com/a/u/b/u/1'), 'b')
+  })
+})
+
+describe('getTabLabel (additional edge cases)', () => {
+  it('should return "default" when tab.url is missing or invalid', () => {
+    const { sandbox } = setupEnvironment()
+    assert.strictEqual(sandbox.test_getTabLabel({}), 'default')
+    assert.strictEqual(sandbox.test_getTabLabel({ url: null }), 'default')
+    assert.strictEqual(sandbox.test_getTabLabel({ url: 'not-a-url' }), 'default')
+  })
+
+  it('should handle very large account numbers', () => {
+    const { sandbox } = setupEnvironment()
+    assert.strictEqual(
+      sandbox.test_getTabLabel({ url: 'https://jules.google.com/u/9999999999/session' }),
+      'u/9999999999'
+    )
+  })
+})


### PR DESCRIPTION
This PR fixes a potential crash in the `extractAccountNum` function by adding a try/catch block around the native `URL` API call. This ensures that malformed or empty URLs from tab objects do not crash the service worker.

Additionally, this PR adds comprehensive unit tests to `tests/background.test.js` covering edge cases for both `extractAccountNum` and `getTabLabel`, improving test coverage for tab management logic.

A security journal entry was added to `.Jules/sentinel.md` documenting the learning.

---
*PR created automatically by Jules for task [11608566717928697736](https://jules.google.com/task/11608566717928697736) started by @n24q02m*