### PR TITLE
🛡️ Sentinel: [HIGH] Fix TOCTOU vulnerability during content script injection

### DIFF
--- a/background.js
+++ b/background.js
@@ -16,7 +16,7 @@ function extractAccountNum(url) {
     const parts = new URL(url).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }
@@ -664,31 +664,28 @@ function getTabLabel(tab) {
 }
 
 async function ensureContentScript(tabId) {
-  const checkOrigin = async () => {
-    const tab = await chrome.tabs.get(tabId)
-    if (!tab.url) return false
-    try {
-      const url = new URL(tab.url)
-      return url.origin === JULES_ORIGIN
-    } catch {
-      return false
-    }
-  }
-
-  if (!(await checkOrigin())) {
-    throw new Error('Security Error: Cannot inject script into non-Jules tab')
+  const frame = await chrome.webNavigation.getFrame({ tabId, frameId: 0 })
+  if (!frame?.url) {
+    throw new Error('Security Error: Cannot verify tab origin')
   }
 
   try {
-    await chrome.tabs.sendMessage(tabId, { action: 'PING' })
-  } catch {
-    // Re-verify immediately before injection to prevent TOCTOU
-    if (!(await checkOrigin())) {
+    const url = new URL(frame.url)
+    if (url.origin !== JULES_ORIGIN) {
       throw new Error('Security Error: Cannot inject script into non-Jules tab')
     }
+  } catch {
+    throw new Error('Security Error: Cannot inject script into non-Jules tab')
+  }
 
+  const documentId = frame.documentId
+  const target = { tabId, documentIds: [documentId] }
+
+  try {
+    await chrome.tabs.sendMessage(tabId, { action: 'PING' }, { documentId })
+  } catch {
     await chrome.scripting.executeScript({
-      target: { tabId },
+      target,
       files: ['content.js']
     })
 
@@ -696,19 +693,22 @@ async function ensureContentScript(tabId) {
     while (Date.now() < deadline) {
       try {
         await new Promise((r) => setTimeout(r, 100))
-        await chrome.tabs.sendMessage(tabId, { action: 'PING' })
-        return
+        await chrome.tabs.sendMessage(tabId, { action: 'PING' }, { documentId })
+        break
       } catch {
         // Keep waiting
       }
     }
-    throw new Error('Content script failed to initialize within 3s')
+    if (Date.now() >= deadline) {
+      throw new Error('Content script failed to initialize within 3s')
+    }
   }
+  return documentId
 }
 
 async function getTabConfig(tabId) {
-  await ensureContentScript(tabId)
-  const response = await chrome.tabs.sendMessage(tabId, { action: 'GET_CONFIG' })
+  const documentId = await ensureContentScript(tabId)
+  const response = await chrome.tabs.sendMessage(tabId, { action: 'GET_CONFIG' }, { documentId })
   if (!response?.config?.at) {
     throw new Error('Could not extract page config (XSRF token missing). Try refreshing the Jules tab.')
   }

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/content.js
+++ b/content.js
@@ -62,7 +62,7 @@ function getAccountNum() {
     const parts = new URL(location.href).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Jules Task Archiver",
   "version": "2.0.0",
   "description": "Bulk archive Jules tasks and start code suggestions via batchexecute API",
-  "permissions": ["storage", "tabs", "scripting"],
+  "permissions": ["storage", "tabs", "scripting", "webNavigation"],
   "host_permissions": ["https://jules.google.com/*", "https://api.github.com/*"],
   "background": {
     "service_worker": "background.js"

--- a/tests/security.test.js
+++ b/tests/security.test.js
@@ -128,16 +128,19 @@ function setupEnvironment(initialTabs = {}) {
       getPlatformInfo: async () => ({})
     },
     tabs: {
-      get: async (id) => {
-        if (initialTabs[id]) return initialTabs[id]
-        return { id, url: 'https://jules.google.com/u/0/' }
-      },
-      sendMessage: async (_tabId, message) => {
+      sendMessage: async (_tabId, message, options) => {
+        chromeMock.tabs.lastMessageOptions = options
         if (message.action === 'PING') {
           // Simulate script not loaded by throwing
           throw new Error('Could not establish connection. Receiving end does not exist.')
         }
         return {}
+      }
+    },
+    webNavigation: {
+      getFrame: async ({ tabId }) => {
+        if (initialTabs[tabId]) return initialTabs[tabId]
+        return { documentId: 'doc_default', url: 'https://jules.google.com/u/0/' }
       }
     },
     scripting: {
@@ -183,23 +186,29 @@ describe('ensureContentScript Security', () => {
     })
   })
 
-  it('should block injection if URL changes to non-Jules origin (TOCTOU)', async () => {
-    const { sandbox, chromeMock } = setupEnvironment()
+  it('should pin execution to documentId to prevent TOCTOU', async () => {
+    const { sandbox, chromeMock } = setupEnvironment({
+      789: { documentId: 'doc_789', url: 'https://jules.google.com/u/0/' }
+    })
 
-    let callCount = 0
-    chromeMock.tabs.get = async (id) => {
-      callCount++
-      if (callCount === 1) {
-        return { id, url: 'https://jules.google.com/u/0/' }
+    let injected = false
+    chromeMock.tabs.sendMessage = async (_tabId, message, options) => {
+      chromeMock.tabs.lastMessageOptions = options
+      if (message.action === 'PING') {
+        if (injected) return { status: 'ok' }
+        throw new Error('Not loaded')
       }
-      return { id, url: 'https://evil.com/' }
+    }
+    chromeMock.scripting.executeScript = async ({ target, files }) => {
+      chromeMock.scripting.lastCall = { target, files }
+      injected = true
     }
 
-    // This is expected to fail CURRENTLY because ensureContentScript doesn't re-check the URL
-    // We WANT it to fail to prove the vulnerability exists.
-    await assert.rejects(sandbox.test_ensureContentScript(123), {
-      message: /Security Error: Cannot inject script into non-Jules tab/
-    })
+    const docId = await sandbox.test_ensureContentScript(789)
+
+    assert.strictEqual(docId, 'doc_789')
+    assert.strictEqual(chromeMock.scripting.lastCall.target.documentIds[0], 'doc_789')
+    assert.strictEqual(chromeMock.tabs.lastMessageOptions.documentId, 'doc_789')
   })
 
   it('should allow injection into valid Jules origin', async () => {


### PR DESCRIPTION
🚨 **Severity:** HIGH

💡 **Vulnerability:** A Time-of-Check to Time-of-Use (TOCTOU) vulnerability existed during content script injection. `ensureContentScript` in `background.js` previously verified the origin of a tab using `chrome.tabs.get`, but then relied solely on `tabId` when executing `chrome.scripting.executeScript`. If the tab navigated to a different origin in the brief time window between the check and the injection, the script would be injected into the unintended, potentially malicious origin.

🎯 **Impact:** If exploited, this could allow the extension's content script to execute within the context of a malicious page, potentially leading to unauthorized access, code execution, or token leakage, compromising the security guarantees of the extension.

🛠️ **Fix:** 
- Added the `webNavigation` permission to `manifest.json`.
- Updated `ensureContentScript` to retrieve a specific `documentId` using `chrome.webNavigation.getFrame`.
- Modified both `chrome.scripting.executeScript` and `chrome.tabs.sendMessage` to strictly require this `documentId` (`target.documentIds: [documentId]` and `options: { documentId }`). This successfully pins the execution strictly to the document verified during the origin check.

✅ **Verification:**
- Ran unit tests via `pnpm test`, with new assertions added to `tests/security.test.js` to ensure the mock Chrome APIs receive the specific `documentId`.
- Verified formatting using `npx @biomejs/biome check --write .`.
- Recorded learning in `.Jules/sentinel.md`.

---
*PR created automatically by Jules for task [7690419683570321554](https://jules.google.com/task/7690419683570321554) started by @n24q02m*