### PR TITLE
🎨 Palette: Add loading spinner to Start button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2025-04-03 - Progressive Disclosure for Multi-Mode UIs
 **Learning:** In a multi-mode UI (like Archive vs Suggestions), showing all settings at once creates cognitive overload, especially when settings like GitHub tokens are only relevant to one mode.
 **Action:** Use progressive disclosure in `popup.js` to hide mode-specific settings (like the `.settings` section and `force` checkbox) when they are not relevant to the currently selected mode, keeping the UI clean and focused.
+## 2024-05-14 - Add loading spinner to long-running batchexecute operation
+**Learning:** In popups that perform API batch operations, simply changing button text to "Running..." without motion isn't enough visual feedback. Users may question whether the application has frozen during long operations, especially if progress logs take time to appear.
+**Action:** Always include an animated loading spinner (`aria-hidden="true"`) alongside loading text inside primary action buttons for operations that take more than a second to execute. Ensure the button uses a flex layout (`display: flex; align-items: center; gap: 8px;`) so the text and spinner remain properly aligned.

--- a/popup.css
+++ b/popup.css
@@ -146,7 +146,10 @@ input:focus-visible {
 }
 
 button.primary {
-  display: block;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
   width: 100%;
   padding: 8px;
   background: #4ade80;
@@ -243,4 +246,19 @@ button.secondary:hover {
 
 .summary .skipped {
   color: #fbbf24;
+}
+
+.spinner {
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgba(15, 23, 42, 0.3); /* match #0f172a */
+  border-radius: 50%;
+  border-top-color: #0f172a;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }

--- a/popup.js
+++ b/popup.js
@@ -112,7 +112,7 @@ startBtn.addEventListener('click', async () => {
 
   // Reset UI
   startBtn.disabled = true
-  startBtn.textContent = 'Running...'
+  startBtn.innerHTML = '<span class="spinner" aria-hidden="true"></span> Running...'
   resetBtn.style.display = 'none'
   progressSection.style.display = 'block'
   summarySection.style.display = 'none'
@@ -215,7 +215,7 @@ chrome.runtime.sendMessage({ action: 'GET_STATE' }, (state) => {
     renderState(state)
     if (state.status === 'running') {
       startBtn.disabled = true
-      startBtn.textContent = 'Running...'
+      startBtn.innerHTML = '<span class="spinner" aria-hidden="true"></span> Running...'
     } else {
       resetBtn.style.display = 'block'
     }


### PR DESCRIPTION
💡 What: Added an animated loading spinner to the primary Start button during long-running batch operations.
🎯 Why: In popups that perform API batch operations, simply changing button text to "Running..." without motion isn't enough visual feedback. Users may question whether the application has frozen during long operations, especially if progress logs take time to appear.
♿ Accessibility: Added `aria-hidden="true"` to the spinner element since the "Running..." text already conveys the state to screen readers.

---
*PR created automatically by Jules for task [17631723613934960008](https://jules.google.com/task/17631723613934960008) started by @n24q02m*