### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix TOCTOU vulnerability in content script injection

### DIFF
--- a/background.js
+++ b/background.js
@@ -16,7 +16,7 @@ function extractAccountNum(url) {
     const parts = new URL(url).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }
@@ -664,31 +664,35 @@ function getTabLabel(tab) {
 }
 
 async function ensureContentScript(tabId) {
-  const checkOrigin = async () => {
-    const tab = await chrome.tabs.get(tabId)
-    if (!tab.url) return false
+  const getDocumentId = async () => {
+    const frame = await chrome.webNavigation.getFrame({ tabId, frameId: 0 })
+    if (!frame?.url) return null
     try {
-      const url = new URL(tab.url)
-      return url.origin === JULES_ORIGIN
+      const url = new URL(frame.url)
+      if (url.origin !== JULES_ORIGIN) return null
+      return frame.documentId
     } catch {
-      return false
+      return null
     }
   }
 
-  if (!(await checkOrigin())) {
+  const documentId = await getDocumentId()
+  if (!documentId) {
     throw new Error('Security Error: Cannot inject script into non-Jules tab')
   }
 
   try {
-    await chrome.tabs.sendMessage(tabId, { action: 'PING' })
+    await chrome.tabs.sendMessage(tabId, { action: 'PING' }, { documentId })
+    return documentId
   } catch {
     // Re-verify immediately before injection to prevent TOCTOU
-    if (!(await checkOrigin())) {
+    const currentDocId = await getDocumentId()
+    if (!currentDocId || currentDocId !== documentId) {
       throw new Error('Security Error: Cannot inject script into non-Jules tab')
     }
 
     await chrome.scripting.executeScript({
-      target: { tabId },
+      target: { tabId, documentIds: [documentId] },
       files: ['content.js']
     })
 
@@ -696,8 +700,8 @@ async function ensureContentScript(tabId) {
     while (Date.now() < deadline) {
       try {
         await new Promise((r) => setTimeout(r, 100))
-        await chrome.tabs.sendMessage(tabId, { action: 'PING' })
-        return
+        await chrome.tabs.sendMessage(tabId, { action: 'PING' }, { documentId })
+        return documentId
       } catch {
         // Keep waiting
       }
@@ -707,8 +711,8 @@ async function ensureContentScript(tabId) {
 }
 
 async function getTabConfig(tabId) {
-  await ensureContentScript(tabId)
-  const response = await chrome.tabs.sendMessage(tabId, { action: 'GET_CONFIG' })
+  const documentId = await ensureContentScript(tabId)
+  const response = await chrome.tabs.sendMessage(tabId, { action: 'GET_CONFIG' }, { documentId })
   if (!response?.config?.at) {
     throw new Error('Could not extract page config (XSRF token missing). Try refreshing the Jules tab.')
   }

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/content.js
+++ b/content.js
@@ -41,7 +41,7 @@ function extractConfig() {
 
   return new Promise((resolve) => {
     // Ask main-world.js to re-broadcast config
-    window.postMessage({ type: 'JULES_REQUEST_CONFIG' }, '*')
+    window.postMessage({ type: 'JULES_REQUEST_CONFIG' }, window.origin)
 
     const timeout = setTimeout(() => resolve(cachedConfig), 2000)
     const handler = (event) => {
@@ -62,7 +62,7 @@ function getAccountNum() {
     const parts = new URL(location.href).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }

--- a/main-world.js
+++ b/main-world.js
@@ -26,7 +26,7 @@ function broadcastConfig() {
           }
         : null
     },
-    '*'
+    window.origin
   )
 }
 
@@ -54,7 +54,7 @@ if (!window.__julesArchiver) {
               capturedAt: Date.now()
             }
           },
-          '*'
+          window.origin
         )
       } catch (_e) {
         /* ignore parse errors */

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Jules Task Archiver",
   "version": "2.0.0",
   "description": "Bulk archive Jules tasks and start code suggestions via batchexecute API",
-  "permissions": ["storage", "tabs", "scripting"],
+  "permissions": ["storage", "tabs", "scripting", "webNavigation"],
   "host_permissions": ["https://jules.google.com/*", "https://api.github.com/*"],
   "background": {
     "service_worker": "background.js"

--- a/tests/security.test.js
+++ b/tests/security.test.js
@@ -127,12 +127,17 @@ function setupEnvironment(initialTabs = {}) {
       onMessage: { addListener: () => {} },
       getPlatformInfo: async () => ({})
     },
+    webNavigation: {
+      getFrame: async ({ tabId }) => {
+        const tabInfo = initialTabs[tabId] || { id: tabId, url: 'https://jules.google.com/u/0/' }
+        return { documentId: `doc-${tabId}`, url: tabInfo.url }
+      }
+    },
     tabs: {
-      get: async (id) => {
-        if (initialTabs[id]) return initialTabs[id]
-        return { id, url: 'https://jules.google.com/u/0/' }
-      },
-      sendMessage: async (_tabId, message) => {
+      sendMessage: async (_tabId, message, options) => {
+        if (!options?.documentId) {
+          throw new Error('Missing documentId in sendMessage')
+        }
         if (message.action === 'PING') {
           // Simulate script not loaded by throwing
           throw new Error('Could not establish connection. Receiving end does not exist.')
@@ -142,6 +147,9 @@ function setupEnvironment(initialTabs = {}) {
     },
     scripting: {
       executeScript: async ({ target, files }) => {
+        if (!target.documentIds || target.documentIds.length === 0) {
+          throw new Error('Missing documentIds in executeScript')
+        }
         chromeMock.scripting.lastCall = { target, files }
       }
     }
@@ -187,35 +195,52 @@ describe('ensureContentScript Security', () => {
     const { sandbox, chromeMock } = setupEnvironment()
 
     let callCount = 0
-    chromeMock.tabs.get = async (id) => {
+    chromeMock.webNavigation.getFrame = async ({ tabId }) => {
       callCount++
       if (callCount === 1) {
-        return { id, url: 'https://jules.google.com/u/0/' }
+        return { documentId: `doc-${tabId}`, url: 'https://jules.google.com/u/0/' }
       }
-      return { id, url: 'https://evil.com/' }
+      return { documentId: `doc-evil-${tabId}`, url: 'https://evil.com/' }
     }
 
-    // This is expected to fail CURRENTLY because ensureContentScript doesn't re-check the URL
-    // We WANT it to fail to prove the vulnerability exists.
     await assert.rejects(sandbox.test_ensureContentScript(123), {
       message: /Security Error: Cannot inject script into non-Jules tab/
     })
   })
 
-  it('should allow injection into valid Jules origin', async () => {
+  it('should block injection if documentId changes (TOCTOU)', async () => {
+    const { sandbox, chromeMock } = setupEnvironment()
+
+    let callCount = 0
+    chromeMock.webNavigation.getFrame = async ({ tabId }) => {
+      callCount++
+      if (callCount === 1) {
+        return { documentId: `doc1-${tabId}`, url: 'https://jules.google.com/u/0/' }
+      }
+      return { documentId: `doc2-${tabId}`, url: 'https://jules.google.com/u/0/' }
+    }
+
+    await assert.rejects(sandbox.test_ensureContentScript(123), {
+      message: /Security Error: Cannot inject script into non-Jules tab/
+    })
+  })
+
+  it('should allow injection into valid Jules origin with pinned documentId', async () => {
     const { sandbox, chromeMock } = setupEnvironment({
       456: { id: 456, url: 'https://jules.google.com/u/1/' }
     })
 
     // Mock successful sendMessage after injection to stop the loop
     let injected = false
-    chromeMock.tabs.sendMessage = async (_tabId, message) => {
+    chromeMock.tabs.sendMessage = async (_tabId, message, options) => {
+      assert.strictEqual(options.documentId, 'doc-456', 'Should use pinned documentId')
       if (message.action === 'PING') {
         if (injected) return { status: 'ok' }
         throw new Error('Not loaded')
       }
     }
-    chromeMock.scripting.executeScript = async () => {
+    chromeMock.scripting.executeScript = async (params) => {
+      if (params.target.documentIds[0] !== 'doc-456') throw new Error('Assertion Failed')
       injected = true
     }
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A Time-of-Check to Time-of-Use (TOCTOU) vulnerability existed in `ensureContentScript` within `background.js`. While it checked if the tab's URL was `JULES_ORIGIN`, a tab could navigate to a different origin before the script injection actually completed, leading to the privileged content script being injected into an untrusted site. Furthermore, `window.postMessage` in `content.js` and `main-world.js` used the wildcard origin `'*'` which could leak sensitive tokens if untrusted origins listened for them.
🎯 Impact: Privileged extension scripts and internal API tokens (like XSRF tokens or Model IDs) could be intercepted and abused by malicious webpages leading to complete account compromise.
🔧 Fix: Added the `webNavigation` permission to `manifest.json` and updated `ensureContentScript` to retrieve a `documentId` using `chrome.webNavigation.getFrame`. The injection (`chrome.scripting.executeScript`) and messaging (`chrome.tabs.sendMessage`) are now pinned to this specific `documentId`, preventing execution if the page navigates. Additionally, updated `window.postMessage` to use `window.origin` instead of `'*'`.
✅ Verification: Ran `pnpm test` and `node --test tests/security.test.js` to verify test passes, updated tests to mock `webNavigation` and assert `documentId` usage.

---
*PR created automatically by Jules for task [3201133139347869192](https://jules.google.com/task/3201133139347869192) started by @n24q02m*