### PR TITLE
[FIX] Insecure window.postMessage Target Origin in fetch observer

### DIFF
--- a/background.js
+++ b/background.js
@@ -12,9 +12,13 @@
 const JULES_ORIGIN = 'https://jules.google.com'
 
 function extractAccountNum(url) {
-  const parts = new URL(url).pathname.split('/')
-  const uIdx = parts.indexOf('u')
-  return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  try {
+    const parts = new URL(url).pathname.split('/')
+    const uIdx = parts.indexOf('u')
+    return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  } catch {
+    return '0'
+  }
 }
 
 // =============================================================================

--- a/content.js
+++ b/content.js
@@ -32,7 +32,7 @@ function extractConfig() {
 
   return new Promise((resolve) => {
     // Ask main-world.js to re-broadcast config
-    window.postMessage({ type: 'JULES_REQUEST_CONFIG' }, '*')
+    window.postMessage({ type: 'JULES_REQUEST_CONFIG' }, window.origin)
 
     const timeout = setTimeout(() => resolve(cachedConfig), 2000)
     const handler = (event) => {

--- a/main-world.js
+++ b/main-world.js
@@ -26,7 +26,7 @@ function broadcastConfig() {
           }
         : null
     },
-    '*'
+    window.origin
   )
 }
 
@@ -54,7 +54,7 @@ if (!window.__julesArchiver) {
               capturedAt: Date.now()
             }
           },
-          '*'
+          window.origin
         )
       } catch (_e) {
         /* ignore parse errors */

--- a/tests/postmessage_security.test.js
+++ b/tests/postmessage_security.test.js
@@ -1,0 +1,73 @@
+const { describe, it } = require('node:test')
+const assert = require('node:assert')
+const fs = require('node:fs')
+const path = require('node:path')
+const vm = require('node:vm')
+
+describe('postMessage Security', () => {
+  const mainWorldJs = fs.readFileSync(path.join(__dirname, '../main-world.js'), 'utf8')
+  const contentJs = fs.readFileSync(path.join(__dirname, '../content.js'), 'utf8')
+
+  function setupSandbox() {
+    const messages = []
+    const sandbox = {
+      window: {
+        origin: 'https://jules.google.com',
+        postMessage: (data, origin) => {
+          messages.push({ data, origin })
+        },
+        addEventListener: () => {},
+        WIZ_global_data: {
+          SNlM0e: 'at-token',
+          cfb2h: 'bl-token',
+          FdrFJe: 'fsid-token',
+          TSDtV: 'beyond:models/gemini-pro'
+        }
+      },
+      chrome: {
+        runtime: {
+          sendMessage: () => {},
+          onMessage: { addListener: () => {} }
+        }
+      },
+      console,
+      setTimeout: (fn) => fn(),
+      clearTimeout: () => {},
+      Date,
+      URL,
+      location: { href: 'https://jules.google.com/u/0/' }
+    }
+    // Cross-reference window and global
+    sandbox.window.window = sandbox.window
+    sandbox.origin = sandbox.window.origin
+    sandbox.postMessage = sandbox.window.postMessage.bind(sandbox.window)
+
+    vm.createContext(sandbox)
+    return { sandbox, messages }
+  }
+
+  it('main-world.js should use window.origin in broadcastConfig', () => {
+    const { sandbox, messages } = setupSandbox()
+    vm.runInContext(mainWorldJs, sandbox)
+
+    // broadcastConfig is called at the end of main-world.js
+    const configMsg = messages.find((m) => m.data.type === 'JULES_ARCHIVER_CONFIG')
+    assert.ok(configMsg, 'Should have sent JULES_ARCHIVER_CONFIG')
+    assert.strictEqual(configMsg.origin, 'https://jules.google.com', 'Target origin should be restricted')
+    assert.notStrictEqual(configMsg.origin, '*', 'Target origin should not be wildcard')
+  })
+
+  it('content.js should use window.origin in extractConfig', async () => {
+    const { sandbox, messages } = setupSandbox()
+    vm.runInContext(contentJs, sandbox)
+
+    // We need to trigger extractConfig.
+    // It's not exported, so we have to run it in the context.
+    vm.runInContext('extractConfig()', sandbox)
+
+    const requestMsg = messages.find((m) => m.data.type === 'JULES_REQUEST_CONFIG')
+    assert.ok(requestMsg, 'Should have sent JULES_REQUEST_CONFIG')
+    assert.strictEqual(requestMsg.origin, 'https://jules.google.com', 'Target origin should be restricted')
+    assert.notStrictEqual(requestMsg.origin, '*', 'Target origin should not be wildcard')
+  })
+})


### PR DESCRIPTION
This PR addresses a security issue where `window.postMessage` used a wildcard ('*') target origin, which could allow malicious iframes to intercept sensitive data.

### Changes:
- Updated `main-world.js` and `content.js` to use `window.origin` as the target origin for `window.postMessage`.
- Added `tests/postmessage_security.test.js` to verify that `window.postMessage` is called with restricted origins.
- Hardened `extractAccountNum` in `background.js` with a `try/catch` block to handle invalid URLs gracefully and prevent service worker crashes.
- Verified all 69 tests pass.
- Applied Biome linting and formatting.

---
*PR created automatically by Jules for task [4277923178835062749](https://jules.google.com/task/4277923178835062749) started by @n24q02m*