### PR TITLE
🎨 Palette: Add loading spinner to Start button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2025-04-03 - Progressive Disclosure for Multi-Mode UIs
 **Learning:** In a multi-mode UI (like Archive vs Suggestions), showing all settings at once creates cognitive overload, especially when settings like GitHub tokens are only relevant to one mode.
 **Action:** Use progressive disclosure in `popup.js` to hide mode-specific settings (like the `.settings` section and `force` checkbox) when they are not relevant to the currently selected mode, keeping the UI clean and focused.
+## 2026-04-18 - Visual Feedback for Async Operations
+**Learning:** The UI lacked clear visual feedback during long-running background batch processes beyond text changes, making it seem unresponsive. Users need visual cues (like a spinner) to indicate active background processing in popup interfaces.
+**Action:** For async batch operations in UI popups, visually indicate background activity by adding an animated loading spinner (`<span class="spinner" aria-hidden="true"></span>`) inside the primary action button, utilizing a flexbox layout (`display: flex; gap: 8px;`) alongside the loading text (e.g., 'Running...').

--- a/popup.css
+++ b/popup.css
@@ -146,7 +146,10 @@ input:focus-visible {
 }
 
 button.primary {
-  display: block;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
   width: 100%;
   padding: 8px;
   background: #4ade80;
@@ -157,6 +160,22 @@ button.primary {
   font-weight: 600;
   cursor: pointer;
   margin-bottom: 12px;
+}
+
+.spinner {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgba(15, 23, 42, 0.3);
+  border-radius: 50%;
+  border-top-color: #0f172a;
+  animation: spin 1s ease-in-out infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 button.primary:hover {

--- a/popup.js
+++ b/popup.js
@@ -112,7 +112,7 @@ startBtn.addEventListener('click', async () => {
 
   // Reset UI
   startBtn.disabled = true
-  startBtn.textContent = 'Running...'
+  startBtn.innerHTML = '<span class="spinner" aria-hidden="true"></span>Running...'
   resetBtn.style.display = 'none'
   progressSection.style.display = 'block'
   summarySection.style.display = 'none'
@@ -215,7 +215,7 @@ chrome.runtime.sendMessage({ action: 'GET_STATE' }, (state) => {
     renderState(state)
     if (state.status === 'running') {
       startBtn.disabled = true
-      startBtn.textContent = 'Running...'
+      startBtn.innerHTML = '<span class="spinner" aria-hidden="true"></span>Running...'
     } else {
       resetBtn.style.display = 'block'
     }


### PR DESCRIPTION
💡 **What:** Added an animated loading spinner (CSS keyframes) to the Start button in `popup.js` and `popup.css` when the application is actively running a batch operation.

🎯 **Why:** The UI previously only changed the button text to "Running..." and disabled it, which didn't feel sufficiently responsive for async background processes. A spinner provides clear, intuitive visual feedback that the application is actively working, reducing user anxiety during long archive or start operations.

📸 **Before/After:**
*(Before)* Button simply read "Running...".
*(After)* Button reads "Running..." with a spinning visual indicator, aligned nicely using flexbox.

♿ **Accessibility:** The spinner `span` uses `aria-hidden="true"` so it doesn't redundantly announce to screen readers, as the button's text changing to "Running..." already conveys the state change.

---
*PR created automatically by Jules for task [16760239303756049864](https://jules.google.com/task/16760239303756049864) started by @n24q02m*