### PR TITLE
🛡️ Sentinel: [HIGH] Fix cross-origin messaging vulnerability

### DIFF
--- a/background.js
+++ b/background.js
@@ -16,7 +16,7 @@ function extractAccountNum(url) {
     const parts = new URL(url).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }

--- a/content.js
+++ b/content.js
@@ -20,7 +20,7 @@ injectMainWorldScript()
 
 // Listen for messages from MAIN world script
 window.addEventListener('message', (event) => {
-  if (event.source !== window) return
+  if (event.source !== window || event.origin !== window.origin) return
   if (event.data?.type === 'JULES_ARCHIVER_CONFIG') {
     cachedConfig = event.data.config
   }
@@ -41,11 +41,11 @@ function extractConfig() {
 
   return new Promise((resolve) => {
     // Ask main-world.js to re-broadcast config
-    window.postMessage({ type: 'JULES_REQUEST_CONFIG' }, '*')
+    window.postMessage({ type: 'JULES_REQUEST_CONFIG' }, window.origin)
 
     const timeout = setTimeout(() => resolve(cachedConfig), 2000)
     const handler = (event) => {
-      if (event.source !== window) return
+      if (event.source !== window || event.origin !== window.origin) return
       if (event.data?.type !== 'JULES_ARCHIVER_CONFIG') return
       window.removeEventListener('message', handler)
       clearTimeout(timeout)
@@ -62,7 +62,7 @@ function getAccountNum() {
     const parts = new URL(location.href).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }

--- a/main-world.js
+++ b/main-world.js
@@ -26,7 +26,7 @@ function broadcastConfig() {
           }
         : null
     },
-    '*'
+    window.origin
   )
 }
 
@@ -54,7 +54,7 @@ if (!window.__julesArchiver) {
               capturedAt: Date.now()
             }
           },
-          '*'
+          window.origin
         )
       } catch (_e) {
         /* ignore parse errors */
@@ -69,7 +69,7 @@ broadcastConfig()
 
 // Also listen for explicit re-extract requests from content.js
 window.addEventListener('message', (event) => {
-  if (event.source !== window) return
+  if (event.source !== window || event.origin !== window.origin) return
   if (event.data?.type === 'JULES_REQUEST_CONFIG') {
     broadcastConfig()
   }


### PR DESCRIPTION
🚨 **Severity**: HIGH

💡 **Vulnerability**: The application was using the wildcard `'*'` as the target origin in `window.postMessage` calls within `main-world.js` and `content.js` to transmit sensitive data between the main world and isolated worlds. The receivers were checking `event.source === window` but failing to verify `event.origin === window.origin`.

🎯 **Impact**: Using a wildcard `'*'` target origin allows any document (including untrusted iframes) to intercept the message if it happens to be the window being messaged. Since this extension passes sensitive tokens (`WIZ_global_data`, `StartSuggestion` payloads), this could result in token leakage or cross-origin messaging attacks.

🔧 **Fix**: Always use a specific target origin (`window.origin`) when transmitting sensitive data via `window.postMessage`. Ensured receivers verify both `event.source === window` and `event.origin === window.origin` to explicitly drop messages originating from other domains.

✅ **Verification**:
- Verified the code changes in `main-world.js` and `content.js` strictly use `window.origin`.
- Successfully ran the test suite (`pnpm test`).
- Enforced formatting and linting (`npx @biomejs/biome check --write --unsafe`).
- Created and updated the `.Jules/sentinel.md` journal file.

---
*PR created automatically by Jules for task [13219568006915752960](https://jules.google.com/task/13219568006915752960) started by @n24q02m*