### PR TITLE
⚡ Bolt: Optimize taskHasOpenPR String Allocations

### DIFF
--- a/background.js
+++ b/background.js
@@ -12,9 +12,14 @@
 const JULES_ORIGIN = 'https://jules.google.com'
 
 function extractAccountNum(url) {
-  const parts = new URL(url).pathname.split('/')
-  const uIdx = parts.indexOf('u')
-  return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  if (!url) return '0'
+  try {
+    const parts = new URL(url).pathname.split('/')
+    const uIdx = parts.indexOf('u')
+    return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  } catch {
+    return '0'
+  }
 }
 
 // =============================================================================
@@ -564,7 +569,14 @@ async function getOpenPRs(owner, repo, token) {
       return []
     }
     const prs = await res.json()
-    const mapped = prs.map((pr) => ({ title: pr.title || '', branch: pr.head?.ref || '' }))
+    const mapped = prs.map((pr) => {
+      const title = pr.title || ''
+      return {
+        title,
+        titleLower: title.toLowerCase(),
+        branch: pr.head?.ref || ''
+      }
+    })
     prCache.set(key, mapped)
     return mapped
   } catch (e) {
@@ -578,7 +590,11 @@ function taskHasOpenPR(task, openPRs) {
   if (openPRs.length === 0) return false
   const taskTitle = (task.title || '').toLowerCase()
   if (!taskTitle || taskTitle === '(untitled)') return false
-  return openPRs.some((pr) => pr.title.toLowerCase().includes(taskTitle) || taskTitle.includes(pr.title.toLowerCase()))
+
+  // ⚡ Bolt Optimization: Uses pre-calculated pr.titleLower property
+  // generated during the initial PR fetch map. This avoids redundant
+  // string conversions inside this O(N*M) nested loop, saving allocations.
+  return openPRs.some((pr) => pr.titleLower.includes(taskTitle) || taskTitle.includes(pr.titleLower))
 }
 
 // =============================================================================

--- a/content.js
+++ b/content.js
@@ -49,9 +49,14 @@ function extractConfig() {
 
 // Detect account from URL
 function getAccountNum() {
-  const parts = new URL(location.href).pathname.split('/')
-  const uIdx = parts.indexOf('u')
-  return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  if (!location.href) return '0'
+  try {
+    const parts = new URL(location.href).pathname.split('/')
+    const uIdx = parts.indexOf('u')
+    return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  } catch {
+    return '0'
+  }
 }
 
 function getAccountLabel() {

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -322,8 +322,10 @@ describe('getOpenPRs', () => {
     const prs = await sandbox.test_getOpenPRs('owner', 'repo', null)
     assert.strictEqual(prs.length, 2)
     assert.strictEqual(prs[0].title, 'Fix bug')
+    assert.strictEqual(prs[0].titleLower, 'fix bug')
     assert.strictEqual(prs[0].branch, 'fix/bug-123')
     assert.strictEqual(prs[1].title, 'Add feature')
+    assert.strictEqual(prs[1].titleLower, 'add feature')
   })
 
   it('should return cached value on cache hit', async () => {
@@ -414,14 +416,14 @@ describe('taskHasOpenPR', () => {
   it('should match when PR title contains task title', () => {
     const { sandbox } = setupEnvironment()
     const task = { title: 'Fix ReDoS vulnerability' }
-    const prs = [{ title: '[SECURITY] Fix ReDoS vulnerability', branch: 'fix/redos-123' }]
+    const prs = [{ title: '[SECURITY] Fix ReDoS vulnerability', titleLower: '[security] fix redos vulnerability', branch: 'fix/redos-123' }]
     assert.strictEqual(sandbox.test_taskHasOpenPR(task, prs), true)
   })
 
   it('should match when task title contains PR title', () => {
     const { sandbox } = setupEnvironment()
     const task = { title: 'Unused return value from loadAllTasks' }
-    const prs = [{ title: 'Unused return value from loadAllTasks', branch: 'fix-unused-123' }]
+    const prs = [{ title: 'Unused return value from loadAllTasks', titleLower: 'unused return value from loadalltasks', branch: 'fix-unused-123' }]
     assert.strictEqual(sandbox.test_taskHasOpenPR(task, prs), true)
   })
 
@@ -429,8 +431,8 @@ describe('taskHasOpenPR', () => {
     const { sandbox } = setupEnvironment()
     const task = { title: 'Fix SQL injection' }
     const prs = [
-      { title: 'Add unit tests', branch: 'test/unit' },
-      { title: 'Update README', branch: 'docs/readme' }
+      { title: 'Add unit tests', titleLower: 'add unit tests', branch: 'test/unit' },
+      { title: 'Update README', titleLower: 'update readme', branch: 'docs/readme' }
     ]
     assert.strictEqual(sandbox.test_taskHasOpenPR(task, prs), false)
   })
@@ -442,7 +444,7 @@ describe('taskHasOpenPR', () => {
 
   it('should return false for untitled tasks', () => {
     const { sandbox } = setupEnvironment()
-    const prs = [{ title: 'Some PR', branch: 'branch' }]
+    const prs = [{ title: 'Some PR', titleLower: 'some pr', branch: 'branch' }]
     assert.strictEqual(sandbox.test_taskHasOpenPR({ title: '(untitled)' }, prs), false)
     assert.strictEqual(sandbox.test_taskHasOpenPR({ title: '' }, prs), false)
   })
@@ -450,7 +452,7 @@ describe('taskHasOpenPR', () => {
   it('should be case-insensitive', () => {
     const { sandbox } = setupEnvironment()
     const task = { title: 'fix REDOS Vulnerability' }
-    const prs = [{ title: '[Security] Fix ReDoS vulnerability', branch: 'fix-123' }]
+    const prs = [{ title: '[Security] Fix ReDoS vulnerability', titleLower: '[security] fix redos vulnerability', branch: 'fix-123' }]
     assert.strictEqual(sandbox.test_taskHasOpenPR(task, prs), true)
   })
 })

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -416,14 +416,26 @@ describe('taskHasOpenPR', () => {
   it('should match when PR title contains task title', () => {
     const { sandbox } = setupEnvironment()
     const task = { title: 'Fix ReDoS vulnerability' }
-    const prs = [{ title: '[SECURITY] Fix ReDoS vulnerability', titleLower: '[security] fix redos vulnerability', branch: 'fix/redos-123' }]
+    const prs = [
+      {
+        title: '[SECURITY] Fix ReDoS vulnerability',
+        titleLower: '[security] fix redos vulnerability',
+        branch: 'fix/redos-123'
+      }
+    ]
     assert.strictEqual(sandbox.test_taskHasOpenPR(task, prs), true)
   })
 
   it('should match when task title contains PR title', () => {
     const { sandbox } = setupEnvironment()
     const task = { title: 'Unused return value from loadAllTasks' }
-    const prs = [{ title: 'Unused return value from loadAllTasks', titleLower: 'unused return value from loadalltasks', branch: 'fix-unused-123' }]
+    const prs = [
+      {
+        title: 'Unused return value from loadAllTasks',
+        titleLower: 'unused return value from loadalltasks',
+        branch: 'fix-unused-123'
+      }
+    ]
     assert.strictEqual(sandbox.test_taskHasOpenPR(task, prs), true)
   })
 
@@ -452,7 +464,13 @@ describe('taskHasOpenPR', () => {
   it('should be case-insensitive', () => {
     const { sandbox } = setupEnvironment()
     const task = { title: 'fix REDOS Vulnerability' }
-    const prs = [{ title: '[Security] Fix ReDoS vulnerability', titleLower: '[security] fix redos vulnerability', branch: 'fix-123' }]
+    const prs = [
+      {
+        title: '[Security] Fix ReDoS vulnerability',
+        titleLower: '[security] fix redos vulnerability',
+        branch: 'fix-123'
+      }
+    ]
     assert.strictEqual(sandbox.test_taskHasOpenPR(task, prs), true)
   })
 })


### PR DESCRIPTION
💡 **What:** 
- Adds a `titleLower` property to PR objects during the initial mapping phase in `getOpenPRs`. 
- Refactors the `taskHasOpenPR` function to consume the cached `titleLower` instead of running `.toLowerCase()` dynamically on every PR iteration.
- Safely wraps native URL constructor operations inside `try/catch` blocks inside `extractAccountNum` and `getAccountNum` to prevent exceptions for empty/invalid URLs.

🎯 **Why:** 
Previously, `taskHasOpenPR` converted the title of every PR to lowercase on the fly during the inner loop of the comparison. This created a redundant `O(N * M)` string allocation overhead where N is the number of active tasks and M is the number of open PRs. Pre-computing this during the API ingestion bounds the allocation to `O(M)`.

📊 **Impact:** 
Significantly reduces string allocations and CPU time required to filter matching PRs, making large batch archives noticeably faster.

🔬 **Measurement:** 
Run `node --test` to verify correct behavior of both `getOpenPRs` parsing and the `taskHasOpenPR` lookup mechanics. Included dedicated test assertions.

---
*PR created automatically by Jules for task [15464785282741767348](https://jules.google.com/task/15464785282741767348) started by @n24q02m*