### PR TITLE
🎨 Palette: Improve keyboard focus visibility for segmented buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-04-03 - Progressive Disclosure for Multi-Mode UIs
 **Learning:** In a multi-mode UI (like Archive vs Suggestions), showing all settings at once creates cognitive overload, especially when settings like GitHub tokens are only relevant to one mode.
 **Action:** Use progressive disclosure in `popup.js` to hide mode-specific settings (like the `.settings` section and `force` checkbox) when they are not relevant to the currently selected mode, keeping the UI clean and focused.
+
+## 2025-04-06 - Keyboard accessibility in overflow: hidden containers
+**Learning:** Elements inside containers with `overflow: hidden` (like the `.segmented` group in `popup.html`) will have their default focus rings clipped if `outline-offset` pushes the outline outside the element bounds.
+**Action:** Always apply a negative outline offset (e.g., `outline-offset: -2px;`) to the child element's `:focus-visible` state when its parent uses `overflow: hidden` to ensure the focus ring remains visible for keyboard users.

--- a/popup.css
+++ b/popup.css
@@ -145,6 +145,10 @@ input:focus-visible {
   outline-offset: 2px;
 }
 
+.segmented button:focus-visible {
+  outline-offset: -2px;
+}
+
 button.primary {
   display: block;
   width: 100%;


### PR DESCRIPTION
### 💡 What
Added a specific CSS rule (`outline-offset: -2px`) for focused segmented buttons (`.segmented button:focus-visible`).

### 🎯 Why
The parent container (`.segmented`) uses `overflow: hidden` to create a unified border radius for the button group. However, the global focus style (`outline-offset: 2px`) pushed the focus ring outside the button's bounds, causing it to be completely clipped and invisible to users navigating via keyboard.

### ♿ Accessibility
Restores critical keyboard navigation visibility. Users tabbing through the "Operation Mode" toggle can now clearly see which button has focus, satisfying WCAG 2.1 Success Criterion 2.4.7 (Focus Visible).

---
*PR created automatically by Jules for task [13945834275844432113](https://jules.google.com/task/13945834275844432113) started by @n24q02m*