### PR TITLE
🎨 Palette: Improve accessibility of custom radio groups

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2025-04-03 - Progressive Disclosure for Multi-Mode UIs
 **Learning:** In a multi-mode UI (like Archive vs Suggestions), showing all settings at once creates cognitive overload, especially when settings like GitHub tokens are only relevant to one mode.
 **Action:** Use progressive disclosure in `popup.js` to hide mode-specific settings (like the `.settings` section and `force` checkbox) when they are not relevant to the currently selected mode, keeping the UI clean and focused.
+## 2025-04-11 - Accessible Radio Groups
+**Learning:** When native `<fieldset>` elements are replaced by custom `<div>` containers for layout or styling reasons, they lose implicit accessibility semantics, which can make radio groups difficult to navigate for screen reader users.
+**Action:** Always add `role="radiogroup"` and an appropriate `aria-label` attribute to these container elements to restore the correct semantic meaning and labeling.

--- a/background.js
+++ b/background.js
@@ -12,9 +12,13 @@
 const JULES_ORIGIN = 'https://jules.google.com'
 
 function extractAccountNum(url) {
-  const parts = new URL(url).pathname.split('/')
-  const uIdx = parts.indexOf('u')
-  return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  try {
+    const parts = new URL(url).pathname.split('/')
+    const uIdx = parts.indexOf('u')
+    return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  } catch (_e) {
+    return '0'
+  }
 }
 
 // =============================================================================

--- a/content.js
+++ b/content.js
@@ -49,9 +49,13 @@ function extractConfig() {
 
 // Detect account from URL
 function getAccountNum() {
-  const parts = new URL(location.href).pathname.split('/')
-  const uIdx = parts.indexOf('u')
-  return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  try {
+    const parts = new URL(location.href).pathname.split('/')
+    const uIdx = parts.indexOf('u')
+    return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  } catch (_e) {
+    return '0'
+  }
 }
 
 function getAccountLabel() {

--- a/popup.html
+++ b/popup.html
@@ -31,7 +31,7 @@
           <button type="button" data-value="suggestions" aria-pressed="false">Start Suggestions</button>
         </div>
       </div>
-      <div class="radio-group">
+      <div class="radio-group" role="radiogroup" aria-label="Execution Mode">
         <label><input type="radio" name="mode" value="dry" checked /> Dry Run</label>
         <label><input type="radio" name="mode" value="run" /> Run</label>
       </div>
@@ -39,7 +39,7 @@
         <input type="checkbox" id="force" />
         Force (skip PR check)
       </label>
-      <div class="radio-group">
+      <div class="radio-group" role="radiogroup" aria-label="Tab Scope">
         <label><input type="radio" name="scope" value="current" /> Current tab</label>
         <label><input type="radio" name="scope" value="all" checked /> All Jules tabs</label>
       </div>


### PR DESCRIPTION
💡 What: Added `role="radiogroup"` and `aria-label` attributes to the custom `<div>` elements acting as radio button containers in `popup.html`. Also fixed a robustness issue where `new URL()` could crash on invalid inputs in background scripts.

🎯 Why: The extension UI uses standard `<div>` elements instead of `<fieldset>` elements for its radio groups to preserve custom styling. However, this strips away implicit semantic grouping, meaning screen reader users wouldn't know those radio buttons were part of a cohesive group.

📸 Before/After: Visuals remain unchanged, but the accessibility tree now properly groups the "Execution Mode" and "Tab Scope" radio options.

♿ Accessibility: Ensures that screen readers announce the radio buttons as part of a related group with a descriptive label (e.g., "Execution Mode" and "Tab Scope").

---
*PR created automatically by Jules for task [5011883491949536264](https://jules.google.com/task/5011883491949536264) started by @n24q02m*