### PR TITLE
🎨 Palette: Add context-aware loading state to start button

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -45,7 +45,7 @@
       </div>
     </section>
 
-    <button type="button" id="startBtn" class="primary">Start</button>
+    <button type="button" id="startBtn" class="primary">Start Archiving</button>
     <button type="button" id="resetBtn" class="secondary" style="display: none">Reset</button>
 
     <section id="progressSection" style="display: none">

--- a/popup.js
+++ b/popup.js
@@ -42,6 +42,11 @@ function setActiveOpMode(value) {
   if (forceCheckboxContainer) {
     forceCheckboxContainer.style.display = isArchive ? 'flex' : 'none'
   }
+
+  // Context-aware start button text
+  if (!startBtn.disabled) {
+    startBtn.textContent = isArchive ? 'Start Archiving' : 'Start Suggestions'
+  }
 }
 
 document.querySelectorAll('#opMode button').forEach((btn) => {
@@ -112,7 +117,8 @@ startBtn.addEventListener('click', async () => {
 
   // Reset UI
   startBtn.disabled = true
-  startBtn.textContent = 'Running...'
+  startBtn.setAttribute('aria-busy', 'true')
+  startBtn.textContent = '⏳ Running...'
   resetBtn.style.display = 'none'
   progressSection.style.display = 'block'
   summarySection.style.display = 'none'
@@ -127,7 +133,8 @@ startBtn.addEventListener('click', async () => {
 resetBtn.addEventListener('click', () => {
   chrome.runtime.sendMessage({ action: 'RESET' })
   startBtn.disabled = false
-  startBtn.textContent = 'Start'
+  startBtn.removeAttribute('aria-busy')
+  startBtn.textContent = opMode === 'archive' ? 'Start Archiving' : 'Start Suggestions'
   resetBtn.style.display = 'none'
   progressSection.style.display = 'none'
   summarySection.style.display = 'none'
@@ -168,7 +175,8 @@ function renderState(state) {
   // Done or error
   if (state.status === 'done' || state.status === 'error') {
     startBtn.disabled = false
-    startBtn.textContent = 'Start'
+    startBtn.removeAttribute('aria-busy')
+    startBtn.textContent = opMode === 'archive' ? 'Start Archiving' : 'Start Suggestions'
     resetBtn.style.display = 'block'
     progressFill.style.width = '100%'
     progressFill.parentElement.setAttribute('aria-valuenow', '100')
@@ -215,7 +223,8 @@ chrome.runtime.sendMessage({ action: 'GET_STATE' }, (state) => {
     renderState(state)
     if (state.status === 'running') {
       startBtn.disabled = true
-      startBtn.textContent = 'Running...'
+      startBtn.setAttribute('aria-busy', 'true')
+      startBtn.textContent = '⏳ Running...'
     } else {
       resetBtn.style.display = 'block'
     }

--- a/tests/security.test.js
+++ b/tests/security.test.js
@@ -71,6 +71,7 @@ describe('Security: ghToken Storage Cleanup', () => {
         dataset: {},
         classList: { toggle: () => {} },
         setAttribute: () => {},
+        removeAttribute: () => {},
         style: {},
         parentElement: {}
       }),


### PR DESCRIPTION
💡 **What:** Added a dynamic, context-aware loading state to the main action button in the extension popup. The button now says "Start Archiving" or "Start Suggestions" depending on the active tab, and switches to "⏳ Running..." while an operation is in progress.
🎯 **Why:** Previously, the button just said "Start" and then "Running...". Providing context-aware text reduces user confusion about which action is going to run. Using the ⏳ native emoji provides an immediate visual cue that an async operation is happening without requiring new CSS rules.
📸 **Before/After:** The button now reads `Start Archiving` or `Start Suggestions` by default, and `⏳ Running...` when active.
♿ **Accessibility:** Added the `aria-busy="true"` attribute when the button is in its loading state, ensuring screen readers announce the loading progress correctly.

---
*PR created automatically by Jules for task [15009269165091756709](https://jules.google.com/task/15009269165091756709) started by @n24q02m*