### PR TITLE
[TEST] Untested getStartConfig function

### DIFF
--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -99,6 +99,7 @@ function setupEnvironment(initialStorage = {}) {
     globalThis.test_SDETAIL = SDETAIL;
     globalThis.test_CATEGORY_CONFIG = CATEGORY_CONFIG;
     globalThis.test_DEFAULT_CATEGORY = DEFAULT_CATEGORY;
+    globalThis.test_getStartConfig = getStartConfig;
   `
 
   const script = new vm.Script(scriptContent)
@@ -796,5 +797,20 @@ describe('getJulesTabs', () => {
     assert.strictEqual(tabs.length, 2)
     assert.strictEqual(sandbox.test_extractAccountNum(tabs[0].url), '0')
     assert.strictEqual(sandbox.test_extractAccountNum(tabs[1].url), '1')
+  })
+})
+
+describe('getStartConfig', () => {
+  it('should return cached config from session storage', async () => {
+    const mockConfig = { modelId: 'test-model' }
+    const { sandbox } = setupEnvironment({ startConfig: mockConfig })
+    const result = await sandbox.test_getStartConfig()
+    assert.deepStrictEqual(result, mockConfig)
+  })
+
+  it('should return null when no config is cached', async () => {
+    const { sandbox } = setupEnvironment({})
+    const result = await sandbox.test_getStartConfig()
+    assert.strictEqual(result, null)
   })
 })


### PR DESCRIPTION
🎯 What: Added unit tests for the `getStartConfig` function in `background.js`.
📊 Coverage: Added tests for scenarios where the configuration is either cached in session storage or missing.
✨ Result: Ensured `getStartConfig` correctly interacts with `chrome.storage.session` and returns the expected values, improving test coverage for the background service worker.

---
*PR created automatically by Jules for task [11572254943506259301](https://jules.google.com/task/11572254943506259301) started by @n24q02m*