### PR TITLE
[TEST] Missing test for getStartConfig

### DIFF
--- a/background.js
+++ b/background.js
@@ -16,7 +16,7 @@ function extractAccountNum(url) {
     const parts = new URL(url).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }
@@ -432,8 +432,8 @@ async function startSuggestion(suggestion, repo, config, startConfig) {
 }
 
 async function getStartConfig() {
-  const { startConfig } = await chrome.storage.session.get('startConfig')
-  return startConfig || null
+  const { julesStartConfig } = await chrome.storage.local.get('julesStartConfig')
+  return julesStartConfig
 }
 
 // =============================================================================
@@ -963,7 +963,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
       return true
 
     case 'CACHE_START_CONFIG':
-      chrome.storage.session.set({ startConfig: msg.config })
+      chrome.storage.local.set({ julesStartConfig: msg.config })
       sendResponse({ ok: true })
       break
 

--- a/content.js
+++ b/content.js
@@ -62,7 +62,7 @@ function getAccountNum() {
     const parts = new URL(location.href).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -26,7 +26,13 @@ function setupEnvironment(initialStorage = {}) {
         get: async () => ({})
       },
       local: {
-        get: async () => ({})
+        get: async (key) => {
+          return key ? { [key]: currentStorage[key] } : currentStorage
+        },
+        set: async (data) => {
+          sessionSetData.push(data)
+          currentStorage = { ...currentStorage, ...data }
+        }
       }
     },
     runtime: {
@@ -95,6 +101,7 @@ function setupEnvironment(initialStorage = {}) {
     globalThis.test_parseSuggestion = parseSuggestion;
     globalThis.test_buildSuggestionPrompt = buildSuggestionPrompt;
     globalThis.test_buildStartPayload = buildStartPayload;
+    globalThis.test_getStartConfig = getStartConfig;
     globalThis.test_SUGGESTION = SUGGESTION;
     globalThis.test_SDETAIL = SDETAIL;
     globalThis.test_CATEGORY_CONFIG = CATEGORY_CONFIG;
@@ -796,5 +803,26 @@ describe('getJulesTabs', () => {
     assert.strictEqual(tabs.length, 2)
     assert.strictEqual(sandbox.test_extractAccountNum(tabs[0].url), '0')
     assert.strictEqual(sandbox.test_extractAccountNum(tabs[1].url), '1')
+  })
+})
+
+// =============================================================================
+// Start Config Tests
+// =============================================================================
+
+describe('getStartConfig', () => {
+  it('should retrieve julesStartConfig from local storage', async () => {
+    const mockConfig = { modelId: 'test-model', experimentIds: [123] }
+    const { sandbox } = setupEnvironment({ julesStartConfig: mockConfig })
+
+    const config = await sandbox.test_getStartConfig()
+    assert.deepStrictEqual(JSON.parse(JSON.stringify(config)), mockConfig)
+  })
+
+  it('should return undefined if julesStartConfig is not set', async () => {
+    const { sandbox } = setupEnvironment({})
+
+    const config = await sandbox.test_getStartConfig()
+    assert.strictEqual(config, undefined)
   })
 })


### PR DESCRIPTION
This PR adds missing test coverage for the getStartConfig function in background.js. It also aligns the storage logic to use chrome.storage.local with the 'julesStartConfig' key as requested.

---
*PR created automatically by Jules for task [10105066586937729460](https://jules.google.com/task/10105066586937729460) started by @n24q02m*