### PR TITLE
🛡️ Sentinel: [HIGH] Fix Denial of Service in URL parsing

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - Service Worker Denial of Service via Unhandled URL Parsing
+**Vulnerability:** A Denial of Service (DoS) vulnerability existed in `extractAccountNum` (in `background.js`) and `getAccountNum` (in `content.js`) where `new URL(url)` could throw a `TypeError` for invalid URLs.
+**Learning:** In Chrome Extension service workers, unhandled exceptions (like `TypeError` from `new URL()`) crash the background process. Because URL parsing is common when intercepting tab updates or handling messages, failure to wrap this in a `try/catch` allows malformed data or invalid tab URLs to completely disable the extension's background execution context.
+**Prevention:** Always wrap `new URL()` and other error-prone parsing logic in `try/catch` blocks within service workers and fail securely by returning a safe fallback value (e.g., `'0'` in this case).

--- a/background.js
+++ b/background.js
@@ -12,9 +12,13 @@
 const JULES_ORIGIN = 'https://jules.google.com'
 
 function extractAccountNum(url) {
-  const parts = new URL(url).pathname.split('/')
-  const uIdx = parts.indexOf('u')
-  return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  try {
+    const parts = new URL(url).pathname.split('/')
+    const uIdx = parts.indexOf('u')
+    return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  } catch {
+    return '0'
+  }
 }
 
 // =============================================================================

--- a/content.js
+++ b/content.js
@@ -49,9 +49,13 @@ function extractConfig() {
 
 // Detect account from URL
 function getAccountNum() {
-  const parts = new URL(location.href).pathname.split('/')
-  const uIdx = parts.indexOf('u')
-  return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  try {
+    const parts = new URL(location.href).pathname.split('/')
+    const uIdx = parts.indexOf('u')
+    return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  } catch {
+    return '0'
+  }
 }
 
 function getAccountLabel() {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Denial of Service (DoS) vulnerability via unhandled exception in background and content scripts during URL parsing.
🎯 Impact: If a tab URL is malformed or invalid when queried by the extension, `new URL()` throws a `TypeError`. Because the service worker does not catch this exception, the entire background process crashes, completely disabling the extension's functionality until restarted.
🔧 Fix: Wrapped URL parsing logic in `try/catch` blocks in both `extractAccountNum` (`background.js`) and `getAccountNum` (`content.js`). The code now fails securely by returning the default fallback value (`'0'`).
✅ Verification: Ran unit tests. The test asserting the parsing of invalid URLs previously failed with `TypeError: Invalid URL` and now passes correctly. Also added an entry to `.Jules/sentinel.md` to document the learning.

---
*PR created automatically by Jules for task [4104657220847343345](https://jules.google.com/task/4104657220847343345) started by @n24q02m*