### PR TITLE
⚡ Bolt: [Performance] Batch suggestions concurrently

### DIFF
--- a/background.js
+++ b/background.js
@@ -10,13 +10,14 @@
 // =============================================================================
 
 const JULES_ORIGIN = 'https://jules.google.com'
+const SUGGESTION_CHUNK_SIZE = 5
 
 function extractAccountNum(url) {
   try {
     const parts = new URL(url).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }
@@ -505,29 +506,51 @@ async function processSuggestionsForTab(tab, options) {
     addLog(`\n[${label}] ${repo}: Found ${suggestions.length} suggestions`)
     updateState({ currentRepo: repo.replace(/^github\//, '') })
 
-    for (const s of suggestions) {
+    // ⚡ Bolt Optimization: Batch requests to prevent rate limits while maximizing throughput
+    for (let i = 0; i < suggestions.length; i += SUGGESTION_CHUNK_SIZE) {
       if (state.status === 'cancelled') break
 
-      if (options.dryRun) {
-        addLog(`  [DRY] Would start: ${s.title} (${s.categorySlug})`)
-      } else {
-        addLog(`  Starting: ${s.title}...`)
-        try {
-          await startSuggestion(s, repo, config, startConfig)
-          addLog(`  Started: ${s.title}`)
-          totalStarted++
-        } catch (err) {
-          addLog(`  [!] Failed to start "${s.title}": ${err.message}`)
-        }
-      }
+      const chunk = suggestions.slice(i, i + SUGGESTION_CHUNK_SIZE)
 
-      updateState({
-        progress: {
-          archived: totalStarted,
-          skipped: state.progress.skipped,
-          total: state.progress.total + 1
+      const results = await Promise.all(
+        chunk.map(async (s) => {
+          if (options.dryRun) {
+            return { s, dryRun: true }
+          }
+          try {
+            await startSuggestion(s, repo, config, startConfig)
+            return { s, success: true }
+          } catch (err) {
+            return { s, success: false, err }
+          }
+        })
+      )
+
+      for (const res of results) {
+        if (state.status === 'cancelled') break
+
+        const { s, dryRun, success, err } = res
+
+        if (dryRun) {
+          addLog(`  [DRY] Would start: ${s.title} (${s.categorySlug})`)
+        } else {
+          addLog(`  Starting: ${s.title}...`)
+          if (success) {
+            addLog(`  Started: ${s.title}`)
+            totalStarted++
+          } else {
+            addLog(`  [!] Failed to start "${s.title}": ${err.message}`)
+          }
         }
-      })
+
+        updateState({
+          progress: {
+            archived: totalStarted,
+            skipped: state.progress.skipped,
+            total: state.progress.total + 1
+          }
+        })
+      }
     }
   }
 

--- a/content.js
+++ b/content.js
@@ -62,7 +62,7 @@ function getAccountNum() {
     const parts = new URL(location.href).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }


### PR DESCRIPTION
💡 What: Modifies `processSuggestionsForTab` to process `startSuggestion` calls in batches using `Promise.all` (chunk size of 5) rather than strictly sequentially. It utilizes a "Concurrent Request, Sequential State" pattern to preserve logging and state ordering.
🎯 Why: Awaiting each `startSuggestion` call individually restricts network throughput. By mapping chunks of items to `Promise.all`, the extension can dispatch multiple external RPC calls concurrently, mitigating the primary bottleneck of sequential network delays while avoiding aggressive parallel spamming.
📊 Impact: Expected to reduce overall elapsed time for large numbers of suggestions by up to ~5x depending on network latency.
🔬 Measurement: Run the task archiver on a repository with > 5 suggestions. Observe the logs printing starting messages in bursts, reducing the total duration of the operation. Tested via `pnpm test`.

---
*PR created automatically by Jules for task [15145034240628797701](https://jules.google.com/task/15145034240628797701) started by @n24q02m*