### PR TITLE
🛡️ Sentinel: High Fix Time-of-Check to Time-of-Use (TOCTOU) during script injection

### DIFF
--- a/background.js
+++ b/background.js
@@ -16,7 +16,7 @@ function extractAccountNum(url) {
     const parts = new URL(url).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }
@@ -664,31 +664,35 @@ function getTabLabel(tab) {
 }
 
 async function ensureContentScript(tabId) {
-  const checkOrigin = async () => {
-    const tab = await chrome.tabs.get(tabId)
-    if (!tab.url) return false
+  const getVerifiedDocumentId = async () => {
+    const frame = await chrome.webNavigation.getFrame({ tabId, frameId: 0 })
+    if (!frame?.url || !frame.documentId) return null
     try {
-      const url = new URL(tab.url)
-      return url.origin === JULES_ORIGIN
+      const url = new URL(frame.url)
+      return url.origin === JULES_ORIGIN ? frame.documentId : null
     } catch {
-      return false
+      return null
     }
   }
 
-  if (!(await checkOrigin())) {
+  const documentId = await getVerifiedDocumentId()
+  if (!documentId) {
     throw new Error('Security Error: Cannot inject script into non-Jules tab')
   }
 
   try {
-    await chrome.tabs.sendMessage(tabId, { action: 'PING' })
+    // Pin message to verified documentId
+    await chrome.tabs.sendMessage(tabId, { action: 'PING' }, { documentId })
+    return documentId
   } catch {
-    // Re-verify immediately before injection to prevent TOCTOU
-    if (!(await checkOrigin())) {
-      throw new Error('Security Error: Cannot inject script into non-Jules tab')
+    // Re-verify documentId hasn't changed before injection to prevent TOCTOU
+    const currentDocId = await getVerifiedDocumentId()
+    if (!currentDocId || currentDocId !== documentId) {
+      throw new Error('Security Error: Tab navigated away before injection')
     }
 
     await chrome.scripting.executeScript({
-      target: { tabId },
+      target: { tabId, documentIds: [documentId] },
       files: ['content.js']
     })
 
@@ -696,8 +700,8 @@ async function ensureContentScript(tabId) {
     while (Date.now() < deadline) {
       try {
         await new Promise((r) => setTimeout(r, 100))
-        await chrome.tabs.sendMessage(tabId, { action: 'PING' })
-        return
+        await chrome.tabs.sendMessage(tabId, { action: 'PING' }, { documentId })
+        return documentId
       } catch {
         // Keep waiting
       }
@@ -707,8 +711,8 @@ async function ensureContentScript(tabId) {
 }
 
 async function getTabConfig(tabId) {
-  await ensureContentScript(tabId)
-  const response = await chrome.tabs.sendMessage(tabId, { action: 'GET_CONFIG' })
+  const documentId = await ensureContentScript(tabId)
+  const response = await chrome.tabs.sendMessage(tabId, { action: 'GET_CONFIG' }, { documentId })
   if (!response?.config?.at) {
     throw new Error('Could not extract page config (XSRF token missing). Try refreshing the Jules tab.')
   }

--- a/content.js
+++ b/content.js
@@ -62,7 +62,7 @@ function getAccountNum() {
     const parts = new URL(location.href).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Jules Task Archiver",
   "version": "2.0.0",
   "description": "Bulk archive Jules tasks and start code suggestions via batchexecute API",
-  "permissions": ["storage", "tabs", "scripting"],
+  "permissions": ["storage", "tabs", "scripting", "webNavigation"],
   "host_permissions": ["https://jules.google.com/*", "https://api.github.com/*"],
   "background": {
     "service_worker": "background.js"

--- a/tests/security.test.js
+++ b/tests/security.test.js
@@ -127,12 +127,24 @@ function setupEnvironment(initialTabs = {}) {
       onMessage: { addListener: () => {} },
       getPlatformInfo: async () => ({})
     },
+    webNavigation: {
+      getFrame: async ({ tabId, frameId }) => {
+        if (frameId !== 0) return null
+        const tab = initialTabs[tabId] || { id: tabId, url: 'https://jules.google.com/u/0/' }
+        return {
+          url: tab.url,
+          documentId: tab.documentId || `doc-${tabId}-v1`,
+          frameId: 0
+        }
+      }
+    },
     tabs: {
       get: async (id) => {
         if (initialTabs[id]) return initialTabs[id]
         return { id, url: 'https://jules.google.com/u/0/' }
       },
-      sendMessage: async (_tabId, message) => {
+      sendMessage: async (tabId, message, options) => {
+        chromeMock.tabs.lastMessage = { tabId, message, options }
         if (message.action === 'PING') {
           // Simulate script not loaded by throwing
           throw new Error('Could not establish connection. Receiving end does not exist.')
@@ -187,19 +199,45 @@ describe('ensureContentScript Security', () => {
     const { sandbox, chromeMock } = setupEnvironment()
 
     let callCount = 0
-    chromeMock.tabs.get = async (id) => {
+    chromeMock.webNavigation.getFrame = async ({ tabId: _tabId }) => {
       callCount++
       if (callCount === 1) {
-        return { id, url: 'https://jules.google.com/u/0/' }
+        return { url: 'https://jules.google.com/u/0/', documentId: 'doc1', frameId: 0 }
       }
-      return { id, url: 'https://evil.com/' }
+      // Simulate navigation to evil.com -> documentId changes
+      return { url: 'https://evil.com/', documentId: 'doc2', frameId: 0 }
     }
 
-    // This is expected to fail CURRENTLY because ensureContentScript doesn't re-check the URL
-    // We WANT it to fail to prove the vulnerability exists.
     await assert.rejects(sandbox.test_ensureContentScript(123), {
-      message: /Security Error: Cannot inject script into non-Jules tab/
+      message: /Security Error: Tab navigated away before injection/
     })
+  })
+
+  it('should pin sendMessage and executeScript to documentId', async () => {
+    const { sandbox, chromeMock } = setupEnvironment({
+      456: { id: 456, url: 'https://jules.google.com/u/1/', documentId: 'fixed-doc-id' }
+    })
+
+    // Mock successful sendMessage after injection to stop the loop
+    let injected = false
+    chromeMock.tabs.sendMessage = async (tabId, message, options) => {
+      chromeMock.tabs.lastMessage = { tabId, message, options }
+      if (message.action === 'PING') {
+        if (injected) return { status: 'ok' }
+        throw new Error('Not loaded')
+      }
+    }
+    chromeMock.scripting.executeScript = async ({ target }) => {
+      chromeMock.scripting.lastCall = { target }
+      injected = true
+    }
+
+    await sandbox.test_ensureContentScript(456)
+
+    assert.strictEqual(chromeMock.tabs.lastMessage.options.documentId, 'fixed-doc-id')
+    assert.deepStrictEqual(JSON.parse(JSON.stringify(chromeMock.scripting.lastCall.target.documentIds)), [
+      'fixed-doc-id'
+    ])
   })
 
   it('should allow injection into valid Jules origin', async () => {


### PR DESCRIPTION
**Severity:** High
**Vulnerability:** Time-of-Check to Time-of-Use (TOCTOU) during script injection and message passing.
**Impact:** A malicious or compromised tab could navigate to a different origin between the security check and the script injection, potentially leading to the extension injecting sensitive logic or tokens into an untrusted origin.
**Fix:** Implemented `documentId` pinning. The extension now uses `chrome.webNavigation.getFrame` to retrieve a unique `documentId` for the verified Jules document and pins all subsequent `chrome.scripting.executeScript` and `chrome.tabs.sendMessage` calls to this specific document instance.
**Verification:** Added unit tests in `tests/security.test.js` that mock `chrome.webNavigation.getFrame` and verify that both `executeScript` and `sendMessage` correctly use the `documentId` and `documentIds` targeting options. Verified that navigation during the check-to-injection window results in a security error.

---
*PR created automatically by Jules for task [3491764153182737391](https://jules.google.com/task/3491764153182737391) started by @n24q02m*