### PR TITLE
🎨 Palette: Add loading spinner to Start button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2025-04-03 - Progressive Disclosure for Multi-Mode UIs
 **Learning:** In a multi-mode UI (like Archive vs Suggestions), showing all settings at once creates cognitive overload, especially when settings like GitHub tokens are only relevant to one mode.
 **Action:** Use progressive disclosure in `popup.js` to hide mode-specific settings (like the `.settings` section and `force` checkbox) when they are not relevant to the currently selected mode, keeping the UI clean and focused.
+## 2025-04-26 - Loading Spinners in Extension Popups
+**Learning:** For asynchronous operations triggered by users in a popup, changing button text (e.g. to "Running...") is often insufficient visual feedback. Without an animated indicator, users might think the extension is frozen.
+**Action:** Always include an animated loading spinner (`.spinner`) using CSS keyframes and a flexbox layout alongside the text to clearly indicate that a background process is active.

--- a/background.js
+++ b/background.js
@@ -16,7 +16,7 @@ function extractAccountNum(url) {
     const parts = new URL(url).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }

--- a/content.js
+++ b/content.js
@@ -62,7 +62,7 @@ function getAccountNum() {
     const parts = new URL(location.href).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }

--- a/popup.css
+++ b/popup.css
@@ -146,7 +146,10 @@ input:focus-visible {
 }
 
 button.primary {
-  display: block;
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  align-items: center;
   width: 100%;
   padding: 8px;
   background: #4ade80;
@@ -243,4 +246,19 @@ button.secondary:hover {
 
 .summary .skipped {
   color: #fbbf24;
+}
+
+.spinner {
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-radius: 50%;
+  border-top-color: #fff;
+  animation: spin 1s ease-in-out infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }

--- a/popup.js
+++ b/popup.js
@@ -112,7 +112,7 @@ startBtn.addEventListener('click', async () => {
 
   // Reset UI
   startBtn.disabled = true
-  startBtn.textContent = 'Running...'
+  startBtn.innerHTML = '<span class="spinner" aria-hidden="true"></span>Running...'
   resetBtn.style.display = 'none'
   progressSection.style.display = 'block'
   summarySection.style.display = 'none'
@@ -215,7 +215,7 @@ chrome.runtime.sendMessage({ action: 'GET_STATE' }, (state) => {
     renderState(state)
     if (state.status === 'running') {
       startBtn.disabled = true
-      startBtn.textContent = 'Running...'
+      startBtn.innerHTML = '<span class="spinner" aria-hidden="true"></span>Running...'
     } else {
       resetBtn.style.display = 'block'
     }


### PR DESCRIPTION
### 💡 What
Added a visual, animated loading spinner to the "Start" button inside the extension popup when an operation is triggered and running.

### 🎯 Why
When operations (like archiving or fetching suggestions) take a few seconds, changing the button text to "Running..." is helpful, but an animated spinner provides much stronger, intuitive visual feedback that the background process is actually active and hasn't frozen.

### 📸 Before/After
Before: The button text simply changed to "Running...".
After: The button text changes to "Running..." alongside an animated CSS-only loading spinner perfectly aligned using flexbox.

### ♿ Accessibility
The spinner element (`<span class="spinner">`) uses `aria-hidden="true"` since it is purely decorative, ensuring that screen readers only announce the status change to "Running..." without being cluttered by decorative elements.

---
*PR created automatically by Jules for task [1982634650789766383](https://jules.google.com/task/1982634650789766383) started by @n24q02m*