### PR TITLE
🛡️ Sentinel: [HIGH] Fix insecure postMessage target origin and missing URL validation

### DIFF
--- a/background.js
+++ b/background.js
@@ -12,9 +12,13 @@
 const JULES_ORIGIN = 'https://jules.google.com'
 
 function extractAccountNum(url) {
-  const parts = new URL(url).pathname.split('/')
-  const uIdx = parts.indexOf('u')
-  return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  try {
+    const parts = new URL(url).pathname.split('/')
+    const uIdx = parts.indexOf('u')
+    return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  } catch (_e) {
+    return '0'
+  }
 }
 
 // =============================================================================

--- a/content.js
+++ b/content.js
@@ -11,7 +11,7 @@ let cachedConfig = null
 
 // Listen for messages from MAIN world script
 window.addEventListener('message', (event) => {
-  if (event.source !== window) return
+  if (event.source !== window || event.origin !== window.origin) return
   if (event.data?.type === 'JULES_ARCHIVER_CONFIG') {
     cachedConfig = event.data.config
   }
@@ -32,11 +32,11 @@ function extractConfig() {
 
   return new Promise((resolve) => {
     // Ask main-world.js to re-broadcast config
-    window.postMessage({ type: 'JULES_REQUEST_CONFIG' }, '*')
+    window.postMessage({ type: 'JULES_REQUEST_CONFIG' }, window.origin)
 
     const timeout = setTimeout(() => resolve(cachedConfig), 2000)
     const handler = (event) => {
-      if (event.source !== window) return
+      if (event.source !== window || event.origin !== window.origin) return
       if (event.data?.type !== 'JULES_ARCHIVER_CONFIG') return
       window.removeEventListener('message', handler)
       clearTimeout(timeout)
@@ -49,9 +49,13 @@ function extractConfig() {
 
 // Detect account from URL
 function getAccountNum() {
-  const parts = new URL(location.href).pathname.split('/')
-  const uIdx = parts.indexOf('u')
-  return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  try {
+    const parts = new URL(location.href).pathname.split('/')
+    const uIdx = parts.indexOf('u')
+    return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  } catch (_e) {
+    return '0'
+  }
 }
 
 function getAccountLabel() {

--- a/main-world.js
+++ b/main-world.js
@@ -26,7 +26,7 @@ function broadcastConfig() {
           }
         : null
     },
-    '*'
+    window.origin
   )
 }
 
@@ -54,7 +54,7 @@ if (!window.__julesArchiver) {
               capturedAt: Date.now()
             }
           },
-          '*'
+          window.origin
         )
       } catch (_e) {
         /* ignore parse errors */
@@ -69,7 +69,7 @@ broadcastConfig()
 
 // Also listen for explicit re-extract requests from content.js
 window.addEventListener('message', (event) => {
-  if (event.source !== window) return
+  if (event.source !== window || event.origin !== window.origin) return
   if (event.data?.type === 'JULES_REQUEST_CONFIG') {
     broadcastConfig()
   }


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix insecure postMessage target origin and missing URL validation

### 🚨 Severity: HIGH

### 💡 Vulnerability
1. `window.postMessage` calls were using the `*` wildcard for target origin, allowing cross-origin frames to intercept `WIZ_global_data` tokens containing sensitive authorization values. Moreover, message listeners relied only on `event.source === window` checks without validating `event.origin`.
2. Missing URL validation on paths resulted in an unhandled exception when parsing malformed URLs, which caused the background or content scripts to crash (`Denial of Service` / `Reliability`).

### 🎯 Impact
1. A malicious iframe or page could potentially intercept the `WIZ_global_data` config tokens if injected into the context, allowing unauthorized API access or spoofing config updates.
2. The scripts could crash due to `TypeError: Invalid URL` if they encountered a malformed `tab.url` or `location.href`, stopping the extension's operations entirely.

### 🔧 Fix
- Explicitly restricted the `postMessage` target origin to `window.origin` in `main-world.js` and `content.js` to ensure the config tokens are strictly dispatched within the expected origin.
- Enhanced the `window.addEventListener('message', ...)` listeners to verify that `event.origin === window.origin` before trusting and processing message data.
- Added a `try-catch` block around the `new URL()` invocations in `extractAccountNum` and `getAccountNum` to safely fall back to the default account `"0"` when URL parsing fails.

### ✅ Verification
- Analyzed `main-world.js` and `content.js` behavior conceptually and reviewed test output (`npm test`).
- Ensured all tests executed successfully, including those specifically validating the new `try-catch` bounds in URL parsing (fixing the pre-existing failing test in `extractAccountNum`).
- `npx @biomejs/biome check .` reports no errors in formatting and styling.

---
*PR created automatically by Jules for task [5994181018709453023](https://jules.google.com/task/5994181018709453023) started by @n24q02m*