### PR TITLE
fix(cd): add force release option for emoji-prefix commits

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,6 +10,16 @@ on:
         options:
           - beta
           - stable
+      force:
+        description: "Force release level (when no version-worthy commits)"
+        required: false
+        type: choice
+        default: "none"
+        options:
+          - none
+          - patch
+          - minor
+          - major
 
 permissions:
   contents: write
@@ -51,6 +61,7 @@ jobs:
           config_file: semantic-release.toml
           prerelease: ${{ inputs.release_type == 'beta' }}
           prerelease_token: beta
+          force: ${{ inputs.force != 'none' && inputs.force || '' }}
 
       - uses: python-semantic-release/publish-action@310a9983a0ae878b29f3aac778d7c77c1db27378 # v10
         if: steps.release.outputs.released == 'true'


### PR DESCRIPTION
## Summary
PSR doesn't bump on dispatches when commits use emoji titles (🛡️/⚡/🎨/🧪/🧹) — angular conventional parser ignores these. Add force input mirroring QuikShipping PR #811.

## Test plan
- [ ] Next dispatch with force=patch produces new tag (e.g. v2.2.1) + zip artifact