### PR TITLE
🛡️ Sentinel: [HIGH] Fix TOCTOU vulnerability in script injection

### DIFF
--- a/background.js
+++ b/background.js
@@ -16,7 +16,7 @@ function extractAccountNum(url) {
     const parts = new URL(url).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }
@@ -664,31 +664,28 @@ function getTabLabel(tab) {
 }
 
 async function ensureContentScript(tabId) {
-  const checkOrigin = async () => {
-    const tab = await chrome.tabs.get(tabId)
-    if (!tab.url) return false
-    try {
-      const url = new URL(tab.url)
-      return url.origin === JULES_ORIGIN
-    } catch {
-      return false
-    }
+  const frame = await chrome.webNavigation.getFrame({ tabId, frameId: 0 })
+  if (!frame) throw new Error('Could not get frame information')
+
+  let isValidOrigin = false
+  try {
+    const url = new URL(frame.url)
+    isValidOrigin = url.origin === JULES_ORIGIN
+  } catch {
+    isValidOrigin = false
   }
 
-  if (!(await checkOrigin())) {
+  if (!isValidOrigin) {
     throw new Error('Security Error: Cannot inject script into non-Jules tab')
   }
 
-  try {
-    await chrome.tabs.sendMessage(tabId, { action: 'PING' })
-  } catch {
-    // Re-verify immediately before injection to prevent TOCTOU
-    if (!(await checkOrigin())) {
-      throw new Error('Security Error: Cannot inject script into non-Jules tab')
-    }
+  const { documentId } = frame
 
+  try {
+    await chrome.tabs.sendMessage(tabId, { action: 'PING' }, { documentId })
+  } catch {
     await chrome.scripting.executeScript({
-      target: { tabId },
+      target: { tabId, documentIds: [documentId] },
       files: ['content.js']
     })
 
@@ -696,7 +693,7 @@ async function ensureContentScript(tabId) {
     while (Date.now() < deadline) {
       try {
         await new Promise((r) => setTimeout(r, 100))
-        await chrome.tabs.sendMessage(tabId, { action: 'PING' })
+        await chrome.tabs.sendMessage(tabId, { action: 'PING' }, { documentId })
         return
       } catch {
         // Keep waiting

--- a/content.js
+++ b/content.js
@@ -62,7 +62,7 @@ function getAccountNum() {
     const parts = new URL(location.href).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Jules Task Archiver",
   "version": "2.0.0",
   "description": "Bulk archive Jules tasks and start code suggestions via batchexecute API",
-  "permissions": ["storage", "tabs", "scripting"],
+  "permissions": ["storage", "tabs", "scripting", "webNavigation"],
   "host_permissions": ["https://jules.google.com/*", "https://api.github.com/*"],
   "background": {
     "service_worker": "background.js"

--- a/tests/security.test.js
+++ b/tests/security.test.js
@@ -132,7 +132,8 @@ function setupEnvironment(initialTabs = {}) {
         if (initialTabs[id]) return initialTabs[id]
         return { id, url: 'https://jules.google.com/u/0/' }
       },
-      sendMessage: async (_tabId, message) => {
+      sendMessage: async (_tabId, message, options) => {
+        chromeMock.tabs.lastSendMessage = { message, options }
         if (message.action === 'PING') {
           // Simulate script not loaded by throwing
           throw new Error('Could not establish connection. Receiving end does not exist.')
@@ -143,6 +144,12 @@ function setupEnvironment(initialTabs = {}) {
     scripting: {
       executeScript: async ({ target, files }) => {
         chromeMock.scripting.lastCall = { target, files }
+      }
+    },
+    webNavigation: {
+      getFrame: async ({ tabId }) => {
+        const tab = await chromeMock.tabs.get(tabId)
+        return { documentId: `doc${tabId}`, url: tab.url }
       }
     }
   }
@@ -195,11 +202,25 @@ describe('ensureContentScript Security', () => {
       return { id, url: 'https://evil.com/' }
     }
 
-    // This is expected to fail CURRENTLY because ensureContentScript doesn't re-check the URL
-    // We WANT it to fail to prove the vulnerability exists.
-    await assert.rejects(sandbox.test_ensureContentScript(123), {
-      message: /Security Error: Cannot inject script into non-Jules tab/
-    })
+    // The mock simulate injection by tracking executeScript target
+    let injected = false
+    chromeMock.tabs.sendMessage = async (_tabId, message, options) => {
+      chromeMock.tabs.lastSendMessage = { message, options }
+      if (message.action === 'PING') {
+        if (injected) return { status: 'ok' }
+        throw new Error('Not loaded')
+      }
+    }
+    chromeMock.scripting.executeScript = async ({ target, files }) => {
+      chromeMock.scripting.lastCall = { target, files }
+      injected = true
+    }
+
+    await sandbox.test_ensureContentScript(123)
+
+    // Verify pinning to documentId prevents TOCTOU
+    assert.strictEqual(chromeMock.scripting.lastCall.target.documentIds[0], 'doc123')
+    assert.strictEqual(chromeMock.tabs.lastSendMessage.options.documentId, 'doc123')
   })
 
   it('should allow injection into valid Jules origin', async () => {


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix TOCTOU vulnerability in script injection

**🚨 Severity:** HIGH
**💡 Vulnerability:** A Time-of-Check to Time-of-Use (TOCTOU) vulnerability existed in `background.js` where `ensureContentScript` validated the `tab.url` but then injected scripts and passed messages using only the `tabId`. This created a window where the tab could navigate to a malicious URL, and the script would inject into an unintended, untrusted context.
**🎯 Impact:** Content scripts intended for the trusted `jules.google.com` origin could be wrongfully injected into a malicious page, potentially leading to unauthorized data exposure or malicious manipulation within the trusted context bounds that the content script assumes.
**🔧 Fix:** Added the `"webNavigation"` permission and updated `ensureContentScript` to use `chrome.webNavigation.getFrame({ tabId, frameId: 0 })`. The extracted `documentId` is then pinned using the `documentIds` field in `chrome.scripting.executeScript` and `options.documentId` in `chrome.tabs.sendMessage`, effectively locking execution to the verified document, rendering navigation-based race conditions impossible.
**✅ Verification:** Handled by automated tests (`node --test tests/security.test.js`). The tests verify that passing the correct `documentId` strictly routes the script and messaging correctly in the DOM. Codebase linting and testing pass perfectly.

---
*PR created automatically by Jules for task [13162761856309036489](https://jules.google.com/task/13162761856309036489) started by @n24q02m*