### PR TITLE
🎨 Palette: Add ARIA roles to custom radio groups for accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-04-03 - Progressive Disclosure for Multi-Mode UIs
 **Learning:** In a multi-mode UI (like Archive vs Suggestions), showing all settings at once creates cognitive overload, especially when settings like GitHub tokens are only relevant to one mode.
 **Action:** Use progressive disclosure in `popup.js` to hide mode-specific settings (like the `.settings` section and `force` checkbox) when they are not relevant to the currently selected mode, keeping the UI clean and focused.
+
+## 2026-04-08 - Semantic Grouping for Custom Radio Groups
+**Learning:** Wrapping UI radio groups in custom div containers (instead of native `fieldset`) for styling removes semantic grouping for screen readers.
+**Action:** Always add `role="radiogroup"` and a descriptive `aria-label` to custom radio group container `div`s.

--- a/popup.html
+++ b/popup.html
@@ -31,7 +31,7 @@
           <button type="button" data-value="suggestions" aria-pressed="false">Start Suggestions</button>
         </div>
       </div>
-      <div class="radio-group">
+      <div class="radio-group" role="radiogroup" aria-label="Execution Mode">
         <label><input type="radio" name="mode" value="dry" checked /> Dry Run</label>
         <label><input type="radio" name="mode" value="run" /> Run</label>
       </div>
@@ -39,7 +39,7 @@
         <input type="checkbox" id="force" />
         Force (skip PR check)
       </label>
-      <div class="radio-group">
+      <div class="radio-group" role="radiogroup" aria-label="Target Scope">
         <label><input type="radio" name="scope" value="current" /> Current tab</label>
         <label><input type="radio" name="scope" value="all" checked /> All Jules tabs</label>
       </div>


### PR DESCRIPTION
### 💡 What
Added `role="radiogroup"` and descriptive `aria-label`s to custom radio group `div` containers in `popup.html`.
Updated the Palette journal with this learning.

### 🎯 Why
Custom UI elements built with `div`s lack the native semantic grouping provided by elements like `<fieldset>`. By adding the `radiogroup` role and labels, screen reader users get the necessary context for what the isolated radio inputs relate to (e.g. "Execution Mode" or "Target Scope").

### 📸 Before/After
No visual changes were made; the updates are purely semantic HTML additions for accessibility.

### ♿ Accessibility
This directly improves screen reader compatibility by logically grouping and labeling related inputs.

---
*PR created automatically by Jules for task [15109305297203192223](https://jules.google.com/task/15109305297203192223) started by @n24q02m*