### PR TITLE
🛡️ Sentinel: [HIGH] Fix cross-origin messaging vulnerabilities

### DIFF
--- a/content.js
+++ b/content.js
@@ -11,7 +11,7 @@ let cachedConfig = null
 
 // Listen for messages from MAIN world script
 window.addEventListener('message', (event) => {
-  if (event.source !== window) return
+  if (event.source !== window || event.origin !== window.origin) return
   if (event.data?.type === 'JULES_ARCHIVER_CONFIG') {
     cachedConfig = event.data.config
   }
@@ -32,11 +32,11 @@ function extractConfig() {
 
   return new Promise((resolve) => {
     // Ask main-world.js to re-broadcast config
-    window.postMessage({ type: 'JULES_REQUEST_CONFIG' }, '*')
+    window.postMessage({ type: 'JULES_REQUEST_CONFIG' }, window.origin)
 
     const timeout = setTimeout(() => resolve(cachedConfig), 2000)
     const handler = (event) => {
-      if (event.source !== window) return
+      if (event.source !== window || event.origin !== window.origin) return
       if (event.data?.type !== 'JULES_ARCHIVER_CONFIG') return
       window.removeEventListener('message', handler)
       clearTimeout(timeout)

--- a/main-world.js
+++ b/main-world.js
@@ -26,7 +26,7 @@ function broadcastConfig() {
           }
         : null
     },
-    '*'
+    window.origin
   )
 }
 
@@ -54,7 +54,7 @@ if (!window.__julesArchiver) {
               capturedAt: Date.now()
             }
           },
-          '*'
+          window.origin
         )
       } catch (_e) {
         /* ignore parse errors */
@@ -69,7 +69,7 @@ broadcastConfig()
 
 // Also listen for explicit re-extract requests from content.js
 window.addEventListener('message', (event) => {
-  if (event.source !== window) return
+  if (event.source !== window || event.origin !== window.origin) return
   if (event.data?.type === 'JULES_REQUEST_CONFIG') {
     broadcastConfig()
   }

--- a/tests/origin_security.test.js
+++ b/tests/origin_security.test.js
@@ -1,0 +1,145 @@
+const { describe, it } = require('node:test')
+const assert = require('node:assert')
+const fs = require('node:fs')
+const path = require('node:path')
+const vm = require('node:vm')
+
+const contentJsPath = path.join(__dirname, '../content.js')
+const mainWorldJsPath = path.join(__dirname, '../main-world.js')
+const contentJsCode = fs.readFileSync(contentJsPath, 'utf8')
+const mainWorldJsCode = fs.readFileSync(mainWorldJsPath, 'utf8')
+
+function setupSandbox(origin = 'https://jules.google.com') {
+  const listeners = []
+  const messagesSent = []
+
+  const windowMock = {
+    origin,
+    postMessage: (data, targetOrigin) => {
+      messagesSent.push({ data, targetOrigin })
+    },
+    addEventListener: (event, handler) => {
+      if (event === 'message') {
+        listeners.push(handler)
+      }
+    },
+    removeEventListener: (event, handler) => {
+      if (event === 'message') {
+        const index = listeners.indexOf(handler)
+        if (index > -1) {
+          listeners.splice(index, 1)
+        }
+      }
+    },
+    WIZ_global_data: {
+      SNlM0e: 'token',
+      cfb2h: 'build',
+      FdrFJe: '123'
+    }
+  }
+
+  // Circular reference for event.source === window checks
+  windowMock.window = windowMock
+
+  const chromeMock = {
+    runtime: {
+      onMessage: {
+        addListener: () => {}
+      },
+      sendMessage: () => {}
+    }
+  }
+
+  const sandbox = {
+    window: windowMock,
+    chrome: chromeMock,
+    setTimeout: (cb) => { cb(); return 1; },
+    clearTimeout: () => {},
+    Date: { now: () => 1000 },
+    Promise,
+    console,
+    location: { href: 'https://jules.google.com/u/0/' },
+    URL,
+    cachedConfig: null
+  }
+
+  vm.createContext(sandbox)
+  return { sandbox, listeners, messagesSent, windowMock }
+}
+
+describe('Origin Security Tests', () => {
+  it('content.js should reject messages from untrusted origins', () => {
+    const { sandbox, listeners, windowMock } = setupSandbox()
+
+    // Add export for testing
+    const testableContentJs = contentJsCode + '\n; globalThis.test_getCachedConfig = () => cachedConfig; globalThis.test_setCachedConfig = (v) => { cachedConfig = v; };'
+
+    vm.runInContext(testableContentJs, sandbox)
+
+    // Check main listener
+    assert.ok(listeners.length >= 1, 'Message listener should be registered')
+    const listener = listeners[0]
+
+    // Simulate valid message
+    listener({
+      source: windowMock,
+      origin: windowMock.origin,
+      data: { type: 'JULES_ARCHIVER_CONFIG', config: { at: 'valid' } }
+    })
+    assert.strictEqual(sandbox.test_getCachedConfig().at, 'valid', 'Valid origin message should be processed')
+
+    // Clear cache
+    sandbox.test_setCachedConfig(null)
+
+    // Simulate invalid message
+    listener({
+      source: windowMock,
+      origin: 'https://evil.com',
+      data: { type: 'JULES_ARCHIVER_CONFIG', config: { at: 'evil' } }
+    })
+    assert.strictEqual(sandbox.test_getCachedConfig(), null, 'Invalid origin message should be rejected')
+  })
+
+  it('main-world.js should reject messages from untrusted origins', () => {
+    const { sandbox, listeners, messagesSent, windowMock } = setupSandbox()
+    vm.runInContext(mainWorldJsCode, sandbox)
+
+    // Get listener
+    const listener = listeners[0]
+
+    // Clear initial broadcast message
+    messagesSent.length = 0
+
+    // Simulate invalid message
+    listener({
+      source: windowMock,
+      origin: 'https://evil.com',
+      data: { type: 'JULES_REQUEST_CONFIG' }
+    })
+
+    assert.strictEqual(messagesSent.length, 0, 'Should not broadcast config for invalid origin')
+
+    // Simulate valid message
+    listener({
+      source: windowMock,
+      origin: windowMock.origin,
+      data: { type: 'JULES_REQUEST_CONFIG' }
+    })
+
+    assert.strictEqual(messagesSent.length, 1, 'Should broadcast config for valid origin')
+    assert.strictEqual(messagesSent[0].targetOrigin, windowMock.origin, 'Broadcast target origin should be window.origin')
+  })
+
+  it('content.js should use window.origin for target origin when requesting config', async () => {
+    const { sandbox, messagesSent, windowMock } = setupSandbox()
+    const testableContentJs = contentJsCode + '\n; globalThis.test_extractConfig = extractConfig; globalThis.test_setCachedConfig = (v) => { cachedConfig = v; };'
+    vm.runInContext(testableContentJs, sandbox)
+
+    sandbox.test_setCachedConfig(null)
+    sandbox.test_extractConfig() // This will call window.postMessage
+
+    const message = messagesSent.find(m => m.data.type === 'JULES_REQUEST_CONFIG')
+    assert.ok(message, 'JULES_REQUEST_CONFIG message should be sent')
+    assert.strictEqual(message.targetOrigin, windowMock.origin, 'Target origin should be window.origin')
+  })
+})

--- a/tests/origin_security.test.js
+++ b/tests/origin_security.test.js
@@ -53,7 +53,10 @@ function setupSandbox(origin = 'https://jules.google.com') {
   const sandbox = {
     window: windowMock,
     chrome: chromeMock,
-    setTimeout: (cb) => { cb(); return 1; },
+    setTimeout: (cb) => {
+      cb()
+      return 1
+    },
     clearTimeout: () => {},
     Date: { now: () => 1000 },
     Promise,
@@ -72,7 +75,7 @@ describe('Origin Security Tests', () => {
     const { sandbox, listeners, windowMock } = setupSandbox()
 
     // Add export for testing
-    const testableContentJs = contentJsCode + '\n; globalThis.test_getCachedConfig = () => cachedConfig; globalThis.test_setCachedConfig = (v) => { cachedConfig = v; };'
+    const testableContentJs = `${contentJsCode}\n; globalThis.test_getCachedConfig = () => cachedConfig; globalThis.test_setCachedConfig = (v) => { cachedConfig = v; };`
 
     vm.runInContext(testableContentJs, sandbox)
 
@@ -127,18 +130,22 @@ describe('Origin Security Tests', () => {
     })
 
     assert.strictEqual(messagesSent.length, 1, 'Should broadcast config for valid origin')
-    assert.strictEqual(messagesSent[0].targetOrigin, windowMock.origin, 'Broadcast target origin should be window.origin')
+    assert.strictEqual(
+      messagesSent[0].targetOrigin,
+      windowMock.origin,
+      'Broadcast target origin should be window.origin'
+    )
   })
 
   it('content.js should use window.origin for target origin when requesting config', async () => {
     const { sandbox, messagesSent, windowMock } = setupSandbox()
-    const testableContentJs = contentJsCode + '\n; globalThis.test_extractConfig = extractConfig; globalThis.test_setCachedConfig = (v) => { cachedConfig = v; };'
+    const testableContentJs = `${contentJsCode}\n; globalThis.test_extractConfig = extractConfig; globalThis.test_setCachedConfig = (v) => { cachedConfig = v; };`
     vm.runInContext(testableContentJs, sandbox)
 
     sandbox.test_setCachedConfig(null)
     sandbox.test_extractConfig() // This will call window.postMessage
 
-    const message = messagesSent.find(m => m.data.type === 'JULES_REQUEST_CONFIG')
+    const message = messagesSent.find((m) => m.data.type === 'JULES_REQUEST_CONFIG')
     assert.ok(message, 'JULES_REQUEST_CONFIG message should be sent')
     assert.strictEqual(message.targetOrigin, windowMock.origin, 'Target origin should be window.origin')
   })


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** `window.postMessage` calls between the injected main-world script and the isolated content script were using a wildcard (`'*'`) target origin and were not verifying the incoming `event.origin` in message listeners.
🎯 **Impact:** Malicious scripts or iframes on the same page could potentially intercept sensitive configuration data (like `WIZ_global_data` tokens) broadcasted via `postMessage`, or send spoofed messages to trigger unintended extension behavior.
🔧 **Fix:** 
- Replaced `'*'` with `window.origin` in all `window.postMessage` calls to restrict message delivery.
- Added explicit `event.origin !== window.origin` checks to all `window.addEventListener('message', ...)` handlers.
- Created an isolated `node:vm` test suite (`tests/origin_security.test.js`) to prove the vulnerabilities are mitigated.
✅ **Verification:** Ran the full test suite (`npm run test`), including the new `origin_security.test.js` tests, and confirmed all passing.

---
*PR created automatically by Jules for task [627914040566351914](https://jules.google.com/task/627914040566351914) started by @n24q02m*