### PR TITLE
🛡️ Sentinel: [HIGH] Fix script injection TOCTOU

### DIFF
--- a/background.js
+++ b/background.js
@@ -664,31 +664,27 @@ function getTabLabel(tab) {
 }
 
 async function ensureContentScript(tabId) {
-  const checkOrigin = async () => {
-    const tab = await chrome.tabs.get(tabId)
-    if (!tab.url) return false
-    try {
-      const url = new URL(tab.url)
-      return url.origin === JULES_ORIGIN
-    } catch {
-      return false
-    }
+  // Use getFrame to pin to specific document instance, preventing TOCTOU attacks
+  const frame = await chrome.webNavigation.getFrame({ tabId, frameId: 0 })
+  if (!frame?.url) {
+    throw new Error('Security Error: Could not determine frame URL')
   }
 
-  if (!(await checkOrigin())) {
+  const docId = frame.documentId
+  try {
+    const url = new URL(frame.url)
+    if (url.origin !== JULES_ORIGIN) {
+      throw new Error('Security Error: Cannot inject script into non-Jules tab')
+    }
+  } catch (_e) {
     throw new Error('Security Error: Cannot inject script into non-Jules tab')
   }
 
   try {
-    await chrome.tabs.sendMessage(tabId, { action: 'PING' })
-  } catch {
-    // Re-verify immediately before injection to prevent TOCTOU
-    if (!(await checkOrigin())) {
-      throw new Error('Security Error: Cannot inject script into non-Jules tab')
-    }
-
+    await chrome.tabs.sendMessage(tabId, { action: 'PING' }, { documentId: docId })
+  } catch (_e) {
     await chrome.scripting.executeScript({
-      target: { tabId },
+      target: { tabId, documentIds: [docId] },
       files: ['content.js']
     })
 
@@ -696,9 +692,9 @@ async function ensureContentScript(tabId) {
     while (Date.now() < deadline) {
       try {
         await new Promise((r) => setTimeout(r, 100))
-        await chrome.tabs.sendMessage(tabId, { action: 'PING' })
+        await chrome.tabs.sendMessage(tabId, { action: 'PING' }, { documentId: docId })
         return
-      } catch {
+      } catch (_e) {
         // Keep waiting
       }
     }

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Jules Task Archiver",
   "version": "2.0.0",
   "description": "Bulk archive Jules tasks and start code suggestions via batchexecute API",
-  "permissions": ["storage", "tabs", "scripting"],
+  "permissions": ["storage", "tabs", "scripting", "webNavigation"],
   "host_permissions": ["https://jules.google.com/*", "https://api.github.com/*"],
   "background": {
     "service_worker": "background.js"

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -42,6 +42,11 @@ function setupEnvironment(initialStorage = {}) {
         account: 'default'
       })
     },
+    webNavigation: {
+      getFrame: async ({ tabId, frameId }) => {
+        return { url: 'https://jules.google.com/u/0/session', documentId: `doc-${tabId}` }
+      }
+    },
     scripting: {
       executeScript: async () => {}
     }

--- a/tests/security.test.js
+++ b/tests/security.test.js
@@ -132,16 +132,29 @@ function setupEnvironment(initialTabs = {}) {
         if (initialTabs[id]) return initialTabs[id]
         return { id, url: 'https://jules.google.com/u/0/' }
       },
-      sendMessage: async (_tabId, message) => {
+      sendMessage: async (_tabId, message, targetArgs) => {
         if (message.action === 'PING') {
+          if (!targetArgs || !targetArgs.documentId) {
+            throw new Error('Missing documentId in sendMessage pinning')
+          }
           // Simulate script not loaded by throwing
           throw new Error('Could not establish connection. Receiving end does not exist.')
         }
         return {}
       }
     },
+    webNavigation: {
+      getFrame: async ({ tabId, frameId }) => {
+        if (frameId !== 0) throw new Error('Expected frameId 0')
+        const tab = initialTabs[tabId] || { url: 'https://jules.google.com/u/0/' }
+        return { url: tab.url, documentId: `doc-${tabId}` }
+      }
+    },
     scripting: {
       executeScript: async ({ target, files }) => {
+        if (!target.documentIds || !target.documentIds.length) {
+          throw new Error('Missing documentIds in executeScript pinning')
+        }
         chromeMock.scripting.lastCall = { target, files }
       }
     }
@@ -186,19 +199,27 @@ describe('ensureContentScript Security', () => {
   it('should block injection if URL changes to non-Jules origin (TOCTOU)', async () => {
     const { sandbox, chromeMock } = setupEnvironment()
 
-    let callCount = 0
-    chromeMock.tabs.get = async (id) => {
-      callCount++
-      if (callCount === 1) {
-        return { id, url: 'https://jules.google.com/u/0/' }
-      }
-      return { id, url: 'https://evil.com/' }
+    // Simulate TOCTOU: getFrame returns a valid Jules URL and documentId
+    chromeMock.webNavigation.getFrame = async () => {
+      return { url: 'https://jules.google.com/u/0/', documentId: 'safe-doc' }
     }
 
-    // This is expected to fail CURRENTLY because ensureContentScript doesn't re-check the URL
-    // We WANT it to fail to prove the vulnerability exists.
+    // But when we try to executeScript with that documentId, it fails
+    // because the user navigated away and the documentId is no longer valid.
+    chromeMock.scripting.executeScript = async ({ target }) => {
+      if (target.documentIds[0] === 'safe-doc') {
+        throw new Error('No frame with documentId safe-doc')
+      }
+    }
+
+    chromeMock.tabs.sendMessage = async (_tabId, _msg, targetArgs) => {
+      if (targetArgs?.documentId === 'safe-doc') {
+        throw new Error('No frame with documentId safe-doc')
+      }
+    }
+
     await assert.rejects(sandbox.test_ensureContentScript(123), {
-      message: /Security Error: Cannot inject script into non-Jules tab/
+      message: /No frame with documentId safe-doc/
     })
   })
 
@@ -209,8 +230,9 @@ describe('ensureContentScript Security', () => {
 
     // Mock successful sendMessage after injection to stop the loop
     let injected = false
-    chromeMock.tabs.sendMessage = async (_tabId, message) => {
+    chromeMock.tabs.sendMessage = async (_tabId, message, targetArgs) => {
       if (message.action === 'PING') {
+        if (!targetArgs || !targetArgs.documentId) throw new Error('missing docId')
         if (injected) return { status: 'ok' }
         throw new Error('Not loaded')
       }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: A Time-Of-Check to Time-Of-Use (TOCTOU) vulnerability existed in `ensureContentScript` where the tab URL was checked asynchronously using `chrome.tabs.get` prior to injecting the content script. This asynchronous gap could allow a malicious site to navigate the tab after validation but before injection, leading to arbitrary script execution in a different origin context.
🎯 Impact: A malicious website could potentially execute arbitrary scripts within a privileged extension context or intercept sensitive messages intended for the application if they can control tab navigation during the check interval.
🔧 Fix: Switched from using `chrome.tabs.get` to `chrome.webNavigation.getFrame`. By retrieving a unique `documentId` and pinning both `chrome.scripting.executeScript` and `chrome.tabs.sendMessage` to that specific `documentId`, execution is cryptographically bound to the exact document instance that was verified. Also added the `webNavigation` permission to `manifest.json`.
✅ Verification: Ran `pnpm test` and ensured the TOCTOU test case accurately simulates a race condition and successfully rejects when the documentId becomes invalid. All linting and tests pass.

---
*PR created automatically by Jules for task [7684896325645822984](https://jules.google.com/task/7684896325645822984) started by @n24q02m*