### PR TITLE
🎨 Palette: Improve accessibility of radio groups and optional hints

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2025-04-03 - Progressive Disclosure for Multi-Mode UIs
 **Learning:** In a multi-mode UI (like Archive vs Suggestions), showing all settings at once creates cognitive overload, especially when settings like GitHub tokens are only relevant to one mode.
 **Action:** Use progressive disclosure in `popup.js` to hide mode-specific settings (like the `.settings` section and `force` checkbox) when they are not relevant to the currently selected mode, keeping the UI clean and focused.
+## 2025-04-08 - Accessible Forms and Radio Groups
+**Learning:** Inputs with inline text hints (like "(optional)") are not automatically read by screen readers unless explicitly linked, and standalone groups of radio buttons lack context without grouping roles.
+**Action:** Use `aria-describedby` to link inputs with their descriptive text hints. Wrap related radio buttons in a container with `role="radiogroup"` and a descriptive `aria-label` to provide context.

--- a/popup.html
+++ b/popup.html
@@ -17,8 +17,8 @@
         <input type="text" id="ghOwner" placeholder="your-github-username" />
       </label>
       <label for="ghToken">
-        GitHub Token <span class="hint">(optional, for private repos)</span>
-        <input type="password" id="ghToken" placeholder="ghp_..." />
+        GitHub Token <span id="ghTokenHint" class="hint">(optional, for private repos)</span>
+        <input type="password" id="ghToken" placeholder="ghp_..." aria-describedby="ghTokenHint" />
       </label>
     </section>
 
@@ -31,7 +31,7 @@
           <button type="button" data-value="suggestions" aria-pressed="false">Start Suggestions</button>
         </div>
       </div>
-      <div class="radio-group">
+      <div class="radio-group" role="radiogroup" aria-label="Execution Mode">
         <label><input type="radio" name="mode" value="dry" checked /> Dry Run</label>
         <label><input type="radio" name="mode" value="run" /> Run</label>
       </div>
@@ -39,7 +39,7 @@
         <input type="checkbox" id="force" />
         Force (skip PR check)
       </label>
-      <div class="radio-group">
+      <div class="radio-group" role="radiogroup" aria-label="Target Scope">
         <label><input type="radio" name="scope" value="current" /> Current tab</label>
         <label><input type="radio" name="scope" value="all" checked /> All Jules tabs</label>
       </div>


### PR DESCRIPTION
This PR implements micro-UX accessibility improvements to the popup UI. 

💡 What:
- Added `aria-describedby` to the `ghToken` password input to explicitly link it to its `(optional)` hint text.
- Added `role="radiogroup"` and descriptive `aria-label`s ("Execution Mode" and "Target Scope") to the custom `div` wrappers around the configuration radio buttons.

🎯 Why:
- Screen readers do not automatically read inline adjacent hint text without an explicit ARIA association. Linking the token input ensures visually impaired users know the token is optional.
- Because the radio button groups were wrapped in custom `div` elements for styling (instead of a `<fieldset>`), screen readers had no context that they belonged together. The explicit `radiogroup` role restores this context and announces their purpose.

♿ Accessibility:
These changes purely affect the semantic structure for assistive technologies and introduce zero visual or behavioral regressions to standard users.

---
*PR created automatically by Jules for task [8402430980056658206](https://jules.google.com/task/8402430980056658206) started by @n24q02m*