### PR TITLE
🎨 Palette: [UX improvement] Add context-aware text and aria-busy logic to popup button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2025-04-03 - Progressive Disclosure for Multi-Mode UIs
 **Learning:** In a multi-mode UI (like Archive vs Suggestions), showing all settings at once creates cognitive overload, especially when settings like GitHub tokens are only relevant to one mode.
 **Action:** Use progressive disclosure in `popup.js` to hide mode-specific settings (like the `.settings` section and `force` checkbox) when they are not relevant to the currently selected mode, keeping the UI clean and focused.
+## 2025-05-04 - Context-Aware Async UI Feedback
+**Learning:** For async operations in UI popups under 'no custom CSS' constraints, use context-aware dynamic text (e.g., 'Start Archiving' vs 'Start Suggestions') and visually indicate background activity using native emojis (e.g., '⏳ Running...') combined with `aria-busy="true"` to improve usability and accessibility without adding new CSS classes.
+**Action:** Update the UI label text according to the selected mode rather than showing a generic 'Start'. Integrate `aria-busy="true"` correctly across states (running, idle, complete, error).

--- a/popup.html
+++ b/popup.html
@@ -45,7 +45,7 @@
       </div>
     </section>
 
-    <button type="button" id="startBtn" class="primary">Start</button>
+    <button type="button" id="startBtn" class="primary">Start Archiving</button>
     <button type="button" id="resetBtn" class="secondary" style="display: none">Reset</button>
 
     <section id="progressSection" style="display: none">

--- a/popup.js
+++ b/popup.js
@@ -31,6 +31,11 @@ function setActiveOpMode(value) {
   })
   opMode = value
 
+  // Update button text contextually
+  if (startBtn) {
+    startBtn.textContent = value === 'archive' ? 'Start Archiving' : 'Start Suggestions'
+  }
+
   // Progressive disclosure: hide archive-specific settings
   const isArchive = value === 'archive'
   const settingsSection = document.querySelector('.settings')
@@ -112,7 +117,8 @@ startBtn.addEventListener('click', async () => {
 
   // Reset UI
   startBtn.disabled = true
-  startBtn.textContent = 'Running...'
+  startBtn.textContent = '⏳ Running...'
+  startBtn.setAttribute('aria-busy', 'true')
   resetBtn.style.display = 'none'
   progressSection.style.display = 'block'
   summarySection.style.display = 'none'
@@ -127,7 +133,8 @@ startBtn.addEventListener('click', async () => {
 resetBtn.addEventListener('click', () => {
   chrome.runtime.sendMessage({ action: 'RESET' })
   startBtn.disabled = false
-  startBtn.textContent = 'Start'
+  startBtn.textContent = opMode === 'archive' ? 'Start Archiving' : 'Start Suggestions'
+  startBtn.setAttribute('aria-busy', 'false')
   resetBtn.style.display = 'none'
   progressSection.style.display = 'none'
   summarySection.style.display = 'none'
@@ -168,12 +175,14 @@ function renderState(state) {
   // Done or error
   if (state.status === 'done' || state.status === 'error') {
     startBtn.disabled = false
-    startBtn.textContent = 'Start'
+    startBtn.textContent = opMode === 'archive' ? 'Start Archiving' : 'Start Suggestions'
+    startBtn.setAttribute('aria-busy', 'false')
     resetBtn.style.display = 'block'
     progressFill.style.width = '100%'
     progressFill.parentElement.setAttribute('aria-valuenow', '100')
 
     if (state.status === 'done') {
+      startBtn.setAttribute('aria-busy', 'false')
       currentInfo.textContent = 'Complete'
       renderSummary(state.results)
     } else {
@@ -215,7 +224,8 @@ chrome.runtime.sendMessage({ action: 'GET_STATE' }, (state) => {
     renderState(state)
     if (state.status === 'running') {
       startBtn.disabled = true
-      startBtn.textContent = 'Running...'
+      startBtn.textContent = '⏳ Running...'
+      startBtn.setAttribute('aria-busy', 'true')
     } else {
       resetBtn.style.display = 'block'
     }


### PR DESCRIPTION
### 💡 What
Modified `popup.html` default start button text and added dynamic text updates in `popup.js` (`Start Archiving` vs `Start Suggestions`) depending on the `opMode`. We also now append a visual indication ("⏳ Running...") coupled with setting `aria-busy="true"` on the button while async tasks execute.

### 🎯 Why
A multi-mode UI that simply uses "Start" and "Running..." provides no specific context to users and offers degraded accessibility. Giving clear explicit action-states (Start Archiving, Start Suggestions, ⏳ Running...) prevents cognitive mismatch. `aria-busy="true"` allows screen readers to natively understand the button's asynchronous loading state without needing complex CSS classes.

### 📸 Before/After
Before:
Default text was "Start" and clicking start changed it to "Running...", providing zero context.

After:
- Selected mode updates the button implicitly (`Start Archiving` or `Start Suggestions`)
- When started, button correctly switches to `⏳ Running...` with `aria-busy="true"` and reverts appropriately once resolved.

### ♿ Accessibility
Enabled `aria-busy="true"` seamlessly without new CSS logic. Button state text is fully descriptive.

---
*PR created automatically by Jules for task [10556934173269290132](https://jules.google.com/task/10556934173269290132) started by @n24q02m*