### PR TITLE
🧪 [TEST] Untested broadcastConfig in main world script

### DIFF
--- a/background.js
+++ b/background.js
@@ -16,7 +16,7 @@ function extractAccountNum(url) {
     const parts = new URL(url).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }

--- a/content.js
+++ b/content.js
@@ -62,7 +62,7 @@ function getAccountNum() {
     const parts = new URL(location.href).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }

--- a/tests/main-world.test.js
+++ b/tests/main-world.test.js
@@ -1,0 +1,182 @@
+const { describe, it } = require('node:test')
+const assert = require('node:assert')
+const fs = require('node:fs')
+const path = require('node:path')
+const vm = require('node:vm')
+
+const mainWorldJs = fs.readFileSync(path.join(__dirname, '../main-world.js'), 'utf8')
+
+function setupSandbox(initialWizData = {}) {
+  const messages = []
+  const listeners = {}
+
+  const windowMock = {
+    WIZ_global_data: initialWizData,
+    postMessage: (data, targetOrigin) => {
+      messages.push({ data, targetOrigin })
+    },
+    addEventListener: (type, listener) => {
+      listeners[type] = listeners[type] || []
+      listeners[type].push(listener)
+    },
+    fetch: async () => ({ ok: true }),
+    __julesArchiver: undefined,
+    Date: {
+      now: () => 1234567890
+    },
+    URLSearchParams: class {
+      constructor(init) {
+        this.params = new URLSearchParams(init)
+      }
+      get(name) {
+        return this.params.get(name)
+      }
+    }
+  }
+
+  // Circular reference common in browsers
+  windowMock.window = windowMock
+
+  const sandbox = {
+    window: windowMock,
+    console,
+    URLSearchParams: windowMock.URLSearchParams,
+    JSON,
+    Date: windowMock.Date,
+    String,
+    setTimeout
+  }
+
+  vm.createContext(sandbox)
+  return { sandbox, windowMock, messages, listeners }
+}
+
+describe('main-world.js', () => {
+  it('should broadcast config on load', () => {
+    const { sandbox, messages } = setupSandbox({
+      SNlM0e: 'at-token',
+      cfb2h: 'bl-label',
+      FdrFJe: 'fsid-token',
+      TSDtV: 'beyond:models/gemini-pro'
+    })
+
+    vm.runInContext(mainWorldJs, sandbox)
+
+    assert.strictEqual(messages.length, 1)
+    assert.strictEqual(messages[0].data.type, 'JULES_ARCHIVER_CONFIG')
+    assert.strictEqual(messages[0].data.config.at, 'at-token')
+    assert.strictEqual(messages[0].data.config.bl, 'bl-label')
+    assert.strictEqual(messages[0].data.config.fsid, 'fsid-token')
+    assert.strictEqual(messages[0].data.config.modelId, 'beyond:models/gemini-pro')
+    assert.strictEqual(messages[0].data.config.timestamp, 1234567890)
+  })
+
+  it('should handle missing WIZ_global_data', () => {
+    const { sandbox, messages } = setupSandbox(null)
+
+    vm.runInContext(mainWorldJs, sandbox)
+
+    assert.strictEqual(messages.length, 1)
+    assert.strictEqual(messages[0].data.config, null)
+  })
+
+  it('should handle partial WIZ_global_data', () => {
+    const { sandbox, messages } = setupSandbox({
+      SNlM0e: 'at-token'
+    })
+
+    vm.runInContext(mainWorldJs, sandbox)
+
+    assert.strictEqual(messages[0].data.config.at, 'at-token')
+    assert.strictEqual(messages[0].data.config.bl, null)
+    assert.strictEqual(messages[0].data.config.modelId, null)
+  })
+
+  it('should respond to JULES_REQUEST_CONFIG message', () => {
+    const { sandbox, messages, listeners, windowMock } = setupSandbox({
+      SNlM0e: 'at-token'
+    })
+
+    vm.runInContext(mainWorldJs, sandbox)
+    assert.strictEqual(messages.length, 1) // Initial broadcast
+
+    // Simulate request message
+    const event = {
+      source: windowMock,
+      data: { type: 'JULES_REQUEST_CONFIG' }
+    }
+    listeners.message.forEach((l) => {
+      l(event)
+    })
+
+    assert.strictEqual(messages.length, 2)
+    assert.strictEqual(messages[1].data.type, 'JULES_ARCHIVER_CONFIG')
+  })
+
+  it('should ignore JULES_REQUEST_CONFIG from other sources', () => {
+    const { sandbox, messages, listeners } = setupSandbox({
+      SNlM0e: 'at-token'
+    })
+
+    vm.runInContext(mainWorldJs, sandbox)
+    assert.strictEqual(messages.length, 1)
+
+    // Simulate request message from wrong source
+    const event = {
+      source: {}, // Not window
+      data: { type: 'JULES_REQUEST_CONFIG' }
+    }
+    listeners.message.forEach((l) => {
+      l(event)
+    })
+
+    assert.strictEqual(messages.length, 1)
+  })
+
+  it('should intercept Rja83d fetch and broadcast start config', async () => {
+    const { sandbox, messages, windowMock } = setupSandbox({})
+
+    vm.runInContext(mainWorldJs, sandbox)
+    assert.strictEqual(messages.length, 1) // Initial broadcast
+
+    // Setup mock payload
+    const payload = [
+      null,
+      null,
+      ['model-config', null, null, null, null, null, null, null, null, null, ['flag1']], // payload[2] and payload[2][10]
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      [null, null, null, null, ['exp1', 'exp2']] // payload[9][4]
+    ]
+    const freq = [[['id', JSON.stringify(payload)]]]
+    const body = `f.req=${encodeURIComponent(JSON.stringify(freq))}`
+
+    // Call intercepted fetch
+    await windowMock.fetch('https://jules.google.com/_/Swebot/data/batchexecute?rpcids=Rja83d', {
+      method: 'POST',
+      body
+    })
+
+    const startMsg = messages.find((m) => m.data.type === 'JULES_START_CONFIG')
+    assert.ok(startMsg, 'JULES_START_CONFIG message should be sent')
+    assert.deepStrictEqual(startMsg.data.config.modelConfig, payload[2])
+    assert.deepStrictEqual(startMsg.data.config.experimentIds, ['exp1', 'exp2'])
+    assert.deepStrictEqual(startMsg.data.config.featureFlags, ['flag1'])
+    assert.strictEqual(startMsg.data.config.capturedAt, 1234567890)
+  })
+
+  it('should ignore other fetch calls', async () => {
+    const { sandbox, messages, windowMock } = setupSandbox({})
+
+    vm.runInContext(mainWorldJs, sandbox)
+    const initialCount = messages.length
+
+    await windowMock.fetch('https://jules.google.com/other-api')
+
+    assert.strictEqual(messages.length, initialCount)
+  })
+})


### PR DESCRIPTION
🎯 What: Added unit tests for `main-world.js` and fixed minor linting issues in `background.js` and `content.js`.

📊 Coverage:
- `broadcastConfig` extraction logic (success, partial, missing WIZ_global_data).
- `JULES_REQUEST_CONFIG` message listener.
- `fetch` observer for `Rja83d` (StartSuggestion) config capture.

✨ Result: `main-world.js` logic is now fully verified in a `node:vm` sandbox environment, ensuring robust token extraction and config capture.

---
*PR created automatically by Jules for task [9036277130688877797](https://jules.google.com/task/9036277130688877797) started by @n24q02m*