### PR TITLE
🎨 Palette: Add ARIA roles to radio groups

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-04-03 - Progressive Disclosure for Multi-Mode UIs
 **Learning:** In a multi-mode UI (like Archive vs Suggestions), showing all settings at once creates cognitive overload, especially when settings like GitHub tokens are only relevant to one mode.
 **Action:** Use progressive disclosure in `popup.js` to hide mode-specific settings (like the `.settings` section and `force` checkbox) when they are not relevant to the currently selected mode, keeping the UI clean and focused.
+
+## 2026-04-09 - Accessible Custom Radio Groups
+**Learning:** Using custom `div` containers to style and structure radio inputs (like `.radio-group` in `popup.html`) breaks screen reader interpretation of the inputs as a cohesive group, making navigation difficult.
+**Action:** Always add `role="radiogroup"` and an explicit `aria-label` to custom wrapper elements that act as fieldsets to restore structural semantics for assistive technologies.

--- a/popup.html
+++ b/popup.html
@@ -31,7 +31,7 @@
           <button type="button" data-value="suggestions" aria-pressed="false">Start Suggestions</button>
         </div>
       </div>
-      <div class="radio-group">
+      <div class="radio-group" role="radiogroup" aria-label="Execution Mode">
         <label><input type="radio" name="mode" value="dry" checked /> Dry Run</label>
         <label><input type="radio" name="mode" value="run" /> Run</label>
       </div>
@@ -39,7 +39,7 @@
         <input type="checkbox" id="force" />
         Force (skip PR check)
       </label>
-      <div class="radio-group">
+      <div class="radio-group" role="radiogroup" aria-label="Tab Scope">
         <label><input type="radio" name="scope" value="current" /> Current tab</label>
         <label><input type="radio" name="scope" value="all" checked /> All Jules tabs</label>
       </div>


### PR DESCRIPTION
💡 What: Added `role="radiogroup"` and `aria-label` attributes to custom `div` containers wrapping radio inputs in `popup.html`.
🎯 Why: Custom `div` elements styling radio groups were breaking screen reader interpretation of cohesive input sections.
📸 Before/After: Visuals remain identical, but semantics are enhanced. (Playwright verification available)
♿ Accessibility: Ensures assistive technologies can navigate and interpret the custom input groupings correctly. Added a UX journal entry documenting this pattern.

---
*PR created automatically by Jules for task [13806517458885766494](https://jules.google.com/task/13806517458885766494) started by @n24q02m*