### PR TITLE
🛡️ Sentinel: [HIGH] Fix TOCTOU vulnerability in script injection

### DIFF
--- a/background.js
+++ b/background.js
@@ -16,7 +16,7 @@ function extractAccountNum(url) {
     const parts = new URL(url).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }
@@ -664,31 +664,36 @@ function getTabLabel(tab) {
 }
 
 async function ensureContentScript(tabId) {
-  const checkOrigin = async () => {
-    const tab = await chrome.tabs.get(tabId)
-    if (!tab.url) return false
+  const getSafeDocumentId = async () => {
     try {
-      const url = new URL(tab.url)
-      return url.origin === JULES_ORIGIN
+      const frame = await chrome.webNavigation.getFrame({ tabId, frameId: 0 })
+      if (!frame?.url) return null
+      const url = new URL(frame.url)
+      if (url.origin === JULES_ORIGIN) {
+        return frame.documentId
+      }
     } catch {
-      return false
+      return null
     }
+    return null
   }
 
-  if (!(await checkOrigin())) {
+  const documentId = await getSafeDocumentId()
+  if (!documentId) {
     throw new Error('Security Error: Cannot inject script into non-Jules tab')
   }
 
   try {
-    await chrome.tabs.sendMessage(tabId, { action: 'PING' })
+    await chrome.tabs.sendMessage(tabId, { action: 'PING' }, { documentId })
   } catch {
     // Re-verify immediately before injection to prevent TOCTOU
-    if (!(await checkOrigin())) {
+    const newDocId = await getSafeDocumentId()
+    if (!newDocId || newDocId !== documentId) {
       throw new Error('Security Error: Cannot inject script into non-Jules tab')
     }
 
     await chrome.scripting.executeScript({
-      target: { tabId },
+      target: { tabId, documentIds: [documentId] },
       files: ['content.js']
     })
 
@@ -696,7 +701,7 @@ async function ensureContentScript(tabId) {
     while (Date.now() < deadline) {
       try {
         await new Promise((r) => setTimeout(r, 100))
-        await chrome.tabs.sendMessage(tabId, { action: 'PING' })
+        await chrome.tabs.sendMessage(tabId, { action: 'PING' }, { documentId })
         return
       } catch {
         // Keep waiting

--- a/content.js
+++ b/content.js
@@ -62,7 +62,7 @@ function getAccountNum() {
     const parts = new URL(location.href).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Jules Task Archiver",
   "version": "2.0.0",
   "description": "Bulk archive Jules tasks and start code suggestions via batchexecute API",
-  "permissions": ["storage", "tabs", "scripting"],
+  "permissions": ["storage", "tabs", "scripting", "webNavigation"],
   "host_permissions": ["https://jules.google.com/*", "https://api.github.com/*"],
   "background": {
     "service_worker": "background.js"

--- a/tests/security.test.js
+++ b/tests/security.test.js
@@ -127,12 +127,20 @@ function setupEnvironment(initialTabs = {}) {
       onMessage: { addListener: () => {} },
       getPlatformInfo: async () => ({})
     },
+    webNavigation: {
+      getFrame: async ({ tabId, frameId }) => {
+        if (frameId !== 0) return null
+        const tab = initialTabs[tabId] || { id: tabId, url: 'https://jules.google.com/u/0/' }
+        return { documentId: `doc-${tabId}`, url: tab.url }
+      }
+    },
     tabs: {
       get: async (id) => {
         if (initialTabs[id]) return initialTabs[id]
         return { id, url: 'https://jules.google.com/u/0/' }
       },
-      sendMessage: async (_tabId, message) => {
+      sendMessage: async (_tabId, message, options) => {
+        if (!options?.documentId) throw new Error('Missing documentId')
         if (message.action === 'PING') {
           // Simulate script not loaded by throwing
           throw new Error('Could not establish connection. Receiving end does not exist.')
@@ -142,6 +150,7 @@ function setupEnvironment(initialTabs = {}) {
     },
     scripting: {
       executeScript: async ({ target, files }) => {
+        if (!target.documentIds || target.documentIds.length === 0) throw new Error('Missing documentIds')
         chromeMock.scripting.lastCall = { target, files }
       }
     }
@@ -187,16 +196,14 @@ describe('ensureContentScript Security', () => {
     const { sandbox, chromeMock } = setupEnvironment()
 
     let callCount = 0
-    chromeMock.tabs.get = async (id) => {
+    chromeMock.webNavigation.getFrame = async ({ tabId }) => {
       callCount++
       if (callCount === 1) {
-        return { id, url: 'https://jules.google.com/u/0/' }
+        return { documentId: `doc-${tabId}`, url: 'https://jules.google.com/u/0/' }
       }
-      return { id, url: 'https://evil.com/' }
+      return { documentId: `doc-${tabId}-evil`, url: 'https://evil.com/' }
     }
 
-    // This is expected to fail CURRENTLY because ensureContentScript doesn't re-check the URL
-    // We WANT it to fail to prove the vulnerability exists.
     await assert.rejects(sandbox.test_ensureContentScript(123), {
       message: /Security Error: Cannot inject script into non-Jules tab/
     })
@@ -209,7 +216,8 @@ describe('ensureContentScript Security', () => {
 
     // Mock successful sendMessage after injection to stop the loop
     let injected = false
-    chromeMock.tabs.sendMessage = async (_tabId, message) => {
+    chromeMock.tabs.sendMessage = async (_tabId, message, options) => {
+      if (!options?.documentId) throw new Error('Missing documentId')
       if (message.action === 'PING') {
         if (injected) return { status: 'ok' }
         throw new Error('Not loaded')


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** A Time-of-Check to Time-of-Use (TOCTOU) vulnerability existed in `ensureContentScript` within `background.js`. The origin of the tab was verified using `chrome.tabs.get`, but an attacker could trigger a navigation event (e.g., redirect) between the verification and the execution of `chrome.scripting.executeScript` or `chrome.tabs.sendMessage`.
🎯 **Impact:** If exploited, this could allow the extension's content script to be injected into a malicious or unauthorized origin, bypassing intended security boundaries.
🔧 **Fix:** Replaced the point-in-time `chrome.tabs.get` URL check with `chrome.webNavigation.getFrame`, which provides both the URL and a unique `documentId`. The `documentId` is then passed to `chrome.scripting.executeScript` (via `target.documentIds`) and `chrome.tabs.sendMessage` to pin the actions directly to the exact, verified document lifecycle. Added `webNavigation` to manifest permissions.
✅ **Verification:** Updated `tests/security.test.js` to mock `webNavigation.getFrame` and enforce the presence of `documentId`. The test suite runs and passes successfully.

---
*PR created automatically by Jules for task [14691975168907185552](https://jules.google.com/task/14691975168907185552) started by @n24q02m*