### PR TITLE
[TEST] Missing test for archiveTask

### DIFF
--- a/archive_test.diff
+++ b/archive_test.diff
@@ -1,0 +1,32 @@
+<<<<<<< SEARCH
+describe('buildBatchRequest', () => {
+=======
+describe('archiveTask', () => {
+  it('should call callBatchExecute with correct parameters', async () => {
+    const { sandbox } = setupEnvironment()
+    let captured = null
+    sandbox.fetch = async (url, options) => {
+      captured = { url, body: options.body }
+      return {
+        ok: true,
+        text: async () => ")]}'\n\n4\n[[]]"
+      }
+    }
+
+    const config = { bl: 'b', fsid: 'f', at: 'a', accountNum: '0' }
+    await sandbox.test_archiveTask('task-123', config)
+
+    assert.ok(captured.url.includes('rpcids=Tjmm5c'))
+    assert.ok(captured.body.includes('Tjmm5c'))
+    assert.ok(captured.body.includes('task-123'))
+
+    // Verify exact payload structure in body
+    const params = new URLSearchParams(captured.body)
+    const freq = JSON.parse(params.get('f.req'))
+    assert.strictEqual(freq[0][0][0], 'Tjmm5c')
+    assert.strictEqual(freq[0][0][1], JSON.stringify([['task-123'], 1]))
+  })
+})
+
+describe('buildBatchRequest', () => {
+>>>>>>> REPLACE

--- a/background.js
+++ b/background.js
@@ -16,7 +16,7 @@ function extractAccountNum(url) {
     const parts = new URL(url).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }

--- a/background_test.diff
+++ b/background_test.diff
@@ -1,0 +1,9 @@
+<<<<<<< SEARCH
+    globalThis.test_DEFAULT_CATEGORY = DEFAULT_CATEGORY;
+  `
+=======
+    globalThis.test_DEFAULT_CATEGORY = DEFAULT_CATEGORY;
+    globalThis.test_archiveTask = archiveTask;
+    globalThis.test_callBatchExecute = callBatchExecute;
+  `
+>>>>>>> REPLACE

--- a/content.js
+++ b/content.js
@@ -62,7 +62,7 @@ function getAccountNum() {
     const parts = new URL(location.href).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -99,6 +99,8 @@ function setupEnvironment(initialStorage = {}) {
     globalThis.test_SDETAIL = SDETAIL;
     globalThis.test_CATEGORY_CONFIG = CATEGORY_CONFIG;
     globalThis.test_DEFAULT_CATEGORY = DEFAULT_CATEGORY;
+    globalThis.test_archiveTask = archiveTask;
+    globalThis.test_callBatchExecute = callBatchExecute;
   `
 
   const script = new vm.Script(scriptContent)
@@ -110,6 +112,33 @@ function setupEnvironment(initialStorage = {}) {
 // =============================================================================
 // batchexecute Client Tests
 // =============================================================================
+
+describe('archiveTask', () => {
+  it('should call callBatchExecute with correct parameters', async () => {
+    const { sandbox } = setupEnvironment()
+    let captured = null
+    sandbox.fetch = async (url, options) => {
+      captured = { url, body: options.body }
+      return {
+        ok: true,
+        text: async () => ")]}'\n\n4\n[[]]"
+      }
+    }
+
+    const config = { bl: 'b', fsid: 'f', at: 'a', accountNum: '0' }
+    await sandbox.test_archiveTask('task-123', config)
+
+    assert.ok(captured.url.includes('rpcids=Tjmm5c'))
+    assert.ok(captured.body.includes('Tjmm5c'))
+    assert.ok(captured.body.includes('task-123'))
+
+    // Verify exact payload structure in body
+    const params = new URLSearchParams(captured.body)
+    const freq = JSON.parse(params.get('f.req'))
+    assert.strictEqual(freq[0][0][0], 'Tjmm5c')
+    assert.strictEqual(freq[0][0][1], JSON.stringify([['task-123'], 1]))
+  })
+})
 
 describe('buildBatchRequest', () => {
   it('should format correct URL and body', () => {


### PR DESCRIPTION
This PR adds missing test coverage for the `archiveTask` function in `background.js`.

Changes:
1.  **Test Environment Update**: Modified `tests/background.test.js` to expose `archiveTask` and `callBatchExecute` to the `node:vm` sandbox.
2.  **New Test Suite**: Added an `archiveTask` test suite that mocks `fetch` to verify the correct RPC ID ('Tjmm5c') and payload structure (`[[taskId], 1]`) are sent to the `batchexecute` API.
3.  **Linting Fixes**: Cleaned up minor Biome linting warnings (unused catch variables) in `background.js` and `content.js` that were detected during the verification process.

Verification:
- Ran `pnpm test` and confirmed all 68 tests pass (including the new `archiveTask` test).
- Ran `npx @biomejs/biome check .` and confirmed no errors/warnings remain.

---
*PR created automatically by Jules for task [3274579528185684725](https://jules.google.com/task/3274579528185684725) started by @n24q02m*