### PR TITLE
[FIX] Missing origin check in message listener in content script

### DIFF
--- a/background.js
+++ b/background.js
@@ -12,9 +12,13 @@
 const JULES_ORIGIN = 'https://jules.google.com'
 
 function extractAccountNum(url) {
-  const parts = new URL(url).pathname.split('/')
-  const uIdx = parts.indexOf('u')
-  return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  try {
+    const parts = new URL(url).pathname.split('/')
+    const uIdx = parts.indexOf('u')
+    return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  } catch {
+    return '0'
+  }
 }
 
 // =============================================================================

--- a/content.js
+++ b/content.js
@@ -11,7 +11,7 @@ let cachedConfig = null
 
 // Listen for messages from MAIN world script
 window.addEventListener('message', (event) => {
-  if (event.source !== window) return
+  if (event.source !== window || event.origin !== window.origin) return
   if (event.data?.type === 'JULES_ARCHIVER_CONFIG') {
     cachedConfig = event.data.config
   }
@@ -32,11 +32,11 @@ function extractConfig() {
 
   return new Promise((resolve) => {
     // Ask main-world.js to re-broadcast config
-    window.postMessage({ type: 'JULES_REQUEST_CONFIG' }, '*')
+    window.postMessage({ type: 'JULES_REQUEST_CONFIG' }, window.origin)
 
     const timeout = setTimeout(() => resolve(cachedConfig), 2000)
     const handler = (event) => {
-      if (event.source !== window) return
+      if (event.source !== window || event.origin !== window.origin) return
       if (event.data?.type !== 'JULES_ARCHIVER_CONFIG') return
       window.removeEventListener('message', handler)
       clearTimeout(timeout)

--- a/main-world.js
+++ b/main-world.js
@@ -26,7 +26,7 @@ function broadcastConfig() {
           }
         : null
     },
-    '*'
+    window.origin
   )
 }
 
@@ -54,7 +54,7 @@ if (!window.__julesArchiver) {
               capturedAt: Date.now()
             }
           },
-          '*'
+          window.origin
         )
       } catch (_e) {
         /* ignore parse errors */
@@ -69,7 +69,7 @@ broadcastConfig()
 
 // Also listen for explicit re-extract requests from content.js
 window.addEventListener('message', (event) => {
-  if (event.source !== window) return
+  if (event.source !== window || event.origin !== window.origin) return
   if (event.data?.type === 'JULES_REQUEST_CONFIG') {
     broadcastConfig()
   }

--- a/tests/security_origin.test.js
+++ b/tests/security_origin.test.js
@@ -1,0 +1,107 @@
+const { describe, it } = require('node:test')
+const assert = require('node:assert')
+const fs = require('node:fs')
+const path = require('node:path')
+const vm = require('node:vm')
+
+const contentJsPath = path.join(__dirname, '..', 'content.js')
+const mainWorldJsPath = path.join(__dirname, '..', 'main-world.js')
+
+function setupSandbox(scriptPath) {
+  const scriptContent = fs.readFileSync(scriptPath, 'utf8')
+
+  const messages = []
+  const chrome = {
+    runtime: {
+      sendMessage: (msg) => messages.push({ to: 'background', msg }),
+      onMessage: { addListener: () => {} }
+    },
+    storage: {
+      session: { set: () => {} }
+    }
+  }
+
+  const listeners = []
+  const mockWindow = {
+    origin: 'https://jules.google.com',
+    location: { href: 'https://jules.google.com/u/0/' },
+    addEventListener: (type, handler) => {
+      if (type === 'message') listeners.push(handler)
+    },
+    removeEventListener: (type, handler) => {
+      if (type === 'message') {
+        const idx = listeners.indexOf(handler)
+        if (idx !== -1) listeners.splice(idx, 1)
+      }
+    },
+    postMessage: (msg, targetOrigin) => {
+      messages.push({ to: 'window', msg, targetOrigin })
+    }
+  }
+
+  const sandbox = {
+    window: mockWindow,
+    chrome,
+    console,
+    setTimeout,
+    clearTimeout,
+    Date,
+    Promise,
+    URL,
+    location: mockWindow.location
+  }
+
+  vm.createContext(sandbox)
+  vm.runInContext(scriptContent, sandbox)
+
+  return { sandbox, listeners, messages, mockWindow }
+}
+
+describe('PostMessage Origin Security', () => {
+  it('content.js should only accept messages from same origin', () => {
+    const { listeners, messages, mockWindow } = setupSandbox(contentJsPath)
+    const handler = listeners[0]
+
+    // 1. Untrusted origin, correct data
+    handler({
+      source: mockWindow,
+      origin: 'https://evil.com',
+      data: { type: 'JULES_START_CONFIG', config: { secret: 'data' } }
+    })
+
+    // Check if it sent to background (should NOT have if fixed)
+    const backgroundMsgs = messages.filter((m) => m.to === 'background')
+    assert.strictEqual(backgroundMsgs.length, 0, 'Should not process messages from untrusted origin')
+  })
+
+  it('main-world.js should only accept messages from same origin', () => {
+    const { listeners, messages, mockWindow } = setupSandbox(mainWorldJsPath)
+    // main-world.js adds a listener at the end
+    const handler = listeners[listeners.length - 1]
+
+    // Mock broadcastConfig behavior check via messages
+    const initialCount = messages.filter((m) => m.to === 'window').length
+
+    // Untrusted origin
+    handler({
+      source: mockWindow,
+      origin: 'https://evil.com',
+      data: { type: 'JULES_REQUEST_CONFIG' }
+    })
+
+    const finalCount = messages.filter((m) => m.to === 'window').length
+    assert.strictEqual(finalCount, initialCount, 'Should not respond to requests from untrusted origin')
+  })
+
+  it('scripts should use window.origin instead of "*" in postMessage', () => {
+    const content = fs.readFileSync(contentJsPath, 'utf8')
+    const mainWorld = fs.readFileSync(mainWorldJsPath, 'utf8')
+
+    // These will FAIL initially
+    assert.ok(
+      !content.includes("postMessage({ type: 'JULES_REQUEST_CONFIG' }, '*')"),
+      'Content script should not use "*" for JULES_REQUEST_CONFIG'
+    )
+    assert.ok(!mainWorld.includes("'*'"), 'Main world script should not use "*" for any postMessage')
+  })
+})


### PR DESCRIPTION
This PR addresses a security issue where message listeners in the content script and main-world script were not verifying the origin of incoming messages. While `event.source === window` was checked, adding an explicit origin check (`event.origin === window.origin`) provides a necessary layer of defense-in-depth.

**Changes:**
- **Security:** Added `event.origin === window.origin` checks to all `window.addEventListener('message', ...)` handlers in `content.js` and `main-world.js`.
- **Security:** Updated all `window.postMessage` calls to use `window.origin` as the target origin instead of the wildcard `*`. This prevents sensitive data from being sent to unintended origins if the window navigates during message delivery.
- **Robustness:** Added a `try/catch` block to `extractAccountNum` in `background.js` to gracefully handle invalid or empty URLs, preventing potential service worker crashes.
- **Testing:** Added `tests/security_origin.test.js` which uses `node:vm` to simulate the message-passing environment and verify the origin checks.
- **Maintenance:** Fixed an existing test failure in `tests/background.test.js` related to invalid URL handling.

**Verification:**
- Ran `npm test` and all 70 tests passed (including new security tests).
- Ran `npx @biomejs/biome check .` to ensure linting and formatting compliance.

---
*PR created automatically by Jules for task [17353764939044332430](https://jules.google.com/task/17353764939044332430) started by @n24q02m*