### PR TITLE
[CLEANUP] extractAccountNum Missing Error Handling

### DIFF
--- a/background.js
+++ b/background.js
@@ -12,9 +12,13 @@
 const JULES_ORIGIN = 'https://jules.google.com'
 
 function extractAccountNum(url) {
-  const parts = new URL(url).pathname.split('/')
-  const uIdx = parts.indexOf('u')
-  return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  try {
+    const parts = new URL(url).pathname.split('/')
+    const uIdx = parts.indexOf('u')
+    return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  } catch {
+    return '0'
+  }
 }
 
 // =============================================================================

--- a/content.js
+++ b/content.js
@@ -49,9 +49,13 @@ function extractConfig() {
 
 // Detect account from URL
 function getAccountNum() {
-  const parts = new URL(location.href).pathname.split('/')
-  const uIdx = parts.indexOf('u')
-  return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  try {
+    const parts = new URL(location.href).pathname.split('/')
+    const uIdx = parts.indexOf('u')
+    return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  } catch {
+    return '0'
+  }
 }
 
 function getAccountLabel() {


### PR DESCRIPTION
This PR adds robust error handling to the URL parsing logic in both `background.js` and `content.js`. By wrapping `new URL()` calls in try/catch blocks, we ensure that the extension doesn't crash on invalid or empty URLs and instead falls back to a safe default account number ('0'). This also resolves a failing test case in the background script test suite.

Verified with `npm test` and `npx @biomejs/biome check .`.

---
*PR created automatically by Jules for task [10143030296413452864](https://jules.google.com/task/10143030296413452864) started by @n24q02m*