### PR TITLE
🧪 [TEST] Missing error path test for getTabConfig

### DIFF
--- a/background.js
+++ b/background.js
@@ -16,7 +16,7 @@ function extractAccountNum(url) {
     const parts = new URL(url).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }

--- a/content.js
+++ b/content.js
@@ -62,7 +62,7 @@ function getAccountNum() {
     const parts = new URL(location.href).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -87,6 +87,7 @@ function setupEnvironment(initialStorage = {}) {
     globalThis.test_ARCHIVABLE_STATES = ARCHIVABLE_STATES;
     globalThis.test_JULES_ORIGIN = JULES_ORIGIN;
     globalThis.test_getJulesTabs = getJulesTabs;
+    globalThis.test_getTabConfig = getTabConfig;
     globalThis.test_extractAccountNum = extractAccountNum;
     globalThis.test_getTabLabel = getTabLabel;
     globalThis.test_getOpenPRs = getOpenPRs;
@@ -796,5 +797,32 @@ describe('getJulesTabs', () => {
     assert.strictEqual(tabs.length, 2)
     assert.strictEqual(sandbox.test_extractAccountNum(tabs[0].url), '0')
     assert.strictEqual(sandbox.test_extractAccountNum(tabs[1].url), '1')
+  })
+})
+
+describe('getTabConfig', () => {
+  it('should return config when sendMessage returns valid response', async () => {
+    const { sandbox } = setupEnvironment()
+    const config = await sandbox.test_getTabConfig(1)
+    assert.strictEqual(config.at, 'token')
+    assert.strictEqual(config.bl, 'build')
+    assert.strictEqual(config.accountNum, '0')
+  })
+
+  it('should throw error when XSRF token is missing', async () => {
+    const { sandbox } = setupEnvironment()
+    sandbox.chrome.tabs.sendMessage = async () => ({
+      config: { bl: 'build' },
+      accountNum: '0'
+    })
+
+    await assert.rejects(sandbox.test_getTabConfig(1), /Could not extract page config \(XSRF token missing\)/)
+  })
+
+  it('should throw error when response is null', async () => {
+    const { sandbox } = setupEnvironment()
+    sandbox.chrome.tabs.sendMessage = async () => null
+
+    await assert.rejects(sandbox.test_getTabConfig(1), /Could not extract page config \(XSRF token missing\)/)
   })
 })


### PR DESCRIPTION
🎯 What
- Added unit tests for `getTabConfig` in `background.js` to cover both success and error paths.
- Exposed `getTabConfig` to the `node:vm` test sandbox.
- Verified that `getTabConfig` correctly throws when the XSRF token (`at`) is missing from the content script response.

📊 Coverage
- Added 3 new test cases to `tests/background.test.js`.
- Total passing tests in the suite increased from 67 to 70.

✨ Result
- Improved test coverage for critical configuration extraction logic in the background service worker.

---
*PR created automatically by Jules for task [1300981454344689841](https://jules.google.com/task/1300981454344689841) started by @n24q02m*