### PR TITLE
🎨 Palette: Improve accessibility for radio button groups

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2025-04-03 - Progressive Disclosure for Multi-Mode UIs
 **Learning:** In a multi-mode UI (like Archive vs Suggestions), showing all settings at once creates cognitive overload, especially when settings like GitHub tokens are only relevant to one mode.
 **Action:** Use progressive disclosure in `popup.js` to hide mode-specific settings (like the `.settings` section and `force` checkbox) when they are not relevant to the currently selected mode, keeping the UI clean and focused.
+## 2025-04-14 - Semantic Grouping for Custom Radio Containers
+**Learning:** When using custom `div` elements instead of semantic `<fieldset>` tags for radio button groups (often done to preserve specific CSS layouts), the semantic association of the grouped options is lost for screen reader users, breaking accessibility.
+**Action:** Always add `role="radiogroup"` and an appropriate `aria-label` attribute to custom wrapper elements containing related radio inputs to ensure screen readers correctly announce the group context.

--- a/background.js
+++ b/background.js
@@ -12,9 +12,13 @@
 const JULES_ORIGIN = 'https://jules.google.com'
 
 function extractAccountNum(url) {
-  const parts = new URL(url).pathname.split('/')
-  const uIdx = parts.indexOf('u')
-  return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  try {
+    const parts = new URL(url).pathname.split('/')
+    const uIdx = parts.indexOf('u')
+    return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  } catch (e) {
+    return '0'
+  }
 }
 
 // =============================================================================

--- a/content.js
+++ b/content.js
@@ -49,9 +49,13 @@ function extractConfig() {
 
 // Detect account from URL
 function getAccountNum() {
-  const parts = new URL(location.href).pathname.split('/')
-  const uIdx = parts.indexOf('u')
-  return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  try {
+    const parts = new URL(location.href).pathname.split('/')
+    const uIdx = parts.indexOf('u')
+    return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  } catch (e) {
+    return '0'
+  }
 }
 
 function getAccountLabel() {

--- a/popup.html
+++ b/popup.html
@@ -31,7 +31,7 @@
           <button type="button" data-value="suggestions" aria-pressed="false">Start Suggestions</button>
         </div>
       </div>
-      <div class="radio-group">
+      <div class="radio-group" role="radiogroup" aria-label="Execution Mode">
         <label><input type="radio" name="mode" value="dry" checked /> Dry Run</label>
         <label><input type="radio" name="mode" value="run" /> Run</label>
       </div>
@@ -39,7 +39,7 @@
         <input type="checkbox" id="force" />
         Force (skip PR check)
       </label>
-      <div class="radio-group">
+      <div class="radio-group" role="radiogroup" aria-label="Scope Selection">
         <label><input type="radio" name="scope" value="current" /> Current tab</label>
         <label><input type="radio" name="scope" value="all" checked /> All Jules tabs</label>
       </div>


### PR DESCRIPTION
### 💡 What
* Added `role="radiogroup"` and `aria-label` attributes to the custom `div` containers that act as wrappers for the radio button options in `popup.html`.
* Wrapped the URL parsing logic (`new URL()`) inside the `extractAccountNum` (`background.js`) and `getAccountNum` (`content.js`) functions with a `try/catch` block to safely default to returning `'0'`.
* Fixed the failing tests in `tests/background.test.js` related to URL parsing.
* Added a new entry to the `.Jules/palette.md` UX journal documenting the necessity of adding semantic grouping to custom radio button wrappers.

### 🎯 Why
* The `popup.html` interface utilizes custom `div` wrappers with the `.radio-group` class to style grouped radio buttons instead of using standard `<fieldset>` elements. While this preserves CSS layouts, it strips away the semantic association between the grouped radio buttons for screen readers, leading to a degraded accessibility experience.
* The application was crashing or throwing errors during tests and potentially in runtime scenarios when attempting to parse malformed, unexpected, or empty URLs because `new URL()` throws a `TypeError` for invalid input strings, necessitating a defensive fallback.

### 📸 Before/After
*(Visuals remain strictly unchanged; this is an underlying accessibility and bugfix update).*

### ♿ Accessibility
* Screen readers (like NVDA or VoiceOver) will now correctly announce the context and grouping of the radio buttons (e.g., "Execution Mode, radio group", "Scope Selection, radio group"), allowing users relying on assistive technologies to properly navigate and understand the relationship between the options.

---
*PR created automatically by Jules for task [8352232238217866587](https://jules.google.com/task/8352232238217866587) started by @n24q02m*