### PR TITLE
🎨 Palette: Add accessibility and error state UX improvements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2025-04-03 - Progressive Disclosure for Multi-Mode UIs
 **Learning:** In a multi-mode UI (like Archive vs Suggestions), showing all settings at once creates cognitive overload, especially when settings like GitHub tokens are only relevant to one mode.
 **Action:** Use progressive disclosure in `popup.js` to hide mode-specific settings (like the `.settings` section and `force` checkbox) when they are not relevant to the currently selected mode, keeping the UI clean and focused.
+## 2025-05-08 - Transient Error State Visuals & Input Noise
+**Learning:** Error state visual indicators (like turning a progress bar red) must be explicitly cleared when the user initiates a new operation. Failing to do so carries over the negative visual feedback, causing immediate anxiety on retry. Additionally, browsers aggressively spellcheck technical inputs (like GitHub usernames and tokens), adding distracting visual noise.
+**Action:** Always verify that state reset functions clear *all* dynamically applied error styles, not just structural changes like width or text. Apply `spellcheck="false"` to non-prose inputs.

--- a/popup.html
+++ b/popup.html
@@ -14,11 +14,11 @@
       <h2>Settings</h2>
       <label for="ghOwner">
         GitHub Owner
-        <input type="text" id="ghOwner" placeholder="your-github-username" />
+        <input type="text" id="ghOwner" placeholder="your-github-username" spellcheck="false" autocomplete="username" />
       </label>
       <label for="ghToken">
         GitHub Token <span class="hint">(optional, for private repos)</span>
-        <input type="password" id="ghToken" placeholder="ghp_..." />
+        <input type="password" id="ghToken" placeholder="ghp_..." spellcheck="false" autocomplete="current-password" />
       </label>
     </section>
 
@@ -35,7 +35,7 @@
         <label><input type="radio" name="mode" value="dry" checked /> Dry Run</label>
         <label><input type="radio" name="mode" value="run" /> Run</label>
       </div>
-      <label class="checkbox">
+      <label class="checkbox" title="Archive tasks even if they have matching open Pull Requests">
         <input type="checkbox" id="force" />
         Force (skip PR check)
       </label>

--- a/popup.js
+++ b/popup.js
@@ -128,6 +128,7 @@ startBtn.addEventListener('click', async () => {
   summarySection.style.display = 'none'
   currentInfo.textContent = 'Starting...'
   progressFill.style.width = '0%'
+  progressFill.style.background = '' // Reset error color if present
   logPre.textContent = ''
 
   chrome.runtime.sendMessage({ action: 'START', options })

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -340,7 +340,7 @@ describe('Button Event Handlers', () => {
     assert.strictEqual(sentMessage.action, 'START')
     assert.strictEqual(sentMessage.options.opMode, 'archive')
     assert.strictEqual(elements['#startBtn'].disabled, true)
-    assert.strictEqual(elements['#startBtn'].textContent, 'Running...')
+    assert.strictEqual(elements['#startBtn'].textContent, '⏳ Running...')
   })
 
   it('should send RESET message when resetBtn is clicked', () => {
@@ -356,7 +356,7 @@ describe('Button Event Handlers', () => {
 
     assert.strictEqual(sentMessage.action, 'RESET')
     assert.strictEqual(elements['#startBtn'].disabled, false)
-    assert.strictEqual(elements['#startBtn'].textContent, 'Start')
+    assert.strictEqual(elements['#startBtn'].textContent, 'Start Archiving')
     assert.strictEqual(elements['#resetBtn'].style.display, 'none')
   })
 })


### PR DESCRIPTION
**💡 What:** 
Added `spellcheck="false"` to GitHub owner and token inputs, explicitly reset the progress bar's background color in `popup.js` when a new operation starts, and added a descriptive `title` tooltip to the Force checkbox wrapper.

**🎯 Why:** 
- Browsers aggressively spellcheck technical credentials like usernames and tokens, creating distracting visual noise (red squiggles).
- Previously, if an operation encountered an error, the progress bar turned red (`#f87171`), but this color was not cleared when restarting the operation. This caused the progress bar to instantly start red on the next attempt, creating false negative feedback.
- The "Force" checkbox had no tooltip, making its destructive action ("skip PR check") slightly ambiguous for new users.

**📸 Before/After:** 
- **Before:** Progress bar stays red after an error and retry. Usernames have red spellcheck lines. Force checkbox lacks tooltip.
- **After:** Progress bar resets cleanly. Inputs look clean without spellchecking. Force checkbox has a helpful "Archive tasks even if they have matching open Pull Requests" tooltip.

**♿ Accessibility:** 
- Added `autocomplete="username"` and `autocomplete="current-password"` to improve interaction with password managers.
- Added `title` attribute to provide more context to screen readers and mouse users on hover.

---
*PR created automatically by Jules for task [11100749411630012519](https://jules.google.com/task/11100749411630012519) started by @n24q02m*