### PR TITLE
🛡️ Sentinel: [HIGH] Fix TOCTOU vulnerability in script injection

### DIFF
--- a/background.js
+++ b/background.js
@@ -16,7 +16,7 @@ function extractAccountNum(url) {
     const parts = new URL(url).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }
@@ -664,31 +664,38 @@ function getTabLabel(tab) {
 }
 
 async function ensureContentScript(tabId) {
-  const checkOrigin = async () => {
-    const tab = await chrome.tabs.get(tabId)
-    if (!tab.url) return false
-    try {
-      const url = new URL(tab.url)
-      return url.origin === JULES_ORIGIN
-    } catch {
-      return false
-    }
+  // Get top-level frame info to prevent TOCTOU by binding to documentId
+  let frame
+  try {
+    frame = await chrome.webNavigation.getFrame({ tabId, frameId: 0 })
+  } catch {
+    throw new Error('Security Error: Cannot access tab frame')
   }
 
-  if (!(await checkOrigin())) {
+  if (!frame?.url) {
     throw new Error('Security Error: Cannot inject script into non-Jules tab')
   }
 
+  let isJulesOrigin = false
   try {
-    await chrome.tabs.sendMessage(tabId, { action: 'PING' })
+    const url = new URL(frame.url)
+    isJulesOrigin = url.origin === JULES_ORIGIN
   } catch {
-    // Re-verify immediately before injection to prevent TOCTOU
-    if (!(await checkOrigin())) {
-      throw new Error('Security Error: Cannot inject script into non-Jules tab')
-    }
+    isJulesOrigin = false
+  }
 
+  if (!isJulesOrigin) {
+    throw new Error('Security Error: Cannot inject script into non-Jules tab')
+  }
+
+  const { documentId } = frame
+
+  try {
+    await chrome.tabs.sendMessage(tabId, { action: 'PING' }, { documentId })
+    return documentId
+  } catch {
     await chrome.scripting.executeScript({
-      target: { tabId },
+      target: { tabId, documentIds: [documentId] },
       files: ['content.js']
     })
 
@@ -696,8 +703,8 @@ async function ensureContentScript(tabId) {
     while (Date.now() < deadline) {
       try {
         await new Promise((r) => setTimeout(r, 100))
-        await chrome.tabs.sendMessage(tabId, { action: 'PING' })
-        return
+        await chrome.tabs.sendMessage(tabId, { action: 'PING' }, { documentId })
+        return documentId
       } catch {
         // Keep waiting
       }
@@ -707,8 +714,8 @@ async function ensureContentScript(tabId) {
 }
 
 async function getTabConfig(tabId) {
-  await ensureContentScript(tabId)
-  const response = await chrome.tabs.sendMessage(tabId, { action: 'GET_CONFIG' })
+  const documentId = await ensureContentScript(tabId)
+  const response = await chrome.tabs.sendMessage(tabId, { action: 'GET_CONFIG' }, { documentId })
   if (!response?.config?.at) {
     throw new Error('Could not extract page config (XSRF token missing). Try refreshing the Jules tab.')
   }

--- a/content.js
+++ b/content.js
@@ -62,7 +62,7 @@ function getAccountNum() {
     const parts = new URL(location.href).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Jules Task Archiver",
   "version": "2.0.0",
   "description": "Bulk archive Jules tasks and start code suggestions via batchexecute API",
-  "permissions": ["storage", "tabs", "scripting"],
+  "permissions": ["storage", "tabs", "scripting", "webNavigation"],
   "host_permissions": ["https://jules.google.com/*", "https://api.github.com/*"],
   "background": {
     "service_worker": "background.js"

--- a/tests/security.test.js
+++ b/tests/security.test.js
@@ -132,7 +132,11 @@ function setupEnvironment(initialTabs = {}) {
         if (initialTabs[id]) return initialTabs[id]
         return { id, url: 'https://jules.google.com/u/0/' }
       },
-      sendMessage: async (_tabId, message) => {
+      sendMessage: async (_tabId, message, options = {}) => {
+        // Assert documentId is passed to prevent TOCTOU
+        if (message.action === 'PING' && !options.documentId) {
+          throw new Error('Security test failure: PING missing documentId')
+        }
         if (message.action === 'PING') {
           // Simulate script not loaded by throwing
           throw new Error('Could not establish connection. Receiving end does not exist.')
@@ -140,8 +144,17 @@ function setupEnvironment(initialTabs = {}) {
         return {}
       }
     },
+    webNavigation: {
+      getFrame: async ({ tabId, frameId }) => {
+        const tab = initialTabs[tabId] || { id: tabId, url: 'https://jules.google.com/u/0/' }
+        return { documentId: `doc-${tabId}-${frameId}`, url: tab.url }
+      }
+    },
     scripting: {
       executeScript: async ({ target, files }) => {
+        if (!target.documentIds || target.documentIds.length === 0) {
+          throw new Error('Security test failure: executeScript missing documentIds')
+        }
         chromeMock.scripting.lastCall = { target, files }
       }
     }
@@ -183,23 +196,29 @@ describe('ensureContentScript Security', () => {
     })
   })
 
-  it('should block injection if URL changes to non-Jules origin (TOCTOU)', async () => {
+  it('should prevent TOCTOU by strictly binding to documentId', async () => {
     const { sandbox, chromeMock } = setupEnvironment()
 
-    let callCount = 0
-    chromeMock.tabs.get = async (id) => {
-      callCount++
-      if (callCount === 1) {
-        return { id, url: 'https://jules.google.com/u/0/' }
+    // Mock successful sendMessage after injection to stop the loop
+    let injected = false
+    let passedOptions = null
+    chromeMock.tabs.sendMessage = async (_tabId, message, options = {}) => {
+      if (message.action === 'PING') {
+        passedOptions = options
+        if (injected) return { status: 'ok' }
+        throw new Error('Not loaded')
       }
-      return { id, url: 'https://evil.com/' }
+    }
+    chromeMock.scripting.executeScript = async ({ target }) => {
+      passedOptions = target
+      injected = true
     }
 
-    // This is expected to fail CURRENTLY because ensureContentScript doesn't re-check the URL
-    // We WANT it to fail to prove the vulnerability exists.
-    await assert.rejects(sandbox.test_ensureContentScript(123), {
-      message: /Security Error: Cannot inject script into non-Jules tab/
-    })
+    const returnedDocId = await sandbox.test_ensureContentScript(123)
+
+    // Ensure documentId is returned and used
+    assert.strictEqual(returnedDocId, 'doc-123-0')
+    assert.strictEqual(passedOptions.documentIds?.[0] || passedOptions.documentId, 'doc-123-0')
   })
 
   it('should allow injection into valid Jules origin', async () => {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `ensureContentScript` logic previously fetched the tab's URL to verify its origin, and then asynchronously injected the content script and passed messages. This sequence created a Time-of-Check to Time-of-Use (TOCTOU) vulnerability where the tab could navigate to a different, non-Jules origin between the verification and the injection, allowing unauthorized script execution on arbitrary sites.
🎯 Impact: An attacker could potentially cause the content script (and sensitive WIZ configuration variables or XSRF tokens) to be injected into or leaked to a malicious origin if they manipulated tab navigation at the right time.
🔧 Fix: Added the `webNavigation` permission to fetch the `documentId` from `chrome.webNavigation.getFrame({ tabId, frameId: 0 })`. Modified `ensureContentScript` to bind the retrieved `documentId` explicitly when calling `chrome.scripting.executeScript` and `chrome.tabs.sendMessage`. This ensures the extension API enforces that execution and messages only occur on the exactly verified document instance.
✅ Verification: Ran unit tests (`pnpm test`) including updated, specific `node:vm` sandbox tests in `tests/security.test.js` that mock `chrome.webNavigation.getFrame` and strictly assert that `documentId` is provided to API calls, verifying the TOCTOU gap is closed.

---
*PR created automatically by Jules for task [8487066336911871221](https://jules.google.com/task/8487066336911871221) started by @n24q02m*