### PR TITLE
[FIX] Missing origin check in message listener

### DIFF
--- a/content.js
+++ b/content.js
@@ -11,7 +11,7 @@ let cachedConfig = null
 
 // Listen for messages from MAIN world script
 window.addEventListener('message', (event) => {
-  if (event.source !== window) return
+  if (event.source !== window || event.origin !== window.origin) return
   if (event.data?.type === 'JULES_ARCHIVER_CONFIG') {
     cachedConfig = event.data.config
   }
@@ -32,11 +32,11 @@ function extractConfig() {
 
   return new Promise((resolve) => {
     // Ask main-world.js to re-broadcast config
-    window.postMessage({ type: 'JULES_REQUEST_CONFIG' }, '*')
+    window.postMessage({ type: 'JULES_REQUEST_CONFIG' }, window.origin)
 
     const timeout = setTimeout(() => resolve(cachedConfig), 2000)
     const handler = (event) => {
-      if (event.source !== window) return
+      if (event.source !== window || event.origin !== window.origin) return
       if (event.data?.type !== 'JULES_ARCHIVER_CONFIG') return
       window.removeEventListener('message', handler)
       clearTimeout(timeout)

--- a/main-world.js
+++ b/main-world.js
@@ -26,7 +26,7 @@ function broadcastConfig() {
           }
         : null
     },
-    '*'
+    window.origin
   )
 }
 
@@ -54,7 +54,7 @@ if (!window.__julesArchiver) {
               capturedAt: Date.now()
             }
           },
-          '*'
+          window.origin
         )
       } catch (_e) {
         /* ignore parse errors */
@@ -69,7 +69,7 @@ broadcastConfig()
 
 // Also listen for explicit re-extract requests from content.js
 window.addEventListener('message', (event) => {
-  if (event.source !== window) return
+  if (event.source !== window || event.origin !== window.origin) return
   if (event.data?.type === 'JULES_REQUEST_CONFIG') {
     broadcastConfig()
   }

--- a/tests/postmessage_security.test.js
+++ b/tests/postmessage_security.test.js
@@ -1,0 +1,134 @@
+const { describe, it } = require('node:test')
+const assert = require('node:assert')
+const fs = require('node:fs')
+const path = require('node:path')
+const vm = require('node:vm')
+
+const mainWorldPath = path.join(__dirname, '..', 'main-world.js')
+const contentJsPath = path.join(__dirname, '..', 'content.js')
+
+function setupSandbox(scriptPath) {
+  const scriptContent = fs.readFileSync(scriptPath, 'utf8')
+  const messagesSent = []
+  const listeners = []
+  const chromeListeners = []
+
+  const windowMock = {
+    origin: 'https://jules.google.com',
+    WIZ_global_data: { SNlM0e: 'token', cfb2h: 'build', FdrFJe: 'fsid' },
+    addEventListener: (type, handler) => {
+      if (type === 'message') listeners.push(handler)
+    },
+    removeEventListener: (type, handler) => {
+      if (type === 'message') {
+        const idx = listeners.indexOf(handler)
+        if (idx !== -1) listeners.splice(idx, 1)
+      }
+    },
+    postMessage: (data, origin) => {
+      messagesSent.push({ data, origin })
+    }
+  }
+
+  const chromeMock = {
+    runtime: {
+      sendMessage: () => {},
+      onMessage: {
+        addListener: (handler) => {
+          chromeListeners.push(handler)
+        }
+      }
+    }
+  }
+
+  const sandbox = {
+    window: windowMock,
+    chrome: chromeMock,
+    console,
+    setTimeout,
+    clearTimeout,
+    Date,
+    URL,
+    location: { href: 'https://jules.google.com/u/0/' },
+    Promise,
+    __julesArchiver: false
+  }
+  // Circular reference for window
+  windowMock.window = windowMock
+  sandbox.window.source = windowMock // Some scripts check event.source === window
+
+  vm.createContext(sandbox)
+  vm.runInContext(scriptContent, sandbox)
+
+  return { sandbox, messagesSent, listeners, chromeListeners, windowMock }
+}
+
+describe('main-world.js PostMessage Security', () => {
+  it('should use window.origin instead of wildcard "*" in postMessage', () => {
+    const { messagesSent } = setupSandbox(mainWorldPath)
+    assert.ok(messagesSent.length > 0, 'Should have sent at least one message')
+    messagesSent.forEach((msg) => {
+      assert.notStrictEqual(msg.origin, '*', 'main-world.js: postMessage should not use wildcard origin')
+      assert.strictEqual(msg.origin, 'https://jules.google.com', 'main-world.js: postMessage should use window.origin')
+    })
+  })
+
+  it('should only accept messages from the same origin', () => {
+    const { listeners, messagesSent, windowMock } = setupSandbox(mainWorldPath)
+    const countBefore = messagesSent.length
+
+    // Simulate message from different origin
+    listeners.forEach((handler) => {
+      handler({
+        origin: 'https://evil.com',
+        source: windowMock,
+        data: { type: 'JULES_REQUEST_CONFIG' }
+      })
+    })
+
+    const countAfter = messagesSent.length
+    assert.strictEqual(countAfter, countBefore, 'Should NOT have broadcasted config for message from evil.com')
+  })
+})
+
+describe('content.js PostMessage Security', () => {
+  it('should only accept messages from the same origin', () => {
+    const { listeners, sandbox, windowMock } = setupSandbox(contentJsPath)
+    let bgMessageSent = false
+    sandbox.chrome.runtime.sendMessage = () => {
+      bgMessageSent = true
+    }
+
+    listeners.forEach((handler) => {
+      handler({
+        origin: 'https://evil.com',
+        source: windowMock,
+        data: { type: 'JULES_START_CONFIG', config: {} }
+      })
+    })
+
+    assert.strictEqual(bgMessageSent, false, 'content.js should NOT relay messages from evil.com')
+  })
+
+  it('should use window.origin instead of wildcard "*" in postMessage', async () => {
+    const { chromeListeners, messagesSent } = setupSandbox(contentJsPath)
+
+    // Trigger extractConfig via GET_CONFIG message
+    const handler = chromeListeners[0]
+    if (handler) {
+      handler({ action: 'GET_CONFIG' }, {}, () => {})
+    }
+
+    // Give it a tick to run the async extractConfig
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    const requestConfigMsg = messagesSent.find((m) => m.data?.type === 'JULES_REQUEST_CONFIG')
+    assert.ok(requestConfigMsg, 'Should have sent JULES_REQUEST_CONFIG')
+    assert.notStrictEqual(requestConfigMsg.origin, '*', 'content.js: postMessage should not use wildcard origin')
+    assert.strictEqual(
+      requestConfigMsg.origin,
+      'https://jules.google.com',
+      'content.js: postMessage should use window.origin'
+    )
+  })
+})


### PR DESCRIPTION
### Description
🛡️ Sentinel: [Medium] Fix missing origin check in message listener

**Vulnerability:**
The `main-world.js` and `content.js` scripts were listening for `message` events without validating the `origin` of the sender. Additionally, `window.postMessage` calls were using the wildcard `*` as the target origin.

**Impact:**
A malicious site or an untrusted iframe could potentially intercept configuration tokens or trigger unintended broadcasts by sending spoofed messages to the extension scripts.

**Fix:**
1. Added `event.origin !== window.origin` checks to all `window.addEventListener('message', ...)` listeners.
2. Replaced the wildcard `*` with `window.origin` in all `window.postMessage` calls to ensure data is only delivered to the same origin.

**Verification:**
Added `tests/postmessage_security.test.js` which uses `node:vm` to:
- Verify that `postMessage` calls do not use `*`.
- Verify that messages from a different origin (e.g., `https://evil.com`) are correctly ignored by the listeners.
- All tests pass.

---
*PR created automatically by Jules for task [17648935612383469964](https://jules.google.com/task/17648935612383469964) started by @n24q02m*