### PR TITLE
[FIX] Missing origin check in message listener in content script

### DIFF
--- a/background.js
+++ b/background.js
@@ -12,9 +12,13 @@
 const JULES_ORIGIN = 'https://jules.google.com'
 
 function extractAccountNum(url) {
-  const parts = new URL(url).pathname.split('/')
-  const uIdx = parts.indexOf('u')
-  return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  try {
+    const parts = new URL(url).pathname.split('/')
+    const uIdx = parts.indexOf('u')
+    return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  } catch {
+    return '0'
+  }
 }
 
 // =============================================================================

--- a/content.js
+++ b/content.js
@@ -6,11 +6,14 @@
  * Handles chrome.runtime messages from background/popup.
  */
 
+const JULES_ORIGIN = 'https://jules.google.com'
+
 // Store config extracted from MAIN world
 let cachedConfig = null
 
 // Listen for messages from MAIN world script
 window.addEventListener('message', (event) => {
+  if (event.origin !== JULES_ORIGIN) return
   if (event.source !== window) return
   if (event.data?.type === 'JULES_ARCHIVER_CONFIG') {
     cachedConfig = event.data.config
@@ -32,10 +35,11 @@ function extractConfig() {
 
   return new Promise((resolve) => {
     // Ask main-world.js to re-broadcast config
-    window.postMessage({ type: 'JULES_REQUEST_CONFIG' }, '*')
+    window.postMessage({ type: 'JULES_REQUEST_CONFIG' }, JULES_ORIGIN)
 
     const timeout = setTimeout(() => resolve(cachedConfig), 2000)
     const handler = (event) => {
+      if (event.origin !== JULES_ORIGIN) return
       if (event.source !== window) return
       if (event.data?.type !== 'JULES_ARCHIVER_CONFIG') return
       window.removeEventListener('message', handler)

--- a/main-world.js
+++ b/main-world.js
@@ -26,7 +26,7 @@ function broadcastConfig() {
           }
         : null
     },
-    '*'
+    window.origin
   )
 }
 
@@ -54,7 +54,7 @@ if (!window.__julesArchiver) {
               capturedAt: Date.now()
             }
           },
-          '*'
+          window.origin
         )
       } catch (_e) {
         /* ignore parse errors */
@@ -69,6 +69,7 @@ broadcastConfig()
 
 // Also listen for explicit re-extract requests from content.js
 window.addEventListener('message', (event) => {
+  if (event.origin !== window.origin) return
   if (event.source !== window) return
   if (event.data?.type === 'JULES_REQUEST_CONFIG') {
     broadcastConfig()

--- a/tests/origin_security.test.js
+++ b/tests/origin_security.test.js
@@ -70,9 +70,11 @@ describe('Security: content.js origin check', () => {
     }
 
     // Call the listeners
-    listeners.forEach(l => l(evilEvent))
+    for (const l of listeners) {
+      l(evilEvent)
+    }
 
-    const sentCount = runtimeMessages.filter(m => m.action === 'CACHE_START_CONFIG').length
+    const sentCount = runtimeMessages.filter((m) => m.action === 'CACHE_START_CONFIG').length
     assert.strictEqual(sentCount, 0, 'Should reject message from incorrect origin')
   })
 
@@ -86,84 +88,94 @@ describe('Security: content.js origin check', () => {
       data: { type: 'JULES_START_CONFIG', config: { ok: 'good' } }
     }
 
-    listeners.forEach(l => l(goodEvent))
+    for (const l of listeners) {
+      l(goodEvent)
+    }
 
-    const sentCount = runtimeMessages.filter(m => m.action === 'CACHE_START_CONFIG').length
+    const sentCount = runtimeMessages.filter((m) => m.action === 'CACHE_START_CONFIG').length
     assert.strictEqual(sentCount, 1, 'Should accept message from correct origin')
   })
 })
 
 function setupMainWorldSandbox() {
-    const listeners = []
-    let broadcasts = []
+  const listeners = []
+  const broadcasts = []
 
-    const windowMock = {
-        addEventListener: (type, handler) => {
-            if (type === 'message') listeners.push(handler)
-        },
-        postMessage: (msg, origin) => {
-            broadcasts.push({ msg, origin })
-        },
-        origin: 'https://jules.google.com',
-        location: { href: 'https://jules.google.com/u/0/' },
-        WIZ_global_data: { SNlM0e: 'token' }
-    }
+  const windowMock = {
+    addEventListener: (type, handler) => {
+      if (type === 'message') listeners.push(handler)
+    },
+    postMessage: (msg, origin) => {
+      broadcasts.push({ msg, origin })
+    },
+    origin: 'https://jules.google.com',
+    location: { href: 'https://jules.google.com/u/0/' },
+    WIZ_global_data: { SNlM0e: 'token' }
+  }
 
-    const sandbox = {
-        window: windowMock,
-        console,
-        setTimeout,
-        clearTimeout,
-        Date,
-        Promise,
-        URL,
-        URLSearchParams,
-        JSON,
-        String,
-        location: windowMock.location
-    }
+  const sandbox = {
+    window: windowMock,
+    console,
+    setTimeout,
+    clearTimeout,
+    Date,
+    Promise,
+    URL,
+    URLSearchParams,
+    JSON,
+    String,
+    location: windowMock.location
+  }
 
-    vm.createContext(sandbox)
-    vm.runInContext(mainWorldJsContent, sandbox)
+  vm.createContext(sandbox)
+  vm.runInContext(mainWorldJsContent, sandbox)
 
-    return { sandbox, listeners, broadcasts }
+  return { sandbox, listeners, broadcasts }
 }
 
 describe('Security: main-world.js origin check', () => {
-    it('should REJECT messages from non-window origin', () => {
-        const { sandbox, listeners, broadcasts } = setupMainWorldSandbox()
+  it('should REJECT messages from non-window origin', () => {
+    const { sandbox, listeners, broadcasts } = setupMainWorldSandbox()
 
-        // Initial broadcast on script load
-        const initialCount = broadcasts.length
+    // Initial broadcast on script load
+    const initialCount = broadcasts.length
 
-        // Simulate message from evil.com requesting config
-        const evilEvent = {
-            origin: 'https://evil.com',
-            source: sandbox.window,
-            data: { type: 'JULES_REQUEST_CONFIG' }
-        }
+    // Simulate message from evil.com requesting config
+    const evilEvent = {
+      origin: 'https://evil.com',
+      source: sandbox.window,
+      data: { type: 'JULES_REQUEST_CONFIG' }
+    }
 
-        // Call the listeners
-        listeners.forEach(l => l(evilEvent))
+    // Call the listeners
+    for (const l of listeners) {
+      l(evilEvent)
+    }
 
-        assert.strictEqual(broadcasts.length, initialCount, 'Should not broadcast again for incorrect origin')
-    })
+    assert.strictEqual(broadcasts.length, initialCount, 'Should not broadcast again for incorrect origin')
+  })
 
-    it('should ACCEPT messages from window origin', () => {
-        const { sandbox, listeners, broadcasts } = setupMainWorldSandbox()
+  it('should ACCEPT messages from window origin', () => {
+    const { sandbox, listeners, broadcasts } = setupMainWorldSandbox()
 
-        const initialCount = broadcasts.length
+    const initialCount = broadcasts.length
 
-        // Simulate message from window requesting config
-        const goodEvent = {
-            origin: sandbox.window.origin,
-            source: sandbox.window,
-            data: { type: 'JULES_REQUEST_CONFIG' }
-        }
+    // Simulate message from window requesting config
+    const goodEvent = {
+      origin: sandbox.window.origin,
+      source: sandbox.window,
+      data: { type: 'JULES_REQUEST_CONFIG' }
+    }
 
-        listeners.forEach(l => l(goodEvent))
+    for (const l of listeners) {
+      l(goodEvent)
+    }
 
-        assert.strictEqual(broadcasts.length, initialCount + 1, 'Should broadcast again for correct origin')
-        assert.strictEqual(broadcasts[broadcasts.length - 1].origin, sandbox.window.origin, 'Should use window origin as target')
-    })
+    assert.strictEqual(broadcasts.length, initialCount + 1, 'Should broadcast again for correct origin')
+    assert.strictEqual(
+      broadcasts[broadcasts.length - 1].origin,
+      sandbox.window.origin,
+      'Should use window origin as target'
+    )
+  })
 })

--- a/tests/origin_security.test.js
+++ b/tests/origin_security.test.js
@@ -1,0 +1,169 @@
+const { describe, it } = require('node:test')
+const assert = require('node:assert')
+const fs = require('node:fs')
+const path = require('node:path')
+const vm = require('node:vm')
+
+const contentJsPath = path.join(__dirname, '../content.js')
+const contentJsContent = fs.readFileSync(contentJsPath, 'utf8')
+
+const mainWorldJsPath = path.join(__dirname, '../main-world.js')
+const mainWorldJsContent = fs.readFileSync(mainWorldJsPath, 'utf8')
+
+function setupContentSandbox() {
+  const runtimeMessages = []
+  const listeners = []
+
+  const windowMock = {
+    addEventListener: (type, handler) => {
+      if (type === 'message') listeners.push(handler)
+    },
+    removeEventListener: (type, handler) => {
+      if (type === 'message') {
+        const idx = listeners.indexOf(handler)
+        if (idx !== -1) listeners.splice(idx, 1)
+      }
+    },
+    postMessage: () => {},
+    origin: 'https://jules.google.com',
+    location: { href: 'https://jules.google.com/u/0/' }
+  }
+
+  const chromeMock = {
+    runtime: {
+      sendMessage: (msg) => {
+        runtimeMessages.push(msg)
+      },
+      onMessage: {
+        addListener: () => {}
+      }
+    }
+  }
+
+  const sandbox = {
+    window: windowMock,
+    chrome: chromeMock,
+    console,
+    setTimeout,
+    clearTimeout,
+    Date,
+    Promise,
+    URL,
+    location: windowMock.location
+  }
+
+  vm.createContext(sandbox)
+  vm.runInContext(contentJsContent, sandbox)
+
+  return { sandbox, listeners, runtimeMessages }
+}
+
+describe('Security: content.js origin check', () => {
+  it('should REJECT messages from non-Jules origin', () => {
+    const { sandbox, listeners, runtimeMessages } = setupContentSandbox()
+
+    // Simulate message from evil.com
+    const evilEvent = {
+      origin: 'https://evil.com',
+      source: sandbox.window,
+      data: { type: 'JULES_START_CONFIG', config: { mal: 'icious' } }
+    }
+
+    // Call the listeners
+    listeners.forEach(l => l(evilEvent))
+
+    const sentCount = runtimeMessages.filter(m => m.action === 'CACHE_START_CONFIG').length
+    assert.strictEqual(sentCount, 0, 'Should reject message from incorrect origin')
+  })
+
+  it('should ACCEPT messages from Jules origin', () => {
+    const { sandbox, listeners, runtimeMessages } = setupContentSandbox()
+
+    // Simulate message from jules.google.com
+    const goodEvent = {
+      origin: 'https://jules.google.com',
+      source: sandbox.window,
+      data: { type: 'JULES_START_CONFIG', config: { ok: 'good' } }
+    }
+
+    listeners.forEach(l => l(goodEvent))
+
+    const sentCount = runtimeMessages.filter(m => m.action === 'CACHE_START_CONFIG').length
+    assert.strictEqual(sentCount, 1, 'Should accept message from correct origin')
+  })
+})
+
+function setupMainWorldSandbox() {
+    const listeners = []
+    let broadcasts = []
+
+    const windowMock = {
+        addEventListener: (type, handler) => {
+            if (type === 'message') listeners.push(handler)
+        },
+        postMessage: (msg, origin) => {
+            broadcasts.push({ msg, origin })
+        },
+        origin: 'https://jules.google.com',
+        location: { href: 'https://jules.google.com/u/0/' },
+        WIZ_global_data: { SNlM0e: 'token' }
+    }
+
+    const sandbox = {
+        window: windowMock,
+        console,
+        setTimeout,
+        clearTimeout,
+        Date,
+        Promise,
+        URL,
+        URLSearchParams,
+        JSON,
+        String,
+        location: windowMock.location
+    }
+
+    vm.createContext(sandbox)
+    vm.runInContext(mainWorldJsContent, sandbox)
+
+    return { sandbox, listeners, broadcasts }
+}
+
+describe('Security: main-world.js origin check', () => {
+    it('should REJECT messages from non-window origin', () => {
+        const { sandbox, listeners, broadcasts } = setupMainWorldSandbox()
+
+        // Initial broadcast on script load
+        const initialCount = broadcasts.length
+
+        // Simulate message from evil.com requesting config
+        const evilEvent = {
+            origin: 'https://evil.com',
+            source: sandbox.window,
+            data: { type: 'JULES_REQUEST_CONFIG' }
+        }
+
+        // Call the listeners
+        listeners.forEach(l => l(evilEvent))
+
+        assert.strictEqual(broadcasts.length, initialCount, 'Should not broadcast again for incorrect origin')
+    })
+
+    it('should ACCEPT messages from window origin', () => {
+        const { sandbox, listeners, broadcasts } = setupMainWorldSandbox()
+
+        const initialCount = broadcasts.length
+
+        // Simulate message from window requesting config
+        const goodEvent = {
+            origin: sandbox.window.origin,
+            source: sandbox.window,
+            data: { type: 'JULES_REQUEST_CONFIG' }
+        }
+
+        listeners.forEach(l => l(goodEvent))
+
+        assert.strictEqual(broadcasts.length, initialCount + 1, 'Should broadcast again for correct origin')
+        assert.strictEqual(broadcasts[broadcasts.length - 1].origin, sandbox.window.origin, 'Should use window origin as target')
+    })
+})


### PR DESCRIPTION
This PR implements origin validation for all message listeners that use `window.postMessage` to prevent cross-origin messaging attacks.

Key changes:
- Added `JULES_ORIGIN` constant to `content.js`.
- Implemented `event.origin === JULES_ORIGIN` checks in `content.js`.
- Implemented `event.origin === window.origin` checks in `main-world.js`.
- Replaced wildcard `'*'` target origins in `postMessage` with specific origins (`JULES_ORIGIN` or `window.origin`).
- Fixed a potential crash in `background.js` when parsing invalid URLs in `extractAccountNum`.
- Added a new test suite `tests/origin_security.test.js` to verify these security properties.

---
*PR created automatically by Jules for task [4476326155351387691](https://jules.google.com/task/4476326155351387691) started by @n24q02m*