### PR TITLE
[PERF] Awaiting startSuggestion sequentially

### DIFF
--- a/background.js
+++ b/background.js
@@ -10,13 +10,14 @@
 // =============================================================================
 
 const JULES_ORIGIN = 'https://jules.google.com'
+const SUGGESTION_CHUNK_SIZE = 5
 
 function extractAccountNum(url) {
   try {
     const parts = new URL(url).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }
@@ -505,29 +506,54 @@ async function processSuggestionsForTab(tab, options) {
     addLog(`\n[${label}] ${repo}: Found ${suggestions.length} suggestions`)
     updateState({ currentRepo: repo.replace(/^github\//, '') })
 
-    for (const s of suggestions) {
+    for (let i = 0; i < suggestions.length; i += SUGGESTION_CHUNK_SIZE) {
       if (state.status === 'cancelled') break
 
+      const chunk = suggestions.slice(i, i + SUGGESTION_CHUNK_SIZE)
+
       if (options.dryRun) {
-        addLog(`  [DRY] Would start: ${s.title} (${s.categorySlug})`)
-      } else {
-        addLog(`  Starting: ${s.title}...`)
-        try {
-          await startSuggestion(s, repo, config, startConfig)
-          addLog(`  Started: ${s.title}`)
-          totalStarted++
-        } catch (err) {
-          addLog(`  [!] Failed to start "${s.title}": ${err.message}`)
+        for (const s of chunk) {
+          addLog(`  [DRY] Would start: ${s.title} (${s.categorySlug})`)
+          updateState({
+            progress: {
+              archived: totalStarted,
+              skipped: state.progress.skipped,
+              total: state.progress.total + 1
+            }
+          })
         }
+        continue
       }
 
-      updateState({
-        progress: {
-          archived: totalStarted,
-          skipped: state.progress.skipped,
-          total: state.progress.total + 1
+      // Parallel requests, sequential state updates
+      const results = await Promise.all(
+        chunk.map(async (s) => {
+          addLog(`  Starting: ${s.title}...`)
+          try {
+            await startSuggestion(s, repo, config, startConfig)
+            return { s, success: true }
+          } catch (err) {
+            return { s, success: false, error: err.message }
+          }
+        })
+      )
+
+      for (const res of results) {
+        if (res.success) {
+          addLog(`  Started: ${res.s.title}`)
+          totalStarted++
+        } else {
+          addLog(`  [!] Failed to start "${res.s.title}": ${res.error}`)
         }
-      })
+
+        updateState({
+          progress: {
+            archived: totalStarted,
+            skipped: state.progress.skipped,
+            total: state.progress.total + 1
+          }
+        })
+      }
     }
   }
 

--- a/background.js.diff
+++ b/background.js.diff
@@ -1,71 +1,76 @@
 <<<<<<< SEARCH
-async function ensureContentScript(tabId) {
-  const tab = await chrome.tabs.get(tabId)
-  if (!tab.url?.startsWith(`${JULES_ORIGIN}/`)) {
-    throw new Error('Security Error: Cannot inject script into non-Jules tab')
-  }
+    for (const s of suggestions) {
+      if (state.status === 'cancelled') break
 
-  try {
-    await chrome.tabs.sendMessage(tabId, { action: 'PING' })
-  } catch {
-    await chrome.scripting.executeScript({
-      target: { tabId },
-      files: ['content.js']
-    })
-    const deadline = Date.now() + 3000
-    while (Date.now() < deadline) {
-      try {
-        await new Promise((r) => setTimeout(r, 100))
-        await chrome.tabs.sendMessage(tabId, { action: 'PING' })
-        return
-      } catch {
-        // Keep waiting
+      if (options.dryRun) {
+        addLog(`  [DRY] Would start: ${s.title} (${s.categorySlug})`)
+      } else {
+        addLog(`  Starting: ${s.title}...`)
+        try {
+          await startSuggestion(s, repo, config, startConfig)
+          addLog(`  Started: ${s.title}`)
+          totalStarted++
+        } catch (err) {
+          addLog(`  [!] Failed to start "${s.title}": ${err.message}`)
+        }
       }
+
+      updateState({
+        progress: {
+          archived: totalStarted,
+          skipped: state.progress.skipped,
+          total: state.progress.total + 1
+        }
+      })
     }
-    throw new Error('Content script failed to initialize within 3s')
-  }
-}
 =======
-async function ensureContentScript(tabId) {
-  const checkOrigin = async () => {
-    const tab = await chrome.tabs.get(tabId)
-    if (!tab.url) return false
-    try {
-      const url = new URL(tab.url)
-      return url.origin === JULES_ORIGIN
-    } catch {
-      return false
-    }
-  }
+    for (let i = 0; i < suggestions.length; i += SUGGESTION_CHUNK_SIZE) {
+      if (state.status === 'cancelled') break
 
-  if (!(await checkOrigin())) {
-    throw new Error('Security Error: Cannot inject script into non-Jules tab')
-  }
+      const chunk = suggestions.slice(i, i + SUGGESTION_CHUNK_SIZE)
 
-  try {
-    await chrome.tabs.sendMessage(tabId, { action: 'PING' })
-  } catch {
-    // Re-verify immediately before injection to prevent TOCTOU
-    if (!(await checkOrigin())) {
-      throw new Error('Security Error: Cannot inject script into non-Jules tab')
-    }
+      if (options.dryRun) {
+        for (const s of chunk) {
+          addLog(`  [DRY] Would start: ${s.title} (${s.categorySlug})`)
+          updateState({
+            progress: {
+              archived: totalStarted,
+              skipped: state.progress.skipped,
+              total: state.progress.total + 1
+            }
+          })
+        }
+        continue
+      }
 
-    await chrome.scripting.executeScript({
-      target: { tabId },
-      files: ['content.js']
-    })
+      // Parallel requests, sequential state updates
+      const results = await Promise.all(
+        chunk.map(async (s) => {
+          addLog(`  Starting: ${s.title}...`)
+          try {
+            await startSuggestion(s, repo, config, startConfig)
+            return { s, success: true }
+          } catch (err) {
+            return { s, success: false, error: err.message }
+          }
+        })
+      )
 
-    const deadline = Date.now() + 3000
-    while (Date.now() < deadline) {
-      try {
-        await new Promise((r) => setTimeout(r, 100))
-        await chrome.tabs.sendMessage(tabId, { action: 'PING' })
-        return
-      } catch {
-        // Keep waiting
+      for (const res of results) {
+        if (res.success) {
+          addLog(`  Started: ${res.s.title}`)
+          totalStarted++
+        } else {
+          addLog(`  [!] Failed to start "${res.s.title}": ${res.error}`)
+        }
+
+        updateState({
+          progress: {
+            archived: totalStarted,
+            skipped: state.progress.skipped,
+            total: state.progress.total + 1
+          }
+        })
       }
     }
-    throw new Error('Content script failed to initialize within 3s')
-  }
-}
 >>>>>>> REPLACE

--- a/content.js
+++ b/content.js
@@ -62,7 +62,7 @@ function getAccountNum() {
     const parts = new URL(location.href).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }


### PR DESCRIPTION
This PR parallelizes the \`startSuggestion\` calls in \`background.js\` to improve performance during bulk operations in Suggestions Mode.

### Changes:
- Introduced \`SUGGESTION_CHUNK_SIZE = 5\` constant to control concurrency.
- Refactored \`processSuggestionsForTab\` to process suggestions in chunks using \`Promise.all\`.
- Implemented a "Concurrent Request, Sequential State" pattern to ensure that network requests are parallelized while logging and progress updates remain sequential and consistent.
- Fixed minor linting issues (unused variables in \`catch\` blocks) identified by Biome.

### Impact:
Reduces the time spent waiting for sequential \`batchexecute\` RPC calls, leading to significantly faster processing of suggestions when multiple items are present in a repository.

### Verification:
- Verified implementation details in \`background.js\`.
- Ran full test suite (\`node --test\`): all 67 tests passed.
- Ran Biome linting: all checks passed.

---
*PR created automatically by Jules for task [11031012223486094557](https://jules.google.com/task/11031012223486094557) started by @n24q02m*