### PR TITLE
🛡️ Sentinel: [HIGH] Fix TOCTOU vulnerability in content script injection

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-04-29 - Prevent TOCTOU in ensureContentScript
+**Vulnerability:** A Time-Of-Check to Time-Of-Use (TOCTOU) vulnerability existed in `ensureContentScript` where origin verification via `chrome.tabs.get` occurred before injection, leaving a window where a tab could navigate to an untrusted origin before `chrome.scripting.executeScript` or `chrome.tabs.sendMessage` executed.
+**Learning:** Checking the URL origin and throwing an error is insufficient if the context changes between the check and the use, particularly for isolated world script injection and cross-world communication.
+**Prevention:** Always use `chrome.webNavigation.getFrame` (requires `webNavigation` permission) to obtain the `documentId`. Pin subsequent operations by passing `documentIds: [documentId]` to `executeScript` and `documentId` to `sendMessage` to guarantee execution strictly within the verified document context.

--- a/background.js
+++ b/background.js
@@ -16,7 +16,7 @@ function extractAccountNum(url) {
     const parts = new URL(url).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }
@@ -664,31 +664,36 @@ function getTabLabel(tab) {
 }
 
 async function ensureContentScript(tabId) {
-  const checkOrigin = async () => {
-    const tab = await chrome.tabs.get(tabId)
-    if (!tab.url) return false
+  const getValidFrame = async () => {
     try {
-      const url = new URL(tab.url)
-      return url.origin === JULES_ORIGIN
+      const frame = await chrome.webNavigation.getFrame({ tabId, frameId: 0 })
+      if (!frame?.url) return null
+      const url = new URL(frame.url)
+      if (url.origin === JULES_ORIGIN) {
+        return frame
+      }
+      return null
     } catch {
-      return false
+      return null
     }
   }
 
-  if (!(await checkOrigin())) {
+  const frame = await getValidFrame()
+  if (!frame) {
     throw new Error('Security Error: Cannot inject script into non-Jules tab')
   }
 
   try {
-    await chrome.tabs.sendMessage(tabId, { action: 'PING' })
+    await chrome.tabs.sendMessage(tabId, { action: 'PING' }, { documentId: frame.documentId })
   } catch {
     // Re-verify immediately before injection to prevent TOCTOU
-    if (!(await checkOrigin())) {
+    const recheckedFrame = await getValidFrame()
+    if (!recheckedFrame || recheckedFrame.documentId !== frame.documentId) {
       throw new Error('Security Error: Cannot inject script into non-Jules tab')
     }
 
     await chrome.scripting.executeScript({
-      target: { tabId },
+      target: { tabId, documentIds: [recheckedFrame.documentId] },
       files: ['content.js']
     })
 
@@ -696,12 +701,13 @@ async function ensureContentScript(tabId) {
     while (Date.now() < deadline) {
       try {
         await new Promise((r) => setTimeout(r, 100))
-        await chrome.tabs.sendMessage(tabId, { action: 'PING' })
+        await chrome.tabs.sendMessage(tabId, { action: 'PING' }, { documentId: recheckedFrame.documentId })
         return
       } catch {
-        // Keep waiting
+        // keep trying
       }
     }
+
     throw new Error('Content script failed to initialize within 3s')
   }
 }

--- a/content.js
+++ b/content.js
@@ -62,7 +62,7 @@ function getAccountNum() {
     const parts = new URL(location.href).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Jules Task Archiver",
   "version": "2.0.0",
   "description": "Bulk archive Jules tasks and start code suggestions via batchexecute API",
-  "permissions": ["storage", "tabs", "scripting"],
+  "permissions": ["storage", "tabs", "scripting", "webNavigation"],
   "host_permissions": ["https://jules.google.com/*", "https://api.github.com/*"],
   "background": {
     "service_worker": "background.js"

--- a/tests/security.test.js
+++ b/tests/security.test.js
@@ -127,12 +127,21 @@ function setupEnvironment(initialTabs = {}) {
       onMessage: { addListener: () => {} },
       getPlatformInfo: async () => ({})
     },
+    webNavigation: {
+      getFrame: async ({ tabId }) => {
+        if (initialTabs[tabId]) {
+          return { documentId: `doc-${tabId}`, url: initialTabs[tabId].url }
+        }
+        return { documentId: `doc-${tabId}`, url: 'https://jules.google.com/u/0/' }
+      }
+    },
     tabs: {
       get: async (id) => {
         if (initialTabs[id]) return initialTabs[id]
         return { id, url: 'https://jules.google.com/u/0/' }
       },
-      sendMessage: async (_tabId, message) => {
+      sendMessage: async (_tabId, message, options) => {
+        chromeMock.tabs.lastSendMessageOptions = options
         if (message.action === 'PING') {
           // Simulate script not loaded by throwing
           throw new Error('Could not establish connection. Receiving end does not exist.')
@@ -187,16 +196,14 @@ describe('ensureContentScript Security', () => {
     const { sandbox, chromeMock } = setupEnvironment()
 
     let callCount = 0
-    chromeMock.tabs.get = async (id) => {
+    chromeMock.webNavigation.getFrame = async ({ tabId }) => {
       callCount++
       if (callCount === 1) {
-        return { id, url: 'https://jules.google.com/u/0/' }
+        return { documentId: 'doc-valid', url: 'https://jules.google.com/u/0/' }
       }
-      return { id, url: 'https://evil.com/' }
+      return { documentId: 'doc-evil', url: 'https://evil.com/' }
     }
 
-    // This is expected to fail CURRENTLY because ensureContentScript doesn't re-check the URL
-    // We WANT it to fail to prove the vulnerability exists.
     await assert.rejects(sandbox.test_ensureContentScript(123), {
       message: /Security Error: Cannot inject script into non-Jules tab/
     })
@@ -215,11 +222,16 @@ describe('ensureContentScript Security', () => {
         throw new Error('Not loaded')
       }
     }
-    chromeMock.scripting.executeScript = async () => {
+    chromeMock.scripting.executeScript = async (options) => {
+      chromeMock.scripting.lastCall = options
       injected = true
     }
 
     await sandbox.test_ensureContentScript(456)
     assert.strictEqual(injected, true)
+
+    // Deep equal fails because arrays are not reference-equal across the VM boundary.
+    // Use deepEqual or string comparison instead.
+    assert.ok(chromeMock.scripting.lastCall.target.documentIds.includes('doc-456'))
   })
 })


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** A Time-Of-Check to Time-Of-Use (TOCTOU) vulnerability was present in `ensureContentScript`. The origin was verified via `chrome.tabs.get` prior to script injection, leaving a race condition window where the tab could navigate to an untrusted origin before `chrome.scripting.executeScript` and `chrome.tabs.sendMessage` were executed.
🎯 **Impact:** Could allow malicious/untrusted origins to receive injected scripts or messages meant exclusively for `JULES_ORIGIN`.
🔧 **Fix:** Added `webNavigation` permissions to `manifest.json`. Updated `ensureContentScript` to retrieve the frame's `documentId` via `chrome.webNavigation.getFrame`, then explicitly bound `chrome.scripting.executeScript` and `chrome.tabs.sendMessage` to that exact `documentId`. This pins execution strictly to the verified document context.
✅ **Verification:** Updated `tests/security.test.js` TOCTOU suite. Run `pnpm test` and `npx @biomejs/biome check` to verify the fix correctly blocks injection during race condition scenarios while permitting valid payloads.

---
*PR created automatically by Jules for task [10078722397258907491](https://jules.google.com/task/10078722397258907491) started by @n24q02m*