### PR TITLE
⚡ Bolt: O(N*M) string lowercasing optimization for PR matching

### DIFF
--- a/background.js
+++ b/background.js
@@ -12,9 +12,13 @@
 const JULES_ORIGIN = 'https://jules.google.com'
 
 function extractAccountNum(url) {
-  const parts = new URL(url).pathname.split('/')
-  const uIdx = parts.indexOf('u')
-  return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  try {
+    const parts = new URL(url).pathname.split('/')
+    const uIdx = parts.indexOf('u')
+    return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  } catch (_e) {
+    return '0'
+  }
 }
 
 // =============================================================================
@@ -564,7 +568,10 @@ async function getOpenPRs(owner, repo, token) {
       return []
     }
     const prs = await res.json()
-    const mapped = prs.map((pr) => ({ title: pr.title || '', branch: pr.head?.ref || '' }))
+    const mapped = prs.map((pr) => {
+      const title = pr.title || ''
+      return { title, titleLower: title.toLowerCase(), branch: pr.head?.ref || '' }
+    })
     prCache.set(key, mapped)
     return mapped
   } catch (e) {
@@ -578,7 +585,12 @@ function taskHasOpenPR(task, openPRs) {
   if (openPRs.length === 0) return false
   const taskTitle = (task.title || '').toLowerCase()
   if (!taskTitle || taskTitle === '(untitled)') return false
-  return openPRs.some((pr) => pr.title.toLowerCase().includes(taskTitle) || taskTitle.includes(pr.title.toLowerCase()))
+  // ⚡ Bolt Optimization: Use pre-calculated titleLower to avoid O(N * M)
+  // redundant toLowerCase() string allocations in nested loops.
+  return openPRs.some((pr) => {
+    const prTitleLower = pr.titleLower !== undefined ? pr.titleLower : (pr.title || '').toLowerCase()
+    return prTitleLower.includes(taskTitle) || taskTitle.includes(prTitleLower)
+  })
 }
 
 // =============================================================================

--- a/content.js
+++ b/content.js
@@ -49,9 +49,13 @@ function extractConfig() {
 
 // Detect account from URL
 function getAccountNum() {
-  const parts = new URL(location.href).pathname.split('/')
-  const uIdx = parts.indexOf('u')
-  return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  try {
+    const parts = new URL(location.href).pathname.split('/')
+    const uIdx = parts.indexOf('u')
+    return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  } catch (_e) {
+    return '0'
+  }
 }
 
 function getAccountLabel() {


### PR DESCRIPTION
💡 What: Added caching of lowercase PR titles during the initial API mapping in `getOpenPRs`, and updated `taskHasOpenPR` to use this cached string instead of calling `.toLowerCase()` on the fly. We also added try/catch blocks for `new URL()` in `extractAccountNum` and `getAccountNum` to prevent errors on invalid URLs.\n🎯 Why: The nested loop comparison caused dynamic `.toLowerCase()` calls N x M times. Pre-computing it during data fetch avoids massive string allocation and conversion overhead.\n📊 Impact: Eliminates O(N*M) string allocation overhead in the `taskHasOpenPR` matching check, boosting parsing speed significantly when there are many tasks and PRs.\n🔬 Measurement: Time the `taskHasOpenPR` calls for identical sets of tasks and PRs before and after; the unit test coverage checks this logic and continues to pass.

---
*PR created automatically by Jules for task [13506668358957118668](https://jules.google.com/task/13506668358957118668) started by @n24q02m*