### PR TITLE
🛡️ Sentinel: [HIGH] Fix cross-origin messaging vulnerability

### DIFF
--- a/background.js
+++ b/background.js
@@ -12,9 +12,13 @@
 const JULES_ORIGIN = 'https://jules.google.com'
 
 function extractAccountNum(url) {
-  const parts = new URL(url).pathname.split('/')
-  const uIdx = parts.indexOf('u')
-  return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  try {
+    const parts = new URL(url).pathname.split('/')
+    const uIdx = parts.indexOf('u')
+    return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  } catch {
+    return '0'
+  }
 }
 
 // =============================================================================

--- a/content.js
+++ b/content.js
@@ -12,6 +12,7 @@ let cachedConfig = null
 // Listen for messages from MAIN world script
 window.addEventListener('message', (event) => {
   if (event.source !== window) return
+  if (event.origin !== window.origin) return
   if (event.data?.type === 'JULES_ARCHIVER_CONFIG') {
     cachedConfig = event.data.config
   }
@@ -32,11 +33,12 @@ function extractConfig() {
 
   return new Promise((resolve) => {
     // Ask main-world.js to re-broadcast config
-    window.postMessage({ type: 'JULES_REQUEST_CONFIG' }, '*')
+    window.postMessage({ type: 'JULES_REQUEST_CONFIG' }, window.origin)
 
     const timeout = setTimeout(() => resolve(cachedConfig), 2000)
     const handler = (event) => {
       if (event.source !== window) return
+      if (event.origin !== window.origin) return
       if (event.data?.type !== 'JULES_ARCHIVER_CONFIG') return
       window.removeEventListener('message', handler)
       clearTimeout(timeout)
@@ -49,9 +51,13 @@ function extractConfig() {
 
 // Detect account from URL
 function getAccountNum() {
-  const parts = new URL(location.href).pathname.split('/')
-  const uIdx = parts.indexOf('u')
-  return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  try {
+    const parts = new URL(location.href).pathname.split('/')
+    const uIdx = parts.indexOf('u')
+    return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  } catch {
+    return '0'
+  }
 }
 
 function getAccountLabel() {

--- a/main-world.js
+++ b/main-world.js
@@ -26,7 +26,7 @@ function broadcastConfig() {
           }
         : null
     },
-    '*'
+    window.origin
   )
 }
 
@@ -54,7 +54,7 @@ if (!window.__julesArchiver) {
               capturedAt: Date.now()
             }
           },
-          '*'
+          window.origin
         )
       } catch (_e) {
         /* ignore parse errors */
@@ -70,6 +70,7 @@ broadcastConfig()
 // Also listen for explicit re-extract requests from content.js
 window.addEventListener('message', (event) => {
   if (event.source !== window) return
+  if (event.origin !== window.origin) return
   if (event.data?.type === 'JULES_REQUEST_CONFIG') {
     broadcastConfig()
   }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `window.postMessage` in `main-world.js` and `content.js` used `*` as the target origin, exposing sensitive configuration tokens (like WIZ_global_data) to interception by potentially malicious cross-origin iframes on the same page. Additionally, message receivers lacked proper `event.origin` validation, allowing external pages to inject config messages.
🎯 Impact: A malicious iframe or extension injected into the page could silently steal sensitive authentication tokens required for batchexecute API calls, or maliciously spoof messages to alter configuration state.
🔧 Fix: 
1. Replaced `*` with `window.origin` in all `window.postMessage` calls to restrict the target origin exclusively to the same origin.
2. Added `if (event.origin !== window.origin) return` to all `message` event listeners in `main-world.js` and `content.js` to drop messages from untrusted origins.
3. Added a `try/catch` block to URL parsing in `extractAccountNum` and `getAccountNum` to prevent unhandled exceptions on malformed URLs.
✅ Verification: Ran `pnpm test` and ensured all tests, including those specifically for `content.js` configuration extraction logic, continue to pass cleanly. Tested that extension features still execute as expected while preventing unauthorized injection/extraction.

---
*PR created automatically by Jules for task [8015423459650823552](https://jules.google.com/task/8015423459650823552) started by @n24q02m*