### PR TITLE
[CLEANUP] Uncaught TypeError in extractAccountNum

### DIFF
--- a/background.js
+++ b/background.js
@@ -16,7 +16,7 @@ function extractAccountNum(url) {
     const parts = new URL(url).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }

--- a/content.js
+++ b/content.js
@@ -62,7 +62,7 @@ function getAccountNum() {
     const parts = new URL(location.href).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -750,6 +750,13 @@ describe('extractAccountNum', () => {
     assert.strictEqual(sandbox.test_extractAccountNum('https://google.com'), '0')
     assert.strictEqual(sandbox.test_extractAccountNum(''), '0')
   })
+
+  it('should handle null, undefined, and malformed URLs gracefully', () => {
+    const { sandbox } = setupEnvironment()
+    assert.strictEqual(sandbox.test_extractAccountNum(null), '0')
+    assert.strictEqual(sandbox.test_extractAccountNum(undefined), '0')
+    assert.strictEqual(sandbox.test_extractAccountNum('not-a-url'), '0')
+  })
 })
 
 describe('getTabLabel', () => {


### PR DESCRIPTION
This PR ensures that the `extractAccountNum` function in `background.js` (and similarly `getAccountNum` in `content.js`) is robust against malformed or missing URL inputs. 

Key changes:
1. **Verification**: Confirmed the `try-catch` block is already implemented in the source code to prevent `TypeError` when parsing invalid URLs.
2. **Robust Testing**: Added new test cases to `tests/background.test.js` to explicitly cover `null`, `undefined`, and non-URL strings, ensuring they all return the default '0'.
3. **Code Quality**: Applied Biome fixes to rename unused catch variables to `_e`, adhering to the project's linting rules.
4. **Validation**: Verified that all 68 tests in the suite pass.

---
*PR created automatically by Jules for task [6825079885480124910](https://jules.google.com/task/6825079885480124910) started by @n24q02m*