### PR TITLE
🛡️ Sentinel: [HIGH] Fix cross-origin data leakage in postMessage

### DIFF
--- a/background.js
+++ b/background.js
@@ -12,9 +12,13 @@
 const JULES_ORIGIN = 'https://jules.google.com'
 
 function extractAccountNum(url) {
-  const parts = new URL(url).pathname.split('/')
-  const uIdx = parts.indexOf('u')
-  return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  try {
+    const parts = new URL(url).pathname.split('/')
+    const uIdx = parts.indexOf('u')
+    return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  } catch (_e) {
+    return '0'
+  }
 }
 
 // =============================================================================

--- a/content.js
+++ b/content.js
@@ -12,6 +12,7 @@ let cachedConfig = null
 // Listen for messages from MAIN world script
 window.addEventListener('message', (event) => {
   if (event.source !== window) return
+  if (event.origin !== window.origin) return
   if (event.data?.type === 'JULES_ARCHIVER_CONFIG') {
     cachedConfig = event.data.config
   }
@@ -32,11 +33,12 @@ function extractConfig() {
 
   return new Promise((resolve) => {
     // Ask main-world.js to re-broadcast config
-    window.postMessage({ type: 'JULES_REQUEST_CONFIG' }, '*')
+    window.postMessage({ type: 'JULES_REQUEST_CONFIG' }, window.origin)
 
     const timeout = setTimeout(() => resolve(cachedConfig), 2000)
     const handler = (event) => {
       if (event.source !== window) return
+      if (event.origin !== window.origin) return
       if (event.data?.type !== 'JULES_ARCHIVER_CONFIG') return
       window.removeEventListener('message', handler)
       clearTimeout(timeout)
@@ -49,9 +51,13 @@ function extractConfig() {
 
 // Detect account from URL
 function getAccountNum() {
-  const parts = new URL(location.href).pathname.split('/')
-  const uIdx = parts.indexOf('u')
-  return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  try {
+    const parts = new URL(location.href).pathname.split('/')
+    const uIdx = parts.indexOf('u')
+    return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
+  } catch (_e) {
+    return '0'
+  }
 }
 
 function getAccountLabel() {

--- a/main-world.js
+++ b/main-world.js
@@ -26,7 +26,7 @@ function broadcastConfig() {
           }
         : null
     },
-    '*'
+    window.origin
   )
 }
 
@@ -54,7 +54,7 @@ if (!window.__julesArchiver) {
               capturedAt: Date.now()
             }
           },
-          '*'
+          window.origin
         )
       } catch (_e) {
         /* ignore parse errors */
@@ -70,6 +70,7 @@ broadcastConfig()
 // Also listen for explicit re-extract requests from content.js
 window.addEventListener('message', (event) => {
   if (event.source !== window) return
+  if (event.origin !== window.origin) return
   if (event.data?.type === 'JULES_REQUEST_CONFIG') {
     broadcastConfig()
   }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** `window.postMessage` calls used wildcard `'*'` target origin, allowing any iframe to intercept configuration data like tokens. Also, the message event listeners did not verify the `event.origin`. Additionally, `new URL()` calls failed on empty/invalid inputs which caused unhandled exceptions.
🎯 **Impact:** Malicious sites or injected iframes could steal sensitive credentials broadcast between the background page and content scripts. Invalid URL inputs could cause unhandled exceptions that crash tab processing.
🔧 **Fix:** Replaced `'*'` target origin with `window.origin` in `window.postMessage` calls in `main-world.js` and `content.js`. Added `if (event.origin !== window.origin) return` to all `message` event listeners to reject untrusted messages. Wrapped `new URL()` calls in `extractAccountNum` and `getAccountNum` with `try-catch` blocks to safely return a `'0'` default.
✅ **Verification:** Ran `pnpm test` successfully (all tests pass, including the previously failing `extractAccountNum` unit test) and `biome check` for formatting and linting.

---
*PR created automatically by Jules for task [11653250707338240989](https://jules.google.com/task/11653250707338240989) started by @n24q02m*