### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix TOCTOU vulnerability in script injection

### DIFF
--- a/background.js
+++ b/background.js
@@ -16,7 +16,7 @@ function extractAccountNum(url) {
     const parts = new URL(url).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }
@@ -665,30 +665,35 @@ function getTabLabel(tab) {
 
 async function ensureContentScript(tabId) {
   const checkOrigin = async () => {
-    const tab = await chrome.tabs.get(tabId)
-    if (!tab.url) return false
     try {
-      const url = new URL(tab.url)
-      return url.origin === JULES_ORIGIN
+      const frame = await chrome.webNavigation.getFrame({ tabId, frameId: 0 })
+      if (!frame?.url || !frame.documentId) return null
+      const url = new URL(frame.url)
+      if (url.origin === JULES_ORIGIN) {
+        return frame.documentId
+      }
+      return null
     } catch {
-      return false
+      return null
     }
   }
 
-  if (!(await checkOrigin())) {
+  let docId = await checkOrigin()
+  if (!docId) {
     throw new Error('Security Error: Cannot inject script into non-Jules tab')
   }
 
   try {
-    await chrome.tabs.sendMessage(tabId, { action: 'PING' })
+    await chrome.tabs.sendMessage(tabId, { action: 'PING' }, { documentId: docId })
   } catch {
     // Re-verify immediately before injection to prevent TOCTOU
-    if (!(await checkOrigin())) {
+    docId = await checkOrigin()
+    if (!docId) {
       throw new Error('Security Error: Cannot inject script into non-Jules tab')
     }
 
     await chrome.scripting.executeScript({
-      target: { tabId },
+      target: { tabId, documentIds: [docId] },
       files: ['content.js']
     })
 
@@ -696,7 +701,7 @@ async function ensureContentScript(tabId) {
     while (Date.now() < deadline) {
       try {
         await new Promise((r) => setTimeout(r, 100))
-        await chrome.tabs.sendMessage(tabId, { action: 'PING' })
+        await chrome.tabs.sendMessage(tabId, { action: 'PING' }, { documentId: docId })
         return
       } catch {
         // Keep waiting

--- a/content.js
+++ b/content.js
@@ -62,7 +62,7 @@ function getAccountNum() {
     const parts = new URL(location.href).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Jules Task Archiver",
   "version": "2.0.0",
   "description": "Bulk archive Jules tasks and start code suggestions via batchexecute API",
-  "permissions": ["storage", "tabs", "scripting"],
+  "permissions": ["storage", "tabs", "scripting", "webNavigation"],
   "host_permissions": ["https://jules.google.com/*", "https://api.github.com/*"],
   "background": {
     "service_worker": "background.js"

--- a/tests/security.test.js
+++ b/tests/security.test.js
@@ -132,7 +132,12 @@ function setupEnvironment(initialTabs = {}) {
         if (initialTabs[id]) return initialTabs[id]
         return { id, url: 'https://jules.google.com/u/0/' }
       },
-      sendMessage: async (_tabId, message) => {
+      sendMessage: async (_tabId, message, options) => {
+        // Assert that documentId is passed correctly
+        if (!options?.documentId) {
+          throw new Error('Missing documentId in sendMessage options')
+        }
+
         if (message.action === 'PING') {
           // Simulate script not loaded by throwing
           throw new Error('Could not establish connection. Receiving end does not exist.')
@@ -140,8 +145,19 @@ function setupEnvironment(initialTabs = {}) {
         return {}
       }
     },
+    webNavigation: {
+      getFrame: async ({ tabId, _frameId }) => {
+        const tabUrl = initialTabs[tabId] ? initialTabs[tabId].url : 'https://jules.google.com/u/0/'
+        // Generate a pseudo-documentId based on URL
+        const docId = tabUrl.includes('evil.com') ? 'evil-doc-123' : 'jules-doc-456'
+        return { documentId: docId, url: tabUrl }
+      }
+    },
     scripting: {
       executeScript: async ({ target, files }) => {
+        if (!target.documentIds || target.documentIds.length === 0) {
+          throw new Error('Missing documentIds in executeScript target')
+        }
         chromeMock.scripting.lastCall = { target, files }
       }
     }
@@ -187,39 +203,40 @@ describe('ensureContentScript Security', () => {
     const { sandbox, chromeMock } = setupEnvironment()
 
     let callCount = 0
-    chromeMock.tabs.get = async (id) => {
+    chromeMock.webNavigation.getFrame = async ({ _tabId, _frameId }) => {
       callCount++
       if (callCount === 1) {
-        return { id, url: 'https://jules.google.com/u/0/' }
+        return { documentId: 'jules-doc-1', url: 'https://jules.google.com/u/0/' }
       }
-      return { id, url: 'https://evil.com/' }
+      return { documentId: 'evil-doc-2', url: 'https://evil.com/' }
     }
 
-    // This is expected to fail CURRENTLY because ensureContentScript doesn't re-check the URL
-    // We WANT it to fail to prove the vulnerability exists.
     await assert.rejects(sandbox.test_ensureContentScript(123), {
       message: /Security Error: Cannot inject script into non-Jules tab/
     })
   })
 
-  it('should allow injection into valid Jules origin', async () => {
+  it('should allow injection into valid Jules origin and use correct documentId', async () => {
     const { sandbox, chromeMock } = setupEnvironment({
       456: { id: 456, url: 'https://jules.google.com/u/1/' }
     })
 
     // Mock successful sendMessage after injection to stop the loop
     let injected = false
-    chromeMock.tabs.sendMessage = async (_tabId, message) => {
+    let usedDocId = null
+    chromeMock.tabs.sendMessage = async (_tabId, message, _options) => {
       if (message.action === 'PING') {
         if (injected) return { status: 'ok' }
         throw new Error('Not loaded')
       }
     }
-    chromeMock.scripting.executeScript = async () => {
+    chromeMock.scripting.executeScript = async ({ target }) => {
+      usedDocId = target.documentIds[0]
       injected = true
     }
 
     await sandbox.test_ensureContentScript(456)
     assert.strictEqual(injected, true)
+    assert.strictEqual(usedDocId, 'jules-doc-456') // Value mocked in setupEnvironment
   })
 })

--- a/tests/security.test.js
+++ b/tests/security.test.js
@@ -149,7 +149,7 @@ function setupEnvironment(initialTabs = {}) {
       getFrame: async ({ tabId, _frameId }) => {
         const tabUrl = initialTabs[tabId] ? initialTabs[tabId].url : 'https://jules.google.com/u/0/'
         // Generate a pseudo-documentId based on URL
-        const docId = tabUrl.includes('evil.com') ? 'evil-doc-123' : 'jules-doc-456'
+        const docId = new URL(tabUrl).hostname === 'evil.com' ? 'evil-doc-123' : 'jules-doc-456'
         return { documentId: docId, url: tabUrl }
       }
     },


### PR DESCRIPTION
🚨 **Severity:** CRITICAL

💡 **Vulnerability:**
A Time-of-Check to Time-of-Use (TOCTOU) vulnerability existed in `ensureContentScript`. The function verified a tab's URL `origin` via `chrome.tabs.get`, but a race condition existed where the user could navigate the tab to a malicious origin in the brief window between the check and the actual `chrome.scripting.executeScript` or `chrome.tabs.sendMessage` calls, potentially injecting extension-privileged scripts into untrusted pages.

🎯 **Impact:**
If exploited, this could result in privilege escalation or cross-site scripting (XSS) within non-Jules origins.

🔧 **Fix:**
Leveraged the `chrome.webNavigation` API (and added the `"webNavigation"` permission) to retrieve a unique `documentId` via `getFrame`. By passing `documentIds: [documentId]` to `executeScript` and `{ documentId }` to `sendMessage`, the Chrome API guarantees execution is pinned atomically to that verified document. If the tab navigates away, the injection is instantly aborted.

✅ **Verification:**
* Added tests in `security.test.js` validating proper behavior when `documentId` constraints are utilized.
* Ran `npx @biomejs/biome check` to ensure code styles are adhered to.
* Executed the `pnpm test` suite to guarantee no regressions exist in the project logic.
* Added a journal entry to `.Jules/sentinel.md` capturing these architectural security patterns.

---
*PR created automatically by Jules for task [945640539295652938](https://jules.google.com/task/945640539295652938) started by @n24q02m*