### PR TITLE
🎨 Palette: [UX] Improve focus management and screen reader accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,6 @@
 ## 2025-05-08 - Transient Error State Visuals & Input Noise
 **Learning:** Error state visual indicators (like turning a progress bar red) must be explicitly cleared when the user initiates a new operation. Failing to do so carries over the negative visual feedback, causing immediate anxiety on retry. Additionally, browsers aggressively spellcheck technical inputs (like GitHub usernames and tokens), adding distracting visual noise.
 **Action:** Always verify that state reset functions clear *all* dynamically applied error styles, not just structural changes like width or text. Apply `spellcheck="false"` to non-prose inputs.
+## 2025-05-15 - Maintaining Keyboard Focus When Hiding Elements
+**Learning:** When a currently focused interactive element (like a Reset button) is hidden from the UI (e.g., `display: none`), keyboard focus is lost and resets to the document body, breaking the user's flow.
+**Action:** Always programmatically move focus to the next logical interactive element (e.g., the primary action button) immediately after hiding the active element.

--- a/popup.html
+++ b/popup.html
@@ -17,8 +17,8 @@
         <input type="text" id="ghOwner" placeholder="your-github-username" spellcheck="false" autocomplete="username" />
       </label>
       <label for="ghToken">
-        GitHub Token <span class="hint">(optional, for private repos)</span>
-        <input type="password" id="ghToken" placeholder="ghp_..." spellcheck="false" autocomplete="current-password" />
+        GitHub Token <span id="ghTokenHint" class="hint">(optional, for private repos)</span>
+        <input type="password" id="ghToken" placeholder="ghp_..." spellcheck="false" autocomplete="current-password" aria-describedby="ghTokenHint" />
       </label>
     </section>
 

--- a/popup.js
+++ b/popup.js
@@ -143,6 +143,7 @@ resetBtn.addEventListener('click', () => {
   resetBtn.style.display = 'none'
   progressSection.style.display = 'none'
   summarySection.style.display = 'none'
+  startBtn.focus()
 })
 
 // --- Listen for state changes ---

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -67,6 +67,7 @@ function setupPopupSandbox() {
       },
       querySelectorAll: (_sel) => [],
       querySelector: (_sel) => null,
+      focus: () => {},
       textContent: '',
       value: '',
       checked: false,


### PR DESCRIPTION
### 💡 What
- **Focus Management:** Added `startBtn.focus()` to the `resetBtn` click handler so that keyboard focus shifts back to the primary action button after the reset button is hidden.
- **Screen Reader Support:** Added `id="ghTokenHint"` to the hint span and `aria-describedby="ghTokenHint"` to the GitHub Token input to semantically link the hint to the field.

### 🎯 Why
- When an interactive element (like the Reset button) is focused and then hidden with `display: none`, focus defaults back to the document body. This breaks the flow for keyboard-only users. Explicitly moving focus prevents this.
- The "(optional, for private repos)" hint was adjacent to the input visually but not programmatically associated, meaning screen reader users wouldn't automatically hear it when tabbing into the field.

### 📸 Before/After
*(No visual changes, but behavioral changes verified via Playwright video/screenshot)*

### ♿ Accessibility
- Improves keyboard navigation continuity by managing focus actively during state transitions.
- Improves screen reader experience by properly associating descriptive text with the corresponding input field using ARIA attributes.

---
*PR created automatically by Jules for task [4907489631184293299](https://jules.google.com/task/4907489631184293299) started by @n24q02m*