### PR TITLE
🛡️ Sentinel: [HIGH] Fix TOCTOU vulnerability in script injection

### DIFF
--- a/background.js
+++ b/background.js
@@ -16,7 +16,7 @@ function extractAccountNum(url) {
     const parts = new URL(url).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }
@@ -664,31 +664,28 @@ function getTabLabel(tab) {
 }
 
 async function ensureContentScript(tabId) {
-  const checkOrigin = async () => {
-    const tab = await chrome.tabs.get(tabId)
-    if (!tab.url) return false
-    try {
-      const url = new URL(tab.url)
-      return url.origin === JULES_ORIGIN
-    } catch {
-      return false
-    }
-  }
-
-  if (!(await checkOrigin())) {
-    throw new Error('Security Error: Cannot inject script into non-Jules tab')
+  // Use webNavigation to get the frame details and pin the documentId
+  const frame = await chrome.webNavigation.getFrame({ tabId, frameId: 0 })
+  if (!frame?.url || !frame.documentId) {
+    throw new Error('Security Error: Cannot determine frame details for tab')
   }
 
   try {
-    await chrome.tabs.sendMessage(tabId, { action: 'PING' })
-  } catch {
-    // Re-verify immediately before injection to prevent TOCTOU
-    if (!(await checkOrigin())) {
+    const url = new URL(frame.url)
+    if (url.origin !== JULES_ORIGIN) {
       throw new Error('Security Error: Cannot inject script into non-Jules tab')
     }
+  } catch {
+    throw new Error('Security Error: Cannot inject script into non-Jules tab')
+  }
 
+  const documentId = frame.documentId
+
+  try {
+    await chrome.tabs.sendMessage(tabId, { action: 'PING' }, { documentId })
+  } catch {
     await chrome.scripting.executeScript({
-      target: { tabId },
+      target: { tabId, documentIds: [documentId] },
       files: ['content.js']
     })
 
@@ -696,19 +693,21 @@ async function ensureContentScript(tabId) {
     while (Date.now() < deadline) {
       try {
         await new Promise((r) => setTimeout(r, 100))
-        await chrome.tabs.sendMessage(tabId, { action: 'PING' })
-        return
+        await chrome.tabs.sendMessage(tabId, { action: 'PING' }, { documentId })
+        return documentId
       } catch {
         // Keep waiting
       }
     }
     throw new Error('Content script failed to initialize within 3s')
   }
+
+  return documentId
 }
 
 async function getTabConfig(tabId) {
-  await ensureContentScript(tabId)
-  const response = await chrome.tabs.sendMessage(tabId, { action: 'GET_CONFIG' })
+  const documentId = await ensureContentScript(tabId)
+  const response = await chrome.tabs.sendMessage(tabId, { action: 'GET_CONFIG' }, { documentId })
   if (!response?.config?.at) {
     throw new Error('Could not extract page config (XSRF token missing). Try refreshing the Jules tab.')
   }

--- a/content.js
+++ b/content.js
@@ -62,7 +62,7 @@ function getAccountNum() {
     const parts = new URL(location.href).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Jules Task Archiver",
   "version": "2.0.0",
   "description": "Bulk archive Jules tasks and start code suggestions via batchexecute API",
-  "permissions": ["storage", "tabs", "scripting"],
+  "permissions": ["storage", "tabs", "scripting", "webNavigation"],
   "host_permissions": ["https://jules.google.com/*", "https://api.github.com/*"],
   "background": {
     "service_worker": "background.js"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,9 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}

--- a/tests/security.test.js
+++ b/tests/security.test.js
@@ -132,7 +132,8 @@ function setupEnvironment(initialTabs = {}) {
         if (initialTabs[id]) return initialTabs[id]
         return { id, url: 'https://jules.google.com/u/0/' }
       },
-      sendMessage: async (_tabId, message) => {
+      sendMessage: async (_tabId, message, options) => {
+        chromeMock.tabs.lastSendMessageArgs = { message, options }
         if (message.action === 'PING') {
           // Simulate script not loaded by throwing
           throw new Error('Could not establish connection. Receiving end does not exist.')
@@ -143,6 +144,15 @@ function setupEnvironment(initialTabs = {}) {
     scripting: {
       executeScript: async ({ target, files }) => {
         chromeMock.scripting.lastCall = { target, files }
+      }
+    },
+    webNavigation: {
+      getFrame: async ({ tabId }) => {
+        const tab = initialTabs[tabId] || { id: tabId, url: 'https://jules.google.com/u/0/' }
+        return {
+          documentId: `doc-${tabId}`,
+          url: tab.url
+        }
       }
     }
   }
@@ -187,39 +197,46 @@ describe('ensureContentScript Security', () => {
     const { sandbox, chromeMock } = setupEnvironment()
 
     let callCount = 0
-    chromeMock.tabs.get = async (id) => {
+    chromeMock.webNavigation.getFrame = async ({ tabId }) => {
       callCount++
       if (callCount === 1) {
-        return { id, url: 'https://jules.google.com/u/0/' }
+        return { documentId: `doc-${tabId}`, url: 'https://evil.com/' }
       }
-      return { id, url: 'https://evil.com/' }
+      return { documentId: `doc-${tabId}`, url: 'https://jules.google.com/u/0/' }
     }
 
-    // This is expected to fail CURRENTLY because ensureContentScript doesn't re-check the URL
-    // We WANT it to fail to prove the vulnerability exists.
     await assert.rejects(sandbox.test_ensureContentScript(123), {
       message: /Security Error: Cannot inject script into non-Jules tab/
     })
   })
 
-  it('should allow injection into valid Jules origin', async () => {
+  it('should allow injection into valid Jules origin and pin documentId', async () => {
     const { sandbox, chromeMock } = setupEnvironment({
       456: { id: 456, url: 'https://jules.google.com/u/1/' }
     })
 
     // Mock successful sendMessage after injection to stop the loop
     let injected = false
-    chromeMock.tabs.sendMessage = async (_tabId, message) => {
+    chromeMock.tabs.sendMessage = async (_tabId, message, options) => {
+      chromeMock.tabs.lastSendMessageArgs = { message, options }
       if (message.action === 'PING') {
         if (injected) return { status: 'ok' }
         throw new Error('Not loaded')
       }
     }
-    chromeMock.scripting.executeScript = async () => {
+    chromeMock.scripting.executeScript = async ({ target, files }) => {
+      chromeMock.scripting.lastCall = { target, files }
       injected = true
     }
 
-    await sandbox.test_ensureContentScript(456)
+    const documentId = await sandbox.test_ensureContentScript(456)
+
+    assert.strictEqual(documentId, 'doc-456')
     assert.strictEqual(injected, true)
+
+    // Verify documentId pinning
+    assert.strictEqual(chromeMock.scripting.lastCall.target.documentIds[0], 'doc-456')
+    assert.strictEqual(chromeMock.scripting.lastCall.target.documentIds.length, 1)
+    assert.strictEqual(chromeMock.tabs.lastSendMessageArgs.options.documentId, 'doc-456')
   })
 })


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Time-of-Check to Time-of-Use (TOCTOU) race condition during `content.js` injection. The tab's URL was verified, and then `chrome.scripting.executeScript` was called by `tabId`. An attacker could potentially navigate the tab to an attacker-controlled origin between the validation check and the injection.
🎯 Impact: Cross-Site Scripting (XSS) via content script injection into unintended, malicious origins.
🛠️ Fix: Used `chrome.webNavigation.getFrame` to fetch the specific frame's `url` and `documentId`. The script injection and message passing now strictly use `documentIds: [documentId]` and `{ documentId }` to guarantee that the extension interacts only with the verified page instance. Updated `tests/security.test.js` to simulate this Manifest V3 pattern.
✅ Verification: Ran `pnpm test` and explicitly verified that the `ensureContentScript` block in `tests/security.test.js` pins the correct `documentId`. Tests pass and no regressions introduced. Added learning to `.Jules/sentinel.md`.

---
*PR created automatically by Jules for task [13604091089369871007](https://jules.google.com/task/13604091089369871007) started by @n24q02m*