### PR TITLE
[TEST] Missing test for callBatchExecute

### DIFF
--- a/background.js
+++ b/background.js
@@ -16,7 +16,7 @@ function extractAccountNum(url) {
     const parts = new URL(url).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }

--- a/content.js
+++ b/content.js
@@ -62,7 +62,7 @@ function getAccountNum() {
     const parts = new URL(location.href).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -7,7 +7,7 @@ const path = require('node:path')
 const bgScriptPath = path.join(__dirname, '..', 'background.js')
 const bgScriptContent = fs.readFileSync(bgScriptPath, 'utf8')
 
-function setupEnvironment(initialStorage = {}) {
+function setupEnvironment(initialStorage = {}, mocks = {}) {
   const sessionSetData = []
   let currentStorage = { ...initialStorage }
 
@@ -49,7 +49,7 @@ function setupEnvironment(initialStorage = {}) {
 
   const sandbox = {
     chrome: chromeMock,
-    fetch: async () => ({ ok: true, json: async () => [], text: async () => ")]}'\n\n4\n[[]]" }),
+    fetch: mocks.fetch || (async () => ({ ok: true, json: async () => [], text: async () => ")]}'\n\n4\n[[]]" })),
     setTimeout,
     setInterval,
     clearInterval,
@@ -78,6 +78,7 @@ function setupEnvironment(initialStorage = {}) {
     globalThis.test_updateState = updateState;
     globalThis.test_addLog = addLog;
     globalThis.test_buildBatchRequest = buildBatchRequest;
+    globalThis.test_callBatchExecute = callBatchExecute;
     globalThis.test_fixJsonControlChars = fixJsonControlChars;
     globalThis.test_findJsonEnd = findJsonEnd;
     globalThis.test_parseResponse = parseResponse;
@@ -796,5 +797,67 @@ describe('getJulesTabs', () => {
     assert.strictEqual(tabs.length, 2)
     assert.strictEqual(sandbox.test_extractAccountNum(tabs[0].url), '0')
     assert.strictEqual(sandbox.test_extractAccountNum(tabs[1].url), '1')
+  })
+})
+
+// =============================================================================
+// callBatchExecute Tests
+// =============================================================================
+
+describe('callBatchExecute', () => {
+  it('should execute successfully and return parsed response', async () => {
+    let fetchCalled = false
+    let fetchOptions = null
+    const mockResponse = ')]}\'\n\n100\n[["wrb.fr","rpc-id","[\\"result\\"]",null,null,null,"generic"]]'
+
+    const mocks = {
+      fetch: async (_url, options) => {
+        fetchCalled = true
+        fetchOptions = options
+        return {
+          ok: true,
+          text: async () => mockResponse
+        }
+      }
+    }
+
+    const { sandbox } = setupEnvironment({}, mocks)
+    const config = { at: 'token', accountNum: '0', bl: 'build' }
+    const result = await sandbox.test_callBatchExecute('rpc-id', ['payload'], config)
+
+    assert.strictEqual(fetchCalled, true)
+    assert.strictEqual(fetchOptions.method, 'POST')
+    assert.strictEqual(fetchOptions.headers['content-type'], 'application/x-www-form-urlencoded;charset=UTF-8')
+    assert.deepStrictEqual(result, ['result'])
+  })
+
+  it('should throw error on HTTP failure', async () => {
+    const mocks = {
+      fetch: async () => ({
+        ok: false,
+        status: 500
+      })
+    }
+
+    const { sandbox } = setupEnvironment({}, mocks)
+    const config = { at: 'token', accountNum: '0', bl: 'build' }
+
+    await assert.rejects(
+      sandbox.test_callBatchExecute('rpc-id', ['payload'], config),
+      /batchexecute rpc-id failed: HTTP 500/
+    )
+  })
+
+  it('should propagate network errors', async () => {
+    const mocks = {
+      fetch: async () => {
+        throw new Error('Network failure')
+      }
+    }
+
+    const { sandbox } = setupEnvironment({}, mocks)
+    const config = { at: 'token', accountNum: '0', bl: 'build' }
+
+    await assert.rejects(sandbox.test_callBatchExecute('rpc-id', ['payload'], config), /Network failure/)
   })
 })


### PR DESCRIPTION
This PR adds missing unit tests for the `callBatchExecute` function in the background script.

### Changes
- **Tests**: Added a new `describe` block in `tests/background.test.js` covering successful RPC execution and error handling.
- **Infrastructure**: Modified the `setupEnvironment` helper to allow injecting custom mocks into the `node:vm` sandbox, enabling precise `fetch` mocking.
- **Cleanup**: Fixed a few linting warnings regarding unused variables in `background.js` and `content.js`.

### Verification
- Ran `pnpm test` - all 70 tests passed (including 3 new tests).
- Ran `npx @biomejs/biome check .` - no linting or formatting issues found.

---
*PR created automatically by Jules for task [5477541044665238095](https://jules.google.com/task/5477541044665238095) started by @n24q02m*