### PR TITLE
🎨 Palette: Add ARIA roles to radio button groups for accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2025-04-03 - Progressive Disclosure for Multi-Mode UIs
 **Learning:** In a multi-mode UI (like Archive vs Suggestions), showing all settings at once creates cognitive overload, especially when settings like GitHub tokens are only relevant to one mode.
 **Action:** Use progressive disclosure in `popup.js` to hide mode-specific settings (like the `.settings` section and `force` checkbox) when they are not relevant to the currently selected mode, keeping the UI clean and focused.
+## 2025-04-12 - ARIA Roles for Custom Radio Groups
+**Learning:** When using custom `div` wrappers instead of native `fieldset` elements to group radio buttons (often done to preserve specific CSS layouts), the semantic grouping is lost for screen readers.
+**Action:** Always add `role="radiogroup"` and an explicit `aria-label` to the container `div` to restore accessibility and ensure screen reader users understand the context of the radio buttons.

--- a/popup.html
+++ b/popup.html
@@ -31,7 +31,7 @@
           <button type="button" data-value="suggestions" aria-pressed="false">Start Suggestions</button>
         </div>
       </div>
-      <div class="radio-group">
+      <div class="radio-group" role="radiogroup" aria-label="Execution mode">
         <label><input type="radio" name="mode" value="dry" checked /> Dry Run</label>
         <label><input type="radio" name="mode" value="run" /> Run</label>
       </div>
@@ -39,7 +39,7 @@
         <input type="checkbox" id="force" />
         Force (skip PR check)
       </label>
-      <div class="radio-group">
+      <div class="radio-group" role="radiogroup" aria-label="Tab scope">
         <label><input type="radio" name="scope" value="current" /> Current tab</label>
         <label><input type="radio" name="scope" value="all" checked /> All Jules tabs</label>
       </div>


### PR DESCRIPTION
**What:**
Added `role="radiogroup"` and specific `aria-label`s ("Execution mode" and "Tab scope") to the custom `div` containers used to group radio buttons in `popup.html`.
Also documented this learning in `.Jules/palette.md`.

**Why:**
The UI uses custom `div` wrappers instead of native `fieldset` elements to preserve the layout and CSS styling for radio button groups. However, doing so removes semantic grouping for screen readers, meaning users navigating with assistive tech lose context for what the radio buttons apply to. Adding `role="radiogroup"` explicitly restores this necessary context.

**Before/After:**
*(No visual changes - purely a semantic HTML addition)*

**Accessibility:**
This satisfies the requirement to fix "Missing ARIA labels, roles, or descriptions" specifically for components acting as groups of inputs.

---
*PR created automatically by Jules for task [17883574664816781206](https://jules.google.com/task/17883574664816781206) started by @n24q02m*