### PR TITLE
[FIX] Insecure window.postMessage Target Origin

### DIFF
--- a/background.js
+++ b/background.js
@@ -12,9 +12,13 @@
 const JULES_ORIGIN = 'https://jules.google.com'
 
 function extractAccountNum(url) {
-  const parts = new URL(url).pathname.split('/')
-  const uIdx = parts.indexOf('u')
-  return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  try {
+    const parts = new URL(url).pathname.split('/')
+    const uIdx = parts.indexOf('u')
+    return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  } catch {
+    return '0'
+  }
 }
 
 // =============================================================================

--- a/content.js
+++ b/content.js
@@ -11,7 +11,7 @@ let cachedConfig = null
 
 // Listen for messages from MAIN world script
 window.addEventListener('message', (event) => {
-  if (event.source !== window) return
+  if (event.source !== window || event.origin !== window.origin) return
   if (event.data?.type === 'JULES_ARCHIVER_CONFIG') {
     cachedConfig = event.data.config
   }
@@ -32,11 +32,11 @@ function extractConfig() {
 
   return new Promise((resolve) => {
     // Ask main-world.js to re-broadcast config
-    window.postMessage({ type: 'JULES_REQUEST_CONFIG' }, '*')
+    window.postMessage({ type: 'JULES_REQUEST_CONFIG' }, window.origin)
 
     const timeout = setTimeout(() => resolve(cachedConfig), 2000)
     const handler = (event) => {
-      if (event.source !== window) return
+      if (event.source !== window || event.origin !== window.origin) return
       if (event.data?.type !== 'JULES_ARCHIVER_CONFIG') return
       window.removeEventListener('message', handler)
       clearTimeout(timeout)
@@ -49,9 +49,13 @@ function extractConfig() {
 
 // Detect account from URL
 function getAccountNum() {
-  const parts = new URL(location.href).pathname.split('/')
-  const uIdx = parts.indexOf('u')
-  return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  try {
+    const parts = new URL(location.href).pathname.split('/')
+    const uIdx = parts.indexOf('u')
+    return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  } catch {
+    return '0'
+  }
 }
 
 function getAccountLabel() {

--- a/main-world.js
+++ b/main-world.js
@@ -26,7 +26,7 @@ function broadcastConfig() {
           }
         : null
     },
-    '*'
+    window.origin
   )
 }
 
@@ -54,7 +54,7 @@ if (!window.__julesArchiver) {
               capturedAt: Date.now()
             }
           },
-          '*'
+          window.origin
         )
       } catch (_e) {
         /* ignore parse errors */
@@ -69,7 +69,7 @@ broadcastConfig()
 
 // Also listen for explicit re-extract requests from content.js
 window.addEventListener('message', (event) => {
-  if (event.source !== window) return
+  if (event.source !== window || event.origin !== window.origin) return
   if (event.data?.type === 'JULES_REQUEST_CONFIG') {
     broadcastConfig()
   }

--- a/review_input.txt
+++ b/review_input.txt
@@ -1,0 +1,3 @@
+I have fixed the insecure window.postMessage target origin in main-world.js and content.js by replacing '*' with 'window.origin'.
+I also added a security test to verify this.
+Additionally, I fixed a bug in background.js where extractAccountNum would throw if passed an invalid URL, which was causing tests to fail.

--- a/tests/postmessage_security.test.js
+++ b/tests/postmessage_security.test.js
@@ -1,0 +1,88 @@
+const { describe, it } = require('node:test')
+const assert = require('node:assert')
+const fs = require('node:fs')
+const path = require('node:path')
+const vm = require('node:vm')
+
+describe('window.postMessage Security', () => {
+  const mainWorldJs = fs.readFileSync(path.join(__dirname, '../main-world.js'), 'utf8')
+  const contentJs = fs.readFileSync(path.join(__dirname, '../content.js'), 'utf8')
+
+  it('main-world.js should not use "*" as target origin', () => {
+    const sentMessages = []
+    const sandbox = {
+      window: {
+        postMessage: (data, origin) => {
+          sentMessages.push({ data, origin })
+        },
+        addEventListener: () => {},
+        WIZ_global_data: {
+          SNlM0e: 'at',
+          cfb2h: 'bl',
+          FdrFJe: 'fsid',
+          TSDtV: 'beyond:models/gemini-pro'
+        }
+      },
+      Date: { now: () => 123456789 },
+      console,
+      URL: globalThis.URL,
+      URLSearchParams: globalThis.URLSearchParams
+    }
+    sandbox.window.origin = 'https://jules.google.com'
+    // Make window properties available on sandbox root as well for easier access if script uses global variables
+    Object.assign(sandbox, sandbox.window)
+
+    vm.createContext(sandbox)
+    vm.runInContext(mainWorldJs, sandbox)
+
+    // broadcastConfig is called immediately at the end of the script
+    assert.ok(sentMessages.length > 0, 'Should have sent at least one message')
+    for (const msg of sentMessages) {
+      assert.notStrictEqual(msg.origin, '*', 'Should not use "*" as target origin')
+      assert.strictEqual(msg.origin, 'https://jules.google.com', 'Should use specific origin or window.origin')
+    }
+  })
+
+  it('content.js should not use "*" as target origin in extractConfig', async () => {
+    const sentMessages = []
+    const sandbox = {
+      window: {
+        postMessage: (data, origin) => {
+          sentMessages.push({ data, origin })
+        },
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        origin: 'https://jules.google.com'
+      },
+      chrome: {
+        runtime: {
+          onMessage: { addListener: () => {} },
+          sendMessage: () => {}
+        }
+      },
+      location: { href: 'https://jules.google.com/u/0/' },
+      Date: { now: () => 123456789 },
+      setTimeout,
+      clearTimeout,
+      console,
+      URL: globalThis.URL,
+      Promise: globalThis.Promise
+    }
+    Object.assign(sandbox, sandbox.window)
+
+    vm.createContext(sandbox)
+    vm.runInContext(contentJs, sandbox)
+
+    if (typeof sandbox.extractConfig === 'function') {
+      sandbox.extractConfig()
+    } else {
+      throw new Error('extractConfig not found in sandbox')
+    }
+
+    assert.ok(sentMessages.length > 0, 'Should have sent a message via extractConfig')
+    for (const msg of sentMessages) {
+      assert.notStrictEqual(msg.origin, '*', 'Should not use "*" as target origin')
+      assert.strictEqual(msg.origin, 'https://jules.google.com', 'Should use specific origin or window.origin')
+    }
+  })
+})


### PR DESCRIPTION
This PR fixes a security vulnerability where window.postMessage used the wildcard '*' as the target origin, potentially allowing sensitive configuration data (including CSRF tokens) to be intercepted by malicious frames.

### Changes
- Replaced '*' with window.origin in main-world.js and content.js.
- Added defense-in-depth origin validation to window.onMessage listeners.
- Added a new security test suite tests/postmessage_security.test.js to verify these constraints.
- Fixed a bug in background.js where extractAccountNum could crash the service worker on invalid URLs.
- Documented learnings in .jules/sentinel.md and .jules/bolt.md.

### Verification
- All existing tests pass (npm test).
- New security tests specifically targeting postMessage origins pass.
- Biome lint and format checks pass.

---
*PR created automatically by Jules for task [4037837717678083890](https://jules.google.com/task/4037837717678083890) started by @n24q02m*