### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix TOCTOU vulnerability in script injection

### DIFF
--- a/background.js
+++ b/background.js
@@ -16,7 +16,7 @@ function extractAccountNum(url) {
     const parts = new URL(url).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }
@@ -664,31 +664,37 @@ function getTabLabel(tab) {
 }
 
 async function ensureContentScript(tabId) {
-  const checkOrigin = async () => {
-    const tab = await chrome.tabs.get(tabId)
-    if (!tab.url) return false
+  const getFrameData = async () => {
     try {
-      const url = new URL(tab.url)
-      return url.origin === JULES_ORIGIN
+      const frame = await chrome.webNavigation.getFrame({ tabId, frameId: 0 })
+      if (!frame?.url || !frame.documentId) return null
+      const url = new URL(frame.url)
+      if (url.origin === JULES_ORIGIN) {
+        return frame.documentId
+      }
+      return null
     } catch {
-      return false
+      return null
     }
   }
 
-  if (!(await checkOrigin())) {
+  let documentId = await getFrameData()
+  if (!documentId) {
     throw new Error('Security Error: Cannot inject script into non-Jules tab')
   }
 
   try {
-    await chrome.tabs.sendMessage(tabId, { action: 'PING' })
+    await chrome.tabs.sendMessage(tabId, { action: 'PING' }, { documentId })
+    return documentId
   } catch {
     // Re-verify immediately before injection to prevent TOCTOU
-    if (!(await checkOrigin())) {
+    documentId = await getFrameData()
+    if (!documentId) {
       throw new Error('Security Error: Cannot inject script into non-Jules tab')
     }
 
     await chrome.scripting.executeScript({
-      target: { tabId },
+      target: { tabId, documentIds: [documentId] },
       files: ['content.js']
     })
 
@@ -696,8 +702,8 @@ async function ensureContentScript(tabId) {
     while (Date.now() < deadline) {
       try {
         await new Promise((r) => setTimeout(r, 100))
-        await chrome.tabs.sendMessage(tabId, { action: 'PING' })
-        return
+        await chrome.tabs.sendMessage(tabId, { action: 'PING' }, { documentId })
+        return documentId
       } catch {
         // Keep waiting
       }
@@ -707,8 +713,8 @@ async function ensureContentScript(tabId) {
 }
 
 async function getTabConfig(tabId) {
-  await ensureContentScript(tabId)
-  const response = await chrome.tabs.sendMessage(tabId, { action: 'GET_CONFIG' })
+  const documentId = await ensureContentScript(tabId)
+  const response = await chrome.tabs.sendMessage(tabId, { action: 'GET_CONFIG' }, { documentId })
   if (!response?.config?.at) {
     throw new Error('Could not extract page config (XSRF token missing). Try refreshing the Jules tab.')
   }

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Jules Task Archiver",
   "version": "2.0.0",
   "description": "Bulk archive Jules tasks and start code suggestions via batchexecute API",
-  "permissions": ["storage", "tabs", "scripting"],
+  "permissions": ["storage", "tabs", "scripting", "webNavigation"],
   "host_permissions": ["https://jules.google.com/*", "https://api.github.com/*"],
   "background": {
     "service_worker": "background.js"

--- a/tests/security.test.js
+++ b/tests/security.test.js
@@ -132,12 +132,21 @@ function setupEnvironment(initialTabs = {}) {
         if (initialTabs[id]) return initialTabs[id]
         return { id, url: 'https://jules.google.com/u/0/' }
       },
-      sendMessage: async (_tabId, message) => {
+      sendMessage: async (_tabId, message, _options) => {
         if (message.action === 'PING') {
           // Simulate script not loaded by throwing
           throw new Error('Could not establish connection. Receiving end does not exist.')
         }
         return {}
+      }
+    },
+    webNavigation: {
+      getFrame: async ({ tabId, frameId }) => {
+        if (frameId !== 0) return null
+        const tab = initialTabs[tabId] || { id: tabId, url: 'https://jules.google.com/u/0/' }
+        if (!tab.url) return null
+        // mock a consistent documentId for the url
+        return { url: tab.url, documentId: `doc-${tabId}-${tab.url}` }
       }
     },
     scripting: {
@@ -187,16 +196,14 @@ describe('ensureContentScript Security', () => {
     const { sandbox, chromeMock } = setupEnvironment()
 
     let callCount = 0
-    chromeMock.tabs.get = async (id) => {
+    chromeMock.webNavigation.getFrame = async ({ tabId }) => {
       callCount++
       if (callCount === 1) {
-        return { id, url: 'https://jules.google.com/u/0/' }
+        return { url: 'https://jules.google.com/u/0/', documentId: `doc-${tabId}-jules` }
       }
-      return { id, url: 'https://evil.com/' }
+      return { url: 'https://evil.com/', documentId: `doc-${tabId}-evil` }
     }
 
-    // This is expected to fail CURRENTLY because ensureContentScript doesn't re-check the URL
-    // We WANT it to fail to prove the vulnerability exists.
     await assert.rejects(sandbox.test_ensureContentScript(123), {
       message: /Security Error: Cannot inject script into non-Jules tab/
     })


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** A Time-of-Check to Time-of-Use (TOCTOU) vulnerability where the URL of a tab was validated, but the tab could navigate to a malicious site by the time the content script was injected or messaged. 
🎯 **Impact:** If exploited, an attacker could spoof origins or intercept scripts by navigating the tab maliciously in between the extension's checks, potentially compromising the extension.
🔧 **Fix:** Utilized `chrome.webNavigation.getFrame` to acquire the explicit `documentId` for the verified URL. Both `chrome.scripting.executeScript` and `chrome.tabs.sendMessage` were updated to strictly use `documentId` to guarantee that code execution only occurs on the specific, verified document instance.
✅ **Verification:** Verified by unit tests mock modifications testing the TOCTOU flaw explicitly, all tests pass successfully. Code linted via Biome.

---
*PR created automatically by Jules for task [12554544411232778261](https://jules.google.com/task/12554544411232778261) started by @n24q02m*