### PR TITLE
[CLEANUP] extractAccountNum Missing Error Handling

### DIFF
--- a/background.js
+++ b/background.js
@@ -12,9 +12,11 @@
 const JULES_ORIGIN = 'https://jules.google.com'
 
 function extractAccountNum(url) {
-  const parts = new URL(url).pathname.split('/')
-  const uIdx = parts.indexOf('u')
-  return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  try {
+    return new URL(url).pathname.split('/u/')[1]?.split('/')[0] || '0'
+  } catch {
+    return '0'
+  }
 }
 
 // =============================================================================

--- a/content.js
+++ b/content.js
@@ -49,9 +49,11 @@ function extractConfig() {
 
 // Detect account from URL
 function getAccountNum() {
-  const parts = new URL(location.href).pathname.split('/')
-  const uIdx = parts.indexOf('u')
-  return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  try {
+    return new URL(location.href).pathname.split('/u/')[1]?.split('/')[0] || '0'
+  } catch {
+    return '0'
+  }
 }
 
 function getAccountLabel() {


### PR DESCRIPTION
Added try...catch blocks to extractAccountNum in background.js and getAccountNum in content.js to gracefully handle invalid URLs. Updated parsing logic to use split('/u/') for better robustness. This prevents potential service worker crashes when parsing malformed or empty URLs.

---
*PR created automatically by Jules for task [9154700639111681359](https://jules.google.com/task/9154700639111681359) started by @n24q02m*