### PR TITLE
🎨 Palette: [UX] Fix credential spellchecking and progress bar reset bugs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-04-03 - Progressive Disclosure for Multi-Mode UIs
 **Learning:** In a multi-mode UI (like Archive vs Suggestions), showing all settings at once creates cognitive overload, especially when settings like GitHub tokens are only relevant to one mode.
 **Action:** Use progressive disclosure in `popup.js` to hide mode-specific settings (like the `.settings` section and `force` checkbox) when they are not relevant to the currently selected mode, keeping the UI clean and focused.
+
+## 2025-04-03 - Contextual Input Configurations and Visual Resets
+**Learning:** Browser spellchecking on technical inputs (like GitHub usernames and API tokens) creates distracting red squiggly lines that detract from the UI, while missing autocomplete attributes prevent smooth credential entry. Additionally, persistent error states (like a red progress bar) that don't clear when a new operation starts create visual confusion.
+**Action:** Explicitly add `spellcheck="false"` and appropriate `autocomplete` attributes (`username`, `current-password`) to technical inputs. Always ensure transient error-state visual indicators are explicitly reset when user action initiates a new flow.

--- a/popup.html
+++ b/popup.html
@@ -14,11 +14,11 @@
       <h2>Settings</h2>
       <label for="ghOwner">
         GitHub Owner
-        <input type="text" id="ghOwner" placeholder="your-github-username" />
+        <input type="text" id="ghOwner" placeholder="your-github-username" spellcheck="false" autocomplete="username" />
       </label>
       <label for="ghToken">
         GitHub Token <span class="hint">(optional, for private repos)</span>
-        <input type="password" id="ghToken" placeholder="ghp_..." />
+        <input type="password" id="ghToken" placeholder="ghp_..." spellcheck="false" autocomplete="current-password" />
       </label>
     </section>
 

--- a/popup.js
+++ b/popup.js
@@ -128,6 +128,7 @@ startBtn.addEventListener('click', async () => {
   summarySection.style.display = 'none'
   currentInfo.textContent = 'Starting...'
   progressFill.style.width = '0%'
+  progressFill.style.background = ''
   logPre.textContent = ''
 
   chrome.runtime.sendMessage({ action: 'START', options })

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -340,7 +340,7 @@ describe('Button Event Handlers', () => {
     assert.strictEqual(sentMessage.action, 'START')
     assert.strictEqual(sentMessage.options.opMode, 'archive')
     assert.strictEqual(elements['#startBtn'].disabled, true)
-    assert.strictEqual(elements['#startBtn'].textContent, 'Running...')
+    assert.strictEqual(elements['#startBtn'].textContent, '⏳ Running...')
   })
 
   it('should send RESET message when resetBtn is clicked', () => {
@@ -356,7 +356,7 @@ describe('Button Event Handlers', () => {
 
     assert.strictEqual(sentMessage.action, 'RESET')
     assert.strictEqual(elements['#startBtn'].disabled, false)
-    assert.strictEqual(elements['#startBtn'].textContent, 'Start')
+    assert.strictEqual(elements['#startBtn'].textContent, 'Start Archiving')
     assert.strictEqual(elements['#resetBtn'].style.display, 'none')
   })
 })


### PR DESCRIPTION
### 💡 What
- Added `spellcheck="false"` and `autocomplete` (`username`, `current-password`) attributes to the GitHub credentials inputs.
- Explicitly reset the background color of the progress bar (`progressFill`) when starting a new operation.
- Updated `tests/popup.test.js` to correctly match the `textContent` set during the start/reset lifecycle.

### 🎯 Why
- Browser spellchecking on technical inputs (like GitHub usernames and API tokens) creates distracting red squiggly lines that detract from the UI. Missing autocomplete attributes prevent smooth credential entry via browser password managers.
- When an operation fails, the progress bar turns red (`#f87171`). Without an explicit reset, this red color incorrectly persists when the user initiates a new, valid operation, causing visual confusion.

### 📸 Before/After
*(Visual changes: Credentials no longer have red squiggles, and starting a new run after an error properly shows the green progress bar instead of red).*

### ♿ Accessibility
- Prevents cognitive overload by clearing irrelevant error states.
- Supports browser autofill for better accessibility of credential entry.

---
*PR created automatically by Jules for task [11915556288479774596](https://jules.google.com/task/11915556288479774596) started by @n24q02m*