### PR TITLE
🛡️ Sentinel: [Low] Fix insecure postMessage target origin

### DIFF
--- a/background.js
+++ b/background.js
@@ -16,7 +16,7 @@ function extractAccountNum(url) {
     const parts = new URL(url).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }

--- a/content.js
+++ b/content.js
@@ -41,7 +41,7 @@ function extractConfig() {
 
   return new Promise((resolve) => {
     // Ask main-world.js to re-broadcast config
-    window.postMessage({ type: 'JULES_REQUEST_CONFIG' }, '*')
+    window.postMessage({ type: 'JULES_REQUEST_CONFIG' }, window.origin)
 
     const timeout = setTimeout(() => resolve(cachedConfig), 2000)
     const handler = (event) => {
@@ -62,7 +62,7 @@ function getAccountNum() {
     const parts = new URL(location.href).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }

--- a/main-world.js
+++ b/main-world.js
@@ -26,7 +26,7 @@ function broadcastConfig() {
           }
         : null
     },
-    '*'
+    window.origin
   )
 }
 
@@ -54,7 +54,7 @@ if (!window.__julesArchiver) {
               capturedAt: Date.now()
             }
           },
-          '*'
+          window.origin
         )
       } catch (_e) {
         /* ignore parse errors */

--- a/tests/origin_security.test.js
+++ b/tests/origin_security.test.js
@@ -1,0 +1,19 @@
+const { describe, it } = require('node:test')
+const assert = require('node:assert')
+const fs = require('node:fs')
+const path = require('node:path')
+
+describe('Origin Security: window.postMessage', () => {
+  const contentJs = fs.readFileSync(path.join(__dirname, '../content.js'), 'utf8')
+  const mainWorldJs = fs.readFileSync(path.join(__dirname, '../main-world.js'), 'utf8')
+
+  it('content.js should not use "*" as target origin in any postMessage calls', () => {
+    const insecureMatches = contentJs.match(/postMessage\s*\([\s\S]+?,\s*['"]\*['"]\s*\)/g)
+    assert.strictEqual(insecureMatches, null, `Insecure postMessage calls found in content.js: ${insecureMatches}`)
+  })
+
+  it('main-world.js should not use "*" as target origin in any postMessage calls', () => {
+    const insecureMatches = mainWorldJs.match(/postMessage\s*\([\s\S]+?,\s*['"]\*['"]\s*\)/g)
+    assert.strictEqual(insecureMatches, null, `Insecure postMessage calls found in main-world.js: ${insecureMatches}`)
+  })
+})


### PR DESCRIPTION
### Severity
Low

### Vulnerability
Insecure `window.postMessage` target origin using the wildcard `*`.

### Impact
Sensitive session tokens and configuration data broadcast between the MAIN world and the isolated content script could be intercepted by untrusted origins (e.g., iframes or other tabs with window references) if the target origin is not restricted.

### Fix
Changed the target origin from `'*'` to `window.origin` in:
- `content.js`: `JULES_REQUEST_CONFIG` request.
- `main-world.js`: `JULES_ARCHIVER_CONFIG` and `JULES_START_CONFIG` broadcasts.

### Verification
- Created `tests/origin_security.test.js` which uses regex to verify that no `postMessage` calls use the wildcard target origin.
- Ran the full test suite (`pnpm test`) to ensure functionality remains intact (all 69 tests passed).
- Verified code quality with Biome.

---
*PR created automatically by Jules for task [5086424425840082723](https://jules.google.com/task/5086424425840082723) started by @n24q02m*