### PR TITLE
[TEST] Missing test for stopKeepAlive

### DIFF
--- a/background.js
+++ b/background.js
@@ -16,7 +16,7 @@ function extractAccountNum(url) {
     const parts = new URL(url).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }

--- a/content.js
+++ b/content.js
@@ -62,7 +62,7 @@ function getAccountNum() {
     const parts = new URL(location.href).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -99,6 +99,9 @@ function setupEnvironment(initialStorage = {}) {
     globalThis.test_SDETAIL = SDETAIL;
     globalThis.test_CATEGORY_CONFIG = CATEGORY_CONFIG;
     globalThis.test_DEFAULT_CATEGORY = DEFAULT_CATEGORY;
+    globalThis.test_startKeepAlive = startKeepAlive;
+    globalThis.test_stopKeepAlive = stopKeepAlive;
+    globalThis.test_getKeepAliveInterval = () => keepAliveInterval;
   `
 
   const script = new vm.Script(scriptContent)
@@ -796,5 +799,35 @@ describe('getJulesTabs', () => {
     assert.strictEqual(tabs.length, 2)
     assert.strictEqual(sandbox.test_extractAccountNum(tabs[0].url), '0')
     assert.strictEqual(sandbox.test_extractAccountNum(tabs[1].url), '1')
+  })
+})
+
+// =============================================================================
+// Keep Alive Tests
+// =============================================================================
+
+describe('keepAlive', () => {
+  it('should start and stop keepAlive interval', () => {
+    const { sandbox } = setupEnvironment()
+
+    // Initial state
+    assert.strictEqual(sandbox.test_getKeepAliveInterval(), null)
+
+    // Start
+    sandbox.test_startKeepAlive()
+    const interval = sandbox.test_getKeepAliveInterval()
+    assert.ok(interval !== null)
+
+    // Start again (should be idempotent)
+    sandbox.test_startKeepAlive()
+    assert.strictEqual(sandbox.test_getKeepAliveInterval(), interval)
+
+    // Stop
+    sandbox.test_stopKeepAlive()
+    assert.strictEqual(sandbox.test_getKeepAliveInterval(), null)
+
+    // Stop again (should handle null)
+    sandbox.test_stopKeepAlive()
+    assert.strictEqual(sandbox.test_getKeepAliveInterval(), null)
   })
 })


### PR DESCRIPTION
Added unit tests for the stopKeepAlive function and the keep-alive mechanism in background.js. 
The internal state of the keep-alive interval is now verified in the test suite by exposing it to the sandbox environment.
Also fixed minor linting issues in background.js and content.js discovered during verification.

---
*PR created automatically by Jules for task [12814920656506034498](https://jules.google.com/task/12814920656506034498) started by @n24q02m*