### PR TITLE
🎨 Palette: Accessible custom radio groups and robust URL parsing

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2025-04-03 - Progressive Disclosure for Multi-Mode UIs
 **Learning:** In a multi-mode UI (like Archive vs Suggestions), showing all settings at once creates cognitive overload, especially when settings like GitHub tokens are only relevant to one mode.
 **Action:** Use progressive disclosure in `popup.js` to hide mode-specific settings (like the `.settings` section and `force` checkbox) when they are not relevant to the currently selected mode, keeping the UI clean and focused.
+## 2025-04-03 - Accessible Custom Radio Groups
+**Learning:** When using custom `div` wrappers (like `.radio-group`) instead of semantic `<fieldset>` elements to preserve CSS styling, screen readers lose the context that the contained radio buttons belong to a cohesive group.
+**Action:** Always add `role="radiogroup"` and an appropriate `aria-label` to custom radio group containers to ensure structural accessibility is maintained without sacrificing visual design.

--- a/background.js
+++ b/background.js
@@ -12,9 +12,13 @@
 const JULES_ORIGIN = 'https://jules.google.com'
 
 function extractAccountNum(url) {
-  const parts = new URL(url).pathname.split('/')
-  const uIdx = parts.indexOf('u')
-  return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  try {
+    const parts = new URL(url).pathname.split('/')
+    const uIdx = parts.indexOf('u')
+    return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  } catch (_e) {
+    return '0'
+  }
 }
 
 // =============================================================================

--- a/popup.html
+++ b/popup.html
@@ -31,7 +31,7 @@
           <button type="button" data-value="suggestions" aria-pressed="false">Start Suggestions</button>
         </div>
       </div>
-      <div class="radio-group">
+      <div class="radio-group" role="radiogroup" aria-label="Execution Mode">
         <label><input type="radio" name="mode" value="dry" checked /> Dry Run</label>
         <label><input type="radio" name="mode" value="run" /> Run</label>
       </div>
@@ -39,7 +39,7 @@
         <input type="checkbox" id="force" />
         Force (skip PR check)
       </label>
-      <div class="radio-group">
+      <div class="radio-group" role="radiogroup" aria-label="Target Scope">
         <label><input type="radio" name="scope" value="current" /> Current tab</label>
         <label><input type="radio" name="scope" value="all" checked /> All Jules tabs</label>
       </div>


### PR DESCRIPTION
💡 **What:** Added `role="radiogroup"` and descriptive `aria-label`s to custom `div.radio-group` wrappers in `popup.html`. Additionally, wrapped a `new URL()` parsing operation in `background.js` in a `try/catch` block to handle malformed URLs safely (fixing an existing failing test).

🎯 **Why:** To maintain visual styling without `<fieldset>`, the extension uses custom `div`s for radio button groups. Screen readers lose the structural grouping context when native `<fieldset>` elements are omitted. The background script change ensures robustness against malformed input URLs.

📸 **Before/After:** No visual changes. This is purely a semantic HTML improvement.

♿ **Accessibility:** Screen readers will now correctly announce "Execution Mode" and "Target Scope" as cohesive radio groups, rather than presenting a disconnected list of radio buttons, significantly improving keyboard and screen reader navigability.

---
*PR created automatically by Jules for task [2355347853314961428](https://jules.google.com/task/2355347853314961428) started by @n24q02m*