### PR TITLE
🧪 [TEST] Untested getAccountLabel content script function

### DIFF
--- a/background.js
+++ b/background.js
@@ -16,7 +16,7 @@ function extractAccountNum(url) {
     const parts = new URL(url).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }

--- a/content.js
+++ b/content.js
@@ -62,7 +62,7 @@ function getAccountNum() {
     const parts = new URL(location.href).pathname.split('/')
     const uIdx = parts.indexOf('u')
     return uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'
-  } catch (e) {
+  } catch (_e) {
     return '0'
   }
 }

--- a/tests/content_account.test.js
+++ b/tests/content_account.test.js
@@ -1,0 +1,90 @@
+const { describe, it } = require('node:test')
+const assert = require('node:assert')
+const fs = require('node:fs')
+const path = require('node:path')
+const vm = require('node:vm')
+
+const contentJsPath = path.join(__dirname, '../content.js')
+const contentJsContent = fs.readFileSync(contentJsPath, 'utf8')
+
+function setupContentSandbox(initialUrl = 'https://jules.google.com/u/0/') {
+  const chrome = {
+    runtime: {
+      getURL: (path) => `chrome-extension://id/${path}`,
+      sendMessage: () => {},
+      onMessage: {
+        addListener: () => {}
+      }
+    }
+  }
+
+  const document = {
+    createElement: () => ({
+      setAttribute: () => {},
+      onload: null,
+      remove: () => {}
+    }),
+    head: {
+      appendChild: (el) => {
+        if (el.onload) el.onload()
+      }
+    },
+    documentElement: {}
+  }
+
+  const window = {
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    postMessage: () => {}
+  }
+
+  const location = {
+    href: initialUrl
+  }
+
+  const sandbox = {
+    chrome,
+    document,
+    window,
+    location,
+    URL,
+    console,
+    setTimeout,
+    clearTimeout,
+    Promise,
+    Date
+  }
+
+  vm.createContext(sandbox)
+  vm.runInContext(contentJsContent, sandbox)
+
+  return sandbox
+}
+
+describe('content.js getAccountLabel', () => {
+  it('should return "default" for account 0', () => {
+    const sandbox = setupContentSandbox('https://jules.google.com/u/0/session')
+    assert.strictEqual(sandbox.getAccountLabel(), 'default')
+  })
+
+  it('should return "u/1" for account 1', () => {
+    const sandbox = setupContentSandbox('https://jules.google.com/u/1/tasks')
+    assert.strictEqual(sandbox.getAccountLabel(), 'u/1')
+  })
+
+  it('should return "default" when no account segment is present', () => {
+    const sandbox = setupContentSandbox('https://jules.google.com/tasks')
+    assert.strictEqual(sandbox.getAccountLabel(), 'default')
+  })
+
+  it('should return "default" for trailing "u" without ID', () => {
+    const sandbox = setupContentSandbox('https://jules.google.com/u/')
+    assert.strictEqual(sandbox.getAccountLabel(), 'default')
+  })
+
+  it('should handle malformed URLs gracefully via getAccountNum try-catch', () => {
+    const sandbox = setupContentSandbox('not-a-url')
+    // getAccountNum has a try-catch that returns '0' on error
+    assert.strictEqual(sandbox.getAccountLabel(), 'default')
+  })
+})


### PR DESCRIPTION
### 🎯 What
- Created \`tests/content_account.test.js\` to test account label logic in \`content.js\`.
- Mocked browser globals (\`chrome\`, \`window\`, \`document\`, \`location\`) for isolated testing within a \`node:vm\` sandbox.
- Verified account label detection logic across various URL patterns.

### 📊 Coverage
- Verified "default" label for account 0 (\`/u/0/\`).
- Verified "u/1" label for account 1 (\`/u/1/\`).
- Verified "default" label for URLs without account segments.
- Verified "default" label for malformed or incomplete account segments.
- Handled \`injectMainWorldScript\` side effects during VM initialization.

### ✨ Result
- All 72 tests pass (including 5 new cases).
- Fixed unused variables in \`content.js\` and \`background.js\` discovered during Biome linting.

---
*PR created automatically by Jules for task [10962798933819609035](https://jules.google.com/task/10962798933819609035) started by @n24q02m*