### PR TITLE
fix: add origin check to message listeners and restrict postMessage target

### DIFF
--- a/content.js
+++ b/content.js
@@ -12,6 +12,8 @@ let cachedConfig = null
 // Listen for messages from MAIN world script
 window.addEventListener('message', (event) => {
   if (event.source !== window) return
+  if (event.origin !== window.origin) return
+
   if (event.data?.type === 'JULES_ARCHIVER_CONFIG') {
     cachedConfig = event.data.config
   }
@@ -32,11 +34,12 @@ function extractConfig() {
 
   return new Promise((resolve) => {
     // Ask main-world.js to re-broadcast config
-    window.postMessage({ type: 'JULES_REQUEST_CONFIG' }, '*')
+    window.postMessage({ type: 'JULES_REQUEST_CONFIG' }, window.origin)
 
     const timeout = setTimeout(() => resolve(cachedConfig), 2000)
     const handler = (event) => {
       if (event.source !== window) return
+      if (event.origin !== window.origin) return
       if (event.data?.type !== 'JULES_ARCHIVER_CONFIG') return
       window.removeEventListener('message', handler)
       clearTimeout(timeout)

--- a/main-world.js
+++ b/main-world.js
@@ -26,7 +26,7 @@ function broadcastConfig() {
           }
         : null
     },
-    '*'
+    window.origin
   )
 }
 
@@ -54,7 +54,7 @@ if (!window.__julesArchiver) {
               capturedAt: Date.now()
             }
           },
-          '*'
+          window.origin
         )
       } catch (_e) {
         /* ignore parse errors */
@@ -70,6 +70,7 @@ broadcastConfig()
 // Also listen for explicit re-extract requests from content.js
 window.addEventListener('message', (event) => {
   if (event.source !== window) return
+  if (event.origin !== window.origin) return
   if (event.data?.type === 'JULES_REQUEST_CONFIG') {
     broadcastConfig()
   }

--- a/tests/postmessage_security.test.js
+++ b/tests/postmessage_security.test.js
@@ -1,0 +1,160 @@
+const { describe, it } = require('node:test')
+const assert = require('node:assert')
+const fs = require('node:fs')
+const path = require('node:path')
+const vm = require('node:vm')
+
+const mainWorldPath = path.join(__dirname, '..', 'main-world.js')
+const mainWorldContent = fs.readFileSync(mainWorldPath, 'utf8')
+
+const contentJsPath = path.join(__dirname, '..', 'content.js')
+const contentJsContent = fs.readFileSync(contentJsPath, 'utf8')
+
+function setupMainWorldSandbox() {
+  const messagesSent = []
+  const listeners = []
+
+  const sandbox = {
+    window: {
+      origin: 'https://jules.google.com',
+      addEventListener: (type, handler) => {
+        if (type === 'message') listeners.push(handler)
+      },
+      postMessage: (data, targetOrigin) => {
+        messagesSent.push({ data, targetOrigin })
+      },
+      WIZ_global_data: {
+        TSDtV: 'beyond:models/gemini-pro',
+        SNlM0e: 'at-token',
+        cfb2h: 'build-label',
+        FdrFJe: 'fsid-token'
+      },
+      __julesArchiver: false,
+      fetch: async () => ({})
+    },
+    console: { log: () => {}, error: () => {} },
+    Date: { now: () => 123456789 },
+    String: String,
+    URLSearchParams: URLSearchParams,
+    JSON: JSON
+  }
+  sandbox.window.window = sandbox.window
+  sandbox.addEventListener = sandbox.window.addEventListener
+  sandbox.postMessage = sandbox.window.postMessage
+  sandbox.origin = sandbox.window.origin
+
+  vm.createContext(sandbox)
+  vm.runInContext(mainWorldContent, sandbox)
+
+  return { sandbox, messagesSent, listeners }
+}
+
+function setupContentJsSandbox() {
+  const messagesSent = []
+  const listeners = []
+  const runtimeMessages = []
+
+  const sandbox = {
+    window: {
+      origin: 'https://jules.google.com',
+      addEventListener: (type, handler) => {
+        if (type === 'message') listeners.push(handler)
+      },
+      removeEventListener: (_type, handler) => {
+        const idx = listeners.indexOf(handler)
+        if (idx !== -1) listeners.splice(idx, 1)
+      },
+      postMessage: (data, targetOrigin) => {
+        messagesSent.push({ data, targetOrigin })
+      }
+    },
+    chrome: {
+      runtime: {
+        sendMessage: (msg) => runtimeMessages.push(msg),
+        onMessage: { addListener: () => {} }
+      }
+    },
+    console: { log: () => {}, error: () => {} },
+    Date: { now: () => 123456789 },
+    URL: URL,
+    location: { href: 'https://jules.google.com/u/0/' },
+    Promise: Promise,
+    setTimeout: setTimeout,
+    clearTimeout: clearTimeout
+  }
+  sandbox.window.window = sandbox.window
+  sandbox.addEventListener = sandbox.window.addEventListener
+  sandbox.postMessage = sandbox.window.postMessage
+  sandbox.origin = sandbox.window.origin
+
+  vm.createContext(sandbox)
+  vm.runInContext(contentJsContent, sandbox)
+
+  return { sandbox, messagesSent, listeners, runtimeMessages }
+}
+
+describe('PostMessage Security: main-world.js', () => {
+  it('should only use window.origin as target for postMessage', () => {
+    const { messagesSent } = setupMainWorldSandbox()
+    assert.ok(messagesSent.length > 0)
+    messagesSent.forEach((msg) => {
+      assert.notStrictEqual(msg.targetOrigin, '*', 'Should not use wildcard origin')
+      assert.strictEqual(msg.targetOrigin, 'https://jules.google.com')
+    })
+  })
+
+  it('should verify event.origin in message listener', () => {
+    const { sandbox, listeners, messagesSent } = setupMainWorldSandbox()
+    const handler = listeners[listeners.length - 1]
+    const initialCount = messagesSent.length
+
+    // Simulate message from wrong origin
+    handler({
+      source: sandbox.window,
+      origin: 'https://evil.com',
+      data: { type: 'JULES_REQUEST_CONFIG' }
+    })
+    assert.strictEqual(messagesSent.length, initialCount, 'Should ignore messages from wrong origin')
+
+    // Simulate message from correct origin
+    handler({
+      source: sandbox.window,
+      origin: 'https://jules.google.com',
+      data: { type: 'JULES_REQUEST_CONFIG' }
+    })
+    assert.ok(messagesSent.length > initialCount, 'Should respond to messages from correct origin')
+  })
+})
+
+describe('PostMessage Security: content.js', () => {
+  it('should use window.origin as target for postMessage when requesting config', async () => {
+    const { sandbox, messagesSent } = setupContentJsSandbox()
+    vm.runInContext('extractConfig()', sandbox)
+
+    const reqMsg = messagesSent.find((m) => m.data?.type === 'JULES_REQUEST_CONFIG')
+    assert.ok(reqMsg)
+    assert.notStrictEqual(reqMsg.targetOrigin, '*', 'Should not use wildcard origin')
+    assert.strictEqual(reqMsg.targetOrigin, 'https://jules.google.com')
+  })
+
+  it('should verify event.origin in message listener', () => {
+    const { listeners, sandbox, runtimeMessages } = setupContentJsSandbox()
+    const handler = listeners[0] // There is only one global listener in content.js for messages
+
+    // Simulate message from wrong origin
+    handler({
+      source: sandbox.window,
+      origin: 'https://evil.com',
+      data: { type: 'JULES_START_CONFIG', config: { foo: 'bar' } }
+    })
+    assert.strictEqual(runtimeMessages.length, 0, 'Should ignore messages from wrong origin')
+
+    // Simulate message from correct origin
+    handler({
+      source: sandbox.window,
+      origin: 'https://jules.google.com',
+      data: { type: 'JULES_START_CONFIG', config: { foo: 'bar' } }
+    })
+    assert.strictEqual(runtimeMessages.length, 1, 'Should process messages from correct origin')
+  })
+})


### PR DESCRIPTION
### [FIX] Missing origin check in message listener

#### What
This PR adds origin validation to `window.postMessage` listeners in both `main-world.js` and `content.js`. It also restricts the target origin of outgoing `postMessage` calls to `window.origin` instead of using the wildcard `'*'`.

#### Why
Using `'*'` as a target origin allows any script on the page (including malicious ones in iframes) to intercept sensitive configuration data. Similarly, missing an `event.origin` check in the message listener allows untrusted origins to trigger actions (like re-broadcasting config) within the extension's context. Verifying `event.origin` against `window.origin` ensures that communication only happens between trusted components on the same domain.

#### Changes
- **`main-world.js`**:
  - Added `if (event.origin !== window.origin) return` to the message listener.
  - Replaced `'*'` with `window.origin` in all `window.postMessage` calls.
- **`content.js`**:
  - Added `if (event.origin !== window.origin) return` to all message listeners (both global and local).
  - Replaced `'*'` with `window.origin` in the `JULES_REQUEST_CONFIG` message.
- **`tests/postmessage_security.test.js`**:
  - New test suite using `node:vm` to verify that both scripts correctly validate incoming message origins and restrict outgoing message targets.

#### Verification
- Ran `npx @biomejs/biome check --write .` to ensure linting and formatting standards.
- Ran `npm test tests/postmessage_security.test.js` (all tests passed).
- Ran the full test suite `npm test` to ensure no regressions in existing functionality.

---
*PR created automatically by Jules for task [15143606718466853442](https://jules.google.com/task/15143606718466853442) started by @n24q02m*