### PR TITLE
🛡️ Sentinel: High Fix insecure postMessage target origin

### DIFF
--- a/background.js
+++ b/background.js
@@ -10,11 +10,14 @@
 // =============================================================================
 
 const JULES_ORIGIN = 'https://jules.google.com'
-
 function extractAccountNum(url) {
-  const parts = new URL(url).pathname.split('/')
-  const uIdx = parts.indexOf('u')
-  return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  try {
+    const parts = new URL(url).pathname.split('/')
+    const uIdx = parts.indexOf('u')
+    return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  } catch {
+    return '0'
+  }
 }
 
 // =============================================================================

--- a/content.js
+++ b/content.js
@@ -5,6 +5,7 @@
  * Relays StartSuggestion config to background service worker.
  * Handles chrome.runtime messages from background/popup.
  */
+const JULES_ORIGIN = 'https://jules.google.com'
 
 // Store config extracted from MAIN world
 let cachedConfig = null
@@ -32,7 +33,7 @@ function extractConfig() {
 
   return new Promise((resolve) => {
     // Ask main-world.js to re-broadcast config
-    window.postMessage({ type: 'JULES_REQUEST_CONFIG' }, '*')
+    window.postMessage({ type: 'JULES_REQUEST_CONFIG' }, JULES_ORIGIN)
 
     const timeout = setTimeout(() => resolve(cachedConfig), 2000)
     const handler = (event) => {

--- a/main-world.js
+++ b/main-world.js
@@ -7,6 +7,7 @@
  *
  * Communicates with content.js (isolated world) via window.postMessage.
  */
+const JULES_ORIGIN = 'https://jules.google.com'
 
 // Extract config and post to isolated world
 function broadcastConfig() {
@@ -26,7 +27,7 @@ function broadcastConfig() {
           }
         : null
     },
-    '*'
+    JULES_ORIGIN
   )
 }
 
@@ -54,7 +55,7 @@ if (!window.__julesArchiver) {
               capturedAt: Date.now()
             }
           },
-          '*'
+          JULES_ORIGIN
         )
       } catch (_e) {
         /* ignore parse errors */

--- a/tests/origin_security.test.js
+++ b/tests/origin_security.test.js
@@ -1,0 +1,80 @@
+const { describe, it } = require('node:test')
+const assert = require('node:assert')
+const fs = require('node:fs')
+const path = require('node:path')
+const vm = require('node:vm')
+
+const contentJsPath = path.join(__dirname, '..', 'content.js')
+const contentJsContent = fs.readFileSync(contentJsPath, 'utf8')
+
+const mainWorldJsPath = path.join(__dirname, '..', 'main-world.js')
+const mainWorldJsContent = fs.readFileSync(mainWorldJsPath, 'utf8')
+
+describe('Origin Security: postMessage target origin', () => {
+  it('content.js should use JULES_ORIGIN as target origin in postMessage', () => {
+    const sentMessages = []
+    const sandbox = {
+      window: {
+        postMessage: (msg, origin) => {
+          sentMessages.push({ msg, origin })
+        },
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        location: { href: 'https://jules.google.com/u/0/' }
+      },
+      setTimeout: () => {},
+      clearTimeout: () => {},
+      Promise,
+      Date,
+      URL,
+      chrome: {
+        runtime: {
+          onMessage: { addListener: () => {} }
+        }
+      }
+    }
+    sandbox.self = sandbox
+    vm.createContext(sandbox)
+    vm.runInContext(contentJsContent, sandbox)
+
+    // Trigger extractConfig (it's not exported, so we have to find it or trigger the message that calls it)
+    // Actually extractConfig is a top-level function in content.js
+    if (typeof sandbox.extractConfig === 'function') {
+      sandbox.extractConfig()
+    } else {
+      // Fallback if not directly accessible (though it should be in vm if not wrapped in IIFE)
+      // content.js is not wrapped in IIFE
+      const script = `${contentJsContent}; extractConfig();`
+      vm.runInContext(script, sandbox)
+    }
+
+    assert.ok(sentMessages.length > 0, 'Should have sent a message')
+    sentMessages.forEach((m) => {
+      assert.strictEqual(m.origin, 'https://jules.google.com', 'content.js postMessage origin should be restricted')
+    })
+  })
+
+  it('main-world.js should use JULES_ORIGIN as target origin in postMessage', () => {
+    const sentMessages = []
+    const sandbox = {
+      window: {
+        postMessage: (msg, origin) => {
+          sentMessages.push({ msg, origin })
+        },
+        WIZ_global_data: { SNlM0e: 'at', cfb2h: 'bl', FdrFJe: 'fsid' },
+        addEventListener: () => {},
+        fetch: () => Promise.resolve({ ok: true })
+      },
+      Date,
+      console
+    }
+    sandbox.self = sandbox
+    vm.createContext(sandbox)
+    vm.runInContext(mainWorldJsContent, sandbox)
+
+    assert.ok(sentMessages.length > 0, 'Should have sent a message')
+    sentMessages.forEach((m) => {
+      assert.strictEqual(m.origin, 'https://jules.google.com', 'main-world.js postMessage origin should be restricted')
+    })
+  })
+})


### PR DESCRIPTION
🛡️ Sentinel: High Fix insecure postMessage target origin

### What
Restricted \`window.postMessage\` target origin from \`*\` to \`https://jules.google.com\` in \`content.js\` and \`main-world.js\`. Also fixed a bug in \`extractAccountNum\` in \`background.js\` where invalid URLs caused a crash.

### Why
Using \`*\` as a target origin allows any script on the page (including malicious ones in iframes) to intercept messages. These messages contain sensitive configuration tokens used for API calls.

### Impact
Improved security by preventing token leakage to potential third-party scripts. Fixed a potential crash in background processing when handling tabs with invalid URLs.

### Verification
- Created \`tests/origin_security.test.js\` to specifically check the \`postMessage\` target origin in both \`content.js\` and \`main-world.js\`.
- Fixed the failing \`extractAccountNum\` test in \`tests/background.test.js\`.
- Ran the full test suite (\`npm run test\`) and all 69 tests passed.
- Ran Biome lint and format checks (\`npx @biomejs/biome check . \`).
- Recorded the security learning in \`.jules/sentinel.md\`.

---
*PR created automatically by Jules for task [218547231852145596](https://jules.google.com/task/218547231852145596) started by @n24q02m*