### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix TOCTOU vulnerability in script injection

### DIFF
--- a/background.js
+++ b/background.js
@@ -16,7 +16,7 @@ function extractAccountNum(url) {
     const parts = new URL(url).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }
@@ -665,30 +665,33 @@ function getTabLabel(tab) {
 
 async function ensureContentScript(tabId) {
   const checkOrigin = async () => {
-    const tab = await chrome.tabs.get(tabId)
-    if (!tab.url) return false
     try {
-      const url = new URL(tab.url)
-      return url.origin === JULES_ORIGIN
+      const frame = await chrome.webNavigation.getFrame({ tabId, frameId: 0 })
+      if (!frame?.url) return { valid: false, documentId: null }
+      const url = new URL(frame.url)
+      return { valid: url.origin === JULES_ORIGIN, documentId: frame.documentId }
     } catch {
-      return false
+      return { valid: false, documentId: null }
     }
   }
 
-  if (!(await checkOrigin())) {
+  const { valid, documentId } = await checkOrigin()
+  if (!valid || !documentId) {
     throw new Error('Security Error: Cannot inject script into non-Jules tab')
   }
 
   try {
-    await chrome.tabs.sendMessage(tabId, { action: 'PING' })
+    await chrome.tabs.sendMessage(tabId, { action: 'PING' }, { documentId })
+    return documentId
   } catch {
     // Re-verify immediately before injection to prevent TOCTOU
-    if (!(await checkOrigin())) {
+    const { valid: reValid, documentId: reDocumentId } = await checkOrigin()
+    if (!reValid || !reDocumentId) {
       throw new Error('Security Error: Cannot inject script into non-Jules tab')
     }
 
     await chrome.scripting.executeScript({
-      target: { tabId },
+      target: { tabId, documentIds: [reDocumentId] },
       files: ['content.js']
     })
 
@@ -696,8 +699,8 @@ async function ensureContentScript(tabId) {
     while (Date.now() < deadline) {
       try {
         await new Promise((r) => setTimeout(r, 100))
-        await chrome.tabs.sendMessage(tabId, { action: 'PING' })
-        return
+        await chrome.tabs.sendMessage(tabId, { action: 'PING' }, { documentId: reDocumentId })
+        return reDocumentId
       } catch {
         // Keep waiting
       }
@@ -707,8 +710,8 @@ async function ensureContentScript(tabId) {
 }
 
 async function getTabConfig(tabId) {
-  await ensureContentScript(tabId)
-  const response = await chrome.tabs.sendMessage(tabId, { action: 'GET_CONFIG' })
+  const documentId = await ensureContentScript(tabId)
+  const response = await chrome.tabs.sendMessage(tabId, { action: 'GET_CONFIG' }, { documentId })
   if (!response?.config?.at) {
     throw new Error('Could not extract page config (XSRF token missing). Try refreshing the Jules tab.')
   }

--- a/content.js
+++ b/content.js
@@ -62,7 +62,7 @@ function getAccountNum() {
     const parts = new URL(location.href).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Jules Task Archiver",
   "version": "2.0.0",
   "description": "Bulk archive Jules tasks and start code suggestions via batchexecute API",
-  "permissions": ["storage", "tabs", "scripting"],
+  "permissions": ["storage", "tabs", "scripting", "webNavigation"],
   "host_permissions": ["https://jules.google.com/*", "https://api.github.com/*"],
   "background": {
     "service_worker": "background.js"

--- a/tests/security.test.js
+++ b/tests/security.test.js
@@ -127,12 +127,18 @@ function setupEnvironment(initialTabs = {}) {
       onMessage: { addListener: () => {} },
       getPlatformInfo: async () => ({})
     },
+    webNavigation: {
+      getFrame: async ({ tabId, frameId }) => {
+        if (initialTabs[tabId]) return { ...initialTabs[tabId], documentId: `doc-${tabId}` }
+        return { url: 'https://jules.google.com/u/0/', documentId: `doc-${tabId}` }
+      }
+    },
     tabs: {
       get: async (id) => {
         if (initialTabs[id]) return initialTabs[id]
         return { id, url: 'https://jules.google.com/u/0/' }
       },
-      sendMessage: async (_tabId, message) => {
+      sendMessage: async (_tabId, message, _options) => {
         if (message.action === 'PING') {
           // Simulate script not loaded by throwing
           throw new Error('Could not establish connection. Receiving end does not exist.')
@@ -187,16 +193,14 @@ describe('ensureContentScript Security', () => {
     const { sandbox, chromeMock } = setupEnvironment()
 
     let callCount = 0
-    chromeMock.tabs.get = async (id) => {
+    chromeMock.webNavigation.getFrame = async ({ tabId }) => {
       callCount++
       if (callCount === 1) {
-        return { id, url: 'https://jules.google.com/u/0/' }
+        return { url: 'https://jules.google.com/u/0/', documentId: 'doc-123' }
       }
-      return { id, url: 'https://evil.com/' }
+      return { url: 'https://evil.com/', documentId: 'doc-evil' }
     }
 
-    // This is expected to fail CURRENTLY because ensureContentScript doesn't re-check the URL
-    // We WANT it to fail to prove the vulnerability exists.
     await assert.rejects(sandbox.test_ensureContentScript(123), {
       message: /Security Error: Cannot inject script into non-Jules tab/
     })
@@ -209,17 +213,24 @@ describe('ensureContentScript Security', () => {
 
     // Mock successful sendMessage after injection to stop the loop
     let injected = false
-    chromeMock.tabs.sendMessage = async (_tabId, message) => {
+    let usedDocumentIds = []
+    let usedDocumentId = null
+    chromeMock.tabs.sendMessage = async (_tabId, message, options) => {
+      if (options?.documentId) usedDocumentId = options.documentId
       if (message.action === 'PING') {
         if (injected) return { status: 'ok' }
         throw new Error('Not loaded')
       }
     }
-    chromeMock.scripting.executeScript = async () => {
+    chromeMock.scripting.executeScript = async ({ target }) => {
       injected = true
+      usedDocumentIds = target.documentIds
     }
 
     await sandbox.test_ensureContentScript(456)
     assert.strictEqual(injected, true)
+    assert.strictEqual(usedDocumentIds.length, 1)
+    assert.strictEqual(usedDocumentIds[0], 'doc-456')
+    assert.strictEqual(usedDocumentId, 'doc-456')
   })
 })


### PR DESCRIPTION
* 🚨 Severity: CRITICAL
* 💡 Vulnerability: Time-Of-Check to Time-Of-Use (TOCTOU) race condition in `ensureContentScript` where the tab URL was verified, but script execution (`executeScript`) and message sending (`sendMessage`) could run on a different origin if the user navigated the tab in the brief window between check and execution.
* 🎯 Impact: If exploited, could lead to injecting content scripts or sending sensitive extension messages (like XSRF tokens) into malicious or unintended origins.
* 🔧 Fix: Used `chrome.webNavigation.getFrame` to acquire a unique `documentId` along with the frame's URL. By passing `documentIds: [documentId]` to `chrome.scripting.executeScript` and `{ documentId }` to `chrome.tabs.sendMessage`, Chrome guarantees the operations will only target the verified document instance, eliminating the race condition.
* ✅ Verification: Verified by adding new tests mocking `webNavigation` and checking `documentId` pinning. Tests pass cleanly.

---
*PR created automatically by Jules for task [9956989059294199816](https://jules.google.com/task/9956989059294199816) started by @n24q02m*