### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix TOCTOU vulnerability in script injection

### DIFF
--- a/background.js
+++ b/background.js
@@ -16,7 +16,7 @@ function extractAccountNum(url) {
     const parts = new URL(url).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }
@@ -664,39 +664,51 @@ function getTabLabel(tab) {
 }
 
 async function ensureContentScript(tabId) {
-  const checkOrigin = async () => {
-    const tab = await chrome.tabs.get(tabId)
-    if (!tab.url) return false
+  const checkOriginAndGetDocId = async () => {
     try {
-      const url = new URL(tab.url)
-      return url.origin === JULES_ORIGIN
+      const frame = await chrome.webNavigation.getFrame({ tabId, frameId: 0 })
+      if (!frame?.url || !frame.documentId) return { valid: false }
+
+      const url = new URL(frame.url)
+      if (url.origin !== JULES_ORIGIN) return { valid: false }
+
+      return { valid: true, documentId: frame.documentId }
     } catch {
-      return false
+      return { valid: false }
     }
   }
 
-  if (!(await checkOrigin())) {
+  const { valid, documentId } = await checkOriginAndGetDocId()
+  if (!valid || !documentId) {
     throw new Error('Security Error: Cannot inject script into non-Jules tab')
   }
 
+  const sendMessageOpts = { documentId }
+
   try {
-    await chrome.tabs.sendMessage(tabId, { action: 'PING' })
+    await chrome.tabs.sendMessage(tabId, { action: 'PING' }, sendMessageOpts)
   } catch {
     // Re-verify immediately before injection to prevent TOCTOU
-    if (!(await checkOrigin())) {
+    const recheck = await checkOriginAndGetDocId()
+    if (!recheck.valid || !recheck.documentId) {
       throw new Error('Security Error: Cannot inject script into non-Jules tab')
     }
 
+    // Use the potentially updated documentId
+    const currentDocId = recheck.documentId
+    const target = { tabId, documentIds: [currentDocId] }
+
     await chrome.scripting.executeScript({
-      target: { tabId },
+      target,
       files: ['content.js']
     })
 
+    const newSendMessageOpts = { documentId: currentDocId }
     const deadline = Date.now() + 3000
     while (Date.now() < deadline) {
       try {
         await new Promise((r) => setTimeout(r, 100))
-        await chrome.tabs.sendMessage(tabId, { action: 'PING' })
+        await chrome.tabs.sendMessage(tabId, { action: 'PING' }, newSendMessageOpts)
         return
       } catch {
         // Keep waiting

--- a/content.js
+++ b/content.js
@@ -62,7 +62,7 @@ function getAccountNum() {
     const parts = new URL(location.href).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Jules Task Archiver",
   "version": "2.0.0",
   "description": "Bulk archive Jules tasks and start code suggestions via batchexecute API",
-  "permissions": ["storage", "tabs", "scripting"],
+  "permissions": ["storage", "tabs", "scripting", "webNavigation"],
   "host_permissions": ["https://jules.google.com/*", "https://api.github.com/*"],
   "background": {
     "service_worker": "background.js"

--- a/tests/security.test.js
+++ b/tests/security.test.js
@@ -144,6 +144,12 @@ function setupEnvironment(initialTabs = {}) {
       executeScript: async ({ target, files }) => {
         chromeMock.scripting.lastCall = { target, files }
       }
+    },
+    webNavigation: {
+      getFrame: async ({ tabId, _frameId }) => {
+        const tab = await chromeMock.tabs.get(tabId)
+        return { documentId: `doc-${tabId}`, url: tab.url }
+      }
     }
   }
 


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** A Time-of-Check to Time-of-Use (TOCTOU) race condition in `ensureContentScript` where the tab URL could change to an untrusted origin between the initial check and the execution of the content script.
🎯 **Impact:** An attacker controlling the page could navigate the tab after verification but before script injection, causing the extension to inject `content.js` (and securely transmit messages) into a potentially malicious origin.
🔧 **Fix:** Refactored the origin check to use `chrome.webNavigation.getFrame` which returns the specific `documentId` corresponding to the verified URL. Both `executeScript` and `sendMessage` are now pinned to this `documentId`, guaranteeing the payload is only delivered to the exact, trusted document instance that was verified. Added the `webNavigation` permission to `manifest.json` to enable this capability.
✅ **Verification:** Run `pnpm test` to verify the security tests (which previously failed on the TOCTOU check) now pass correctly by throwing a security error when the URL changes. Run `pnpm lint` to verify code quality.

---
*PR created automatically by Jules for task [7112696120321893403](https://jules.google.com/task/7112696120321893403) started by @n24q02m*