### PR TITLE
🛡️ Sentinel: HIGH Fix TOCTOU vulnerability in content script injection

### DIFF
--- a/background.js
+++ b/background.js
@@ -16,7 +16,7 @@ function extractAccountNum(url) {
     const parts = new URL(url).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }
@@ -664,31 +664,36 @@ function getTabLabel(tab) {
 }
 
 async function ensureContentScript(tabId) {
-  const checkOrigin = async () => {
-    const tab = await chrome.tabs.get(tabId)
-    if (!tab.url) return false
+  const getFrameInfo = async () => {
     try {
-      const url = new URL(tab.url)
-      return url.origin === JULES_ORIGIN
+      const frame = await chrome.webNavigation.getFrame({ tabId, frameId: 0 })
+      if (!frame?.url) return null
+      const url = new URL(frame.url)
+      if (url.origin === JULES_ORIGIN) {
+        return frame.documentId
+      }
+      return null
     } catch {
-      return false
+      return null
     }
   }
 
-  if (!(await checkOrigin())) {
+  let docId = await getFrameInfo()
+  if (!docId) {
     throw new Error('Security Error: Cannot inject script into non-Jules tab')
   }
 
   try {
-    await chrome.tabs.sendMessage(tabId, { action: 'PING' })
+    await chrome.tabs.sendMessage(tabId, { action: 'PING' }, { documentId: docId })
   } catch {
     // Re-verify immediately before injection to prevent TOCTOU
-    if (!(await checkOrigin())) {
+    docId = await getFrameInfo()
+    if (!docId) {
       throw new Error('Security Error: Cannot inject script into non-Jules tab')
     }
 
     await chrome.scripting.executeScript({
-      target: { tabId },
+      target: { tabId, documentIds: [docId] },
       files: ['content.js']
     })
 
@@ -696,7 +701,7 @@ async function ensureContentScript(tabId) {
     while (Date.now() < deadline) {
       try {
         await new Promise((r) => setTimeout(r, 100))
-        await chrome.tabs.sendMessage(tabId, { action: 'PING' })
+        await chrome.tabs.sendMessage(tabId, { action: 'PING' }, { documentId: docId })
         return
       } catch {
         // Keep waiting

--- a/content.js
+++ b/content.js
@@ -62,7 +62,7 @@ function getAccountNum() {
     const parts = new URL(location.href).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Jules Task Archiver",
   "version": "2.0.0",
   "description": "Bulk archive Jules tasks and start code suggestions via batchexecute API",
-  "permissions": ["storage", "tabs", "scripting"],
+  "permissions": ["storage", "tabs", "scripting", "webNavigation"],
   "host_permissions": ["https://jules.google.com/*", "https://api.github.com/*"],
   "background": {
     "service_worker": "background.js"

--- a/tests/security.test.js
+++ b/tests/security.test.js
@@ -127,12 +127,22 @@ function setupEnvironment(initialTabs = {}) {
       onMessage: { addListener: () => {} },
       getPlatformInfo: async () => ({})
     },
+    webNavigation: {
+      getFrame: async ({ tabId, frameId }) => {
+        if (frameId !== 0) return null
+        const tab = initialTabs[tabId] || { id: tabId, url: 'https://jules.google.com/u/0/' }
+        return { documentId: `doc-${tabId}`, url: tab.url }
+      }
+    },
     tabs: {
       get: async (id) => {
         if (initialTabs[id]) return initialTabs[id]
         return { id, url: 'https://jules.google.com/u/0/' }
       },
-      sendMessage: async (_tabId, message) => {
+      sendMessage: async (_tabId, message, options) => {
+        if (options?.documentId) {
+          chromeMock.tabs.lastSendMessageDocumentId = options.documentId
+        }
         if (message.action === 'PING') {
           // Simulate script not loaded by throwing
           throw new Error('Could not establish connection. Receiving end does not exist.')
@@ -187,16 +197,15 @@ describe('ensureContentScript Security', () => {
     const { sandbox, chromeMock } = setupEnvironment()
 
     let callCount = 0
-    chromeMock.tabs.get = async (id) => {
+    chromeMock.webNavigation.getFrame = async ({ tabId, frameId }) => {
+      if (frameId !== 0) return null
       callCount++
       if (callCount === 1) {
-        return { id, url: 'https://jules.google.com/u/0/' }
+        return { documentId: `doc-${tabId}`, url: 'https://jules.google.com/u/0/' }
       }
-      return { id, url: 'https://evil.com/' }
+      return { documentId: `doc-evil-${tabId}`, url: 'https://evil.com/' }
     }
 
-    // This is expected to fail CURRENTLY because ensureContentScript doesn't re-check the URL
-    // We WANT it to fail to prove the vulnerability exists.
     await assert.rejects(sandbox.test_ensureContentScript(123), {
       message: /Security Error: Cannot inject script into non-Jules tab/
     })
@@ -209,17 +218,23 @@ describe('ensureContentScript Security', () => {
 
     // Mock successful sendMessage after injection to stop the loop
     let injected = false
-    chromeMock.tabs.sendMessage = async (_tabId, message) => {
+    chromeMock.tabs.sendMessage = async (_tabId, message, options) => {
+      if (options?.documentId) {
+        chromeMock.tabs.lastSendMessageDocumentId = options.documentId
+      }
       if (message.action === 'PING') {
         if (injected) return { status: 'ok' }
         throw new Error('Not loaded')
       }
     }
-    chromeMock.scripting.executeScript = async () => {
+    chromeMock.scripting.executeScript = async ({ target, files }) => {
+      chromeMock.scripting.lastCall = { target, files }
       injected = true
     }
 
     await sandbox.test_ensureContentScript(456)
     assert.strictEqual(injected, true)
+    assert.strictEqual(chromeMock.tabs.lastSendMessageDocumentId, 'doc-456')
+    assert.strictEqual(chromeMock.scripting.lastCall.target.documentIds[0], 'doc-456')
   })
 })


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** A Time-Of-Check to Time-Of-Use (TOCTOU) vulnerability in `ensureContentScript` allowed a potential race condition. The extension checked a tab's URL (`chrome.tabs.get`) and subsequently injected a content script into it. If the tab quickly navigated to a different site between the check and injection, the script could be injected into an untrusted page.
🎯 **Impact:** If exploited, this could allow the extension's sensitive content scripts to run on non-Jules origins, potentially exposing extension privileges or messages to unauthorized, malicious sites.
🔧 **Fix:** Replaced the URL check pattern with `chrome.webNavigation.getFrame` to acquire a stable `documentId`. The script injection (`chrome.scripting.executeScript`) and message passing (`chrome.tabs.sendMessage`) are now explicitly pinned to this `documentId`, guaranteeing execution only occurs in the initially verified document. Required adding the `webNavigation` permission to `manifest.json`.
✅ **Verification:** Updated the existing `node:vm` sandbox tests in `tests/security.test.js` to correctly mock `chrome.webNavigation.getFrame` and assert that the `documentId` constraints are utilized effectively. All tests pass.

---
*PR created automatically by Jules for task [13429594001883265632](https://jules.google.com/task/13429594001883265632) started by @n24q02m*