### PR TITLE
🎨 Palette: Add loading spinner to async start button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2025-04-03 - Progressive Disclosure for Multi-Mode UIs
 **Learning:** In a multi-mode UI (like Archive vs Suggestions), showing all settings at once creates cognitive overload, especially when settings like GitHub tokens are only relevant to one mode.
 **Action:** Use progressive disclosure in `popup.js` to hide mode-specific settings (like the `.settings` section and `force` checkbox) when they are not relevant to the currently selected mode, keeping the UI clean and focused.
+## 2024-05-18 - Visual Feedback for Async Operations
+**Learning:** Adding a subtle, animated visual indicator (like a loading spinner) alongside text changes (e.g., changing "Start" to "Running...") during asynchronous operations significantly improves perceived responsiveness and reassures the user that background tasks are executing, especially in Chrome extension popups where native browser feedback mechanisms are often absent. Flexbox layout combined with `gap` provides clean, consistent alignment for such elements.
+**Action:** When implementing or reviewing buttons that trigger asynchronous actions, always ensure a distinct visual state change occurs. Use flexbox on the button to easily integrate an animated icon (like a CSS spinner) next to the status text.

--- a/background.js
+++ b/background.js
@@ -16,7 +16,7 @@ function extractAccountNum(url) {
     const parts = new URL(url).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/content.js
+++ b/content.js
@@ -62,7 +62,7 @@ function getAccountNum() {
     const parts = new URL(location.href).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }

--- a/popup.css
+++ b/popup.css
@@ -146,7 +146,10 @@ input:focus-visible {
 }
 
 button.primary {
-  display: block;
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  align-items: center;
   width: 100%;
   padding: 8px;
   background: #4ade80;
@@ -243,4 +246,19 @@ button.secondary:hover {
 
 .summary .skipped {
   color: #fbbf24;
+}
+
+.spinner {
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgba(15, 23, 42, 0.3);
+  border-top-color: #0f172a;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }

--- a/popup.js
+++ b/popup.js
@@ -112,7 +112,7 @@ startBtn.addEventListener('click', async () => {
 
   // Reset UI
   startBtn.disabled = true
-  startBtn.textContent = 'Running...'
+  startBtn.innerHTML = '<span class="spinner" aria-hidden="true"></span>Running...'
   resetBtn.style.display = 'none'
   progressSection.style.display = 'block'
   summarySection.style.display = 'none'
@@ -215,7 +215,7 @@ chrome.runtime.sendMessage({ action: 'GET_STATE' }, (state) => {
     renderState(state)
     if (state.status === 'running') {
       startBtn.disabled = true
-      startBtn.textContent = 'Running...'
+      startBtn.innerHTML = '<span class="spinner" aria-hidden="true"></span>Running...'
     } else {
       resetBtn.style.display = 'block'
     }


### PR DESCRIPTION
### 💡 What
Added a visual, animated CSS spinner inside the primary "Start" button while it is in the `Running...` state during asynchronous background operations. Fixed minor Biome linter warnings in `background.js` and `content.js` regarding unused catch variables.

### 🎯 Why
Chrome extension popups lack native browser feedback loops for asynchronous tasks (e.g. no favicon spinning). Users benefit greatly from a direct, animated visual indicator next to text changes, assuring them the background operation hasn't hung.

### 📸 Before/After
*Before:* Button simply changes text to `Running...`.
*After:* Button changes to `<spinner> Running...` using Flexbox layout to maintain perfect alignment. (Verified via visual Playwright test).

### ♿ Accessibility
The spinner span includes `aria-hidden="true"` so that screen readers continue to only read the status text ("Running...") and are not interrupted by meaningless DOM elements.

---
*PR created automatically by Jules for task [16799995694885927360](https://jules.google.com/task/16799995694885927360) started by @n24q02m*