### PR TITLE
[CLEANUP] extractAccountNum Missing Error Handling

### DIFF
--- a/background.js
+++ b/background.js
@@ -12,9 +12,13 @@
 const JULES_ORIGIN = 'https://jules.google.com'
 
 function extractAccountNum(url) {
-  const parts = new URL(url).pathname.split('/')
-  const uIdx = parts.indexOf('u')
-  return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  try {
+    const parts = new URL(url).pathname.split('/')
+    const uIdx = parts.indexOf('u')
+    return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  } catch (_e) {
+    return '0'
+  }
 }
 
 // =============================================================================

--- a/content.js
+++ b/content.js
@@ -49,9 +49,13 @@ function extractConfig() {
 
 // Detect account from URL
 function getAccountNum() {
-  const parts = new URL(location.href).pathname.split('/')
-  const uIdx = parts.indexOf('u')
-  return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  try {
+    const parts = new URL(location.href).pathname.split('/')
+    const uIdx = parts.indexOf('u')
+    return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  } catch (_e) {
+    return '0'
+  }
 }
 
 function getAccountLabel() {


### PR DESCRIPTION
The `new URL()` constructor throws a `TypeError` if the provided string is not a valid URL (e.g., an empty string). This was causing a test failure in `background.test.js` when an empty string was passed to `extractAccountNum`.

This change wraps the URL parsing logic in `try-catch` blocks in both `background.js` and `content.js`, ensuring that the functions return a safe default value of '0' instead of throwing an exception. This improves the overall robustness of the account extraction logic.

Verified with `npm test`.

---
*PR created automatically by Jules for task [16936310346299762116](https://jules.google.com/task/16936310346299762116) started by @n24q02m*