### PR TITLE
🛡️ Sentinel: MEDIUM Fix weak wildcard message origin validation

### DIFF
--- a/background.js
+++ b/background.js
@@ -16,7 +16,7 @@ function extractAccountNum(url) {
     const parts = new URL(url).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }

--- a/content.js
+++ b/content.js
@@ -41,7 +41,7 @@ function extractConfig() {
 
   return new Promise((resolve) => {
     // Ask main-world.js to re-broadcast config
-    window.postMessage({ type: 'JULES_REQUEST_CONFIG' }, '*')
+    window.postMessage({ type: 'JULES_REQUEST_CONFIG' }, window.location.origin)
 
     const timeout = setTimeout(() => resolve(cachedConfig), 2000)
     const handler = (event) => {
@@ -62,7 +62,7 @@ function getAccountNum() {
     const parts = new URL(location.href).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }

--- a/main-world.js
+++ b/main-world.js
@@ -26,7 +26,7 @@ function broadcastConfig() {
           }
         : null
     },
-    '*'
+    window.location.origin
   )
 }
 
@@ -54,7 +54,7 @@ if (!window.__julesArchiver) {
               capturedAt: Date.now()
             }
           },
-          '*'
+          window.location.origin
         )
       } catch (_e) {
         /* ignore parse errors */

--- a/tests/postmessage_security.test.js
+++ b/tests/postmessage_security.test.js
@@ -1,0 +1,38 @@
+const { describe, it } = require('node:test')
+const assert = require('node:assert')
+const fs = require('node:fs')
+const path = require('node:path')
+
+describe('PostMessage Security', () => {
+  it('main-world.js should NOT use wildcard origin for postMessage', () => {
+    const content = fs.readFileSync(path.join(__dirname, '../main-world.js'), 'utf8')
+    assert.ok(
+      !content.includes(
+        'postMessage(' +
+          '{' +
+          "\n      type: 'JULES_ARCHIVER_CONFIG',\n      config: w\n        ? {\n            at: w.SNlM0e || null,\n            bl: w.cfb2h || null,\n            fsid: w.FdrFJe || null,\n            modelId: modelMatch ? modelMatch[0] : null,\n            timestamp: Date.now()\n          }\n        : null\n    }, '*'"
+      ),
+      'Should not use "*" for JULES_ARCHIVER_CONFIG'
+    )
+    assert.ok(content.includes('window.location.origin'), 'Should use window.location.origin')
+  })
+
+  it('content.js should NOT use wildcard origin for postMessage', () => {
+    const content = fs.readFileSync(path.join(__dirname, '../content.js'), 'utf8')
+    assert.ok(
+      !content.includes("window.postMessage({ type: 'JULES_REQUEST_CONFIG' }, '*')"),
+      'Should not use "*" for JULES_REQUEST_CONFIG'
+    )
+    assert.ok(content.includes('window.location.origin'), 'Should use window.location.origin')
+  })
+
+  it('Source code should not contain postMessage(..., "*")', () => {
+    const mainWorld = fs.readFileSync(path.join(__dirname, '../main-world.js'), 'utf8')
+    const contentJs = fs.readFileSync(path.join(__dirname, '../content.js'), 'utf8')
+
+    const wildcardRegex = /postMessage\s*\(\s*\{[^}]+\}\s*,\s*['"]\*['"]\s*\)/
+
+    assert.strictEqual(wildcardRegex.test(mainWorld), false, 'main-world.js should not contain postMessage with "*"')
+    assert.strictEqual(wildcardRegex.test(contentJs), false, 'content.js should not contain postMessage with "*"')
+  })
+})


### PR DESCRIPTION
🚨 Severity: Medium
💡 Vulnerability: JULES_ARCHIVER_CONFIG and other messages were being sent with '*' as the target origin in postMessage.
🎯 Impact: Malicious scripts on the same page could intercept sensitive WIZ_global_data tokens.
🛠️ Fix: Changed target origin from '*' to 'window.location.origin' in both main-world.js and content.js.
✅ Verification: Added tests/postmessage_security.test.js and verified with pnpm test.

---
*PR created automatically by Jules for task [15299998300145471134](https://jules.google.com/task/15299998300145471134) started by @n24q02m*