### PR TITLE
🎨 Palette: [UX] Improve popup.html accessibility and keyboard focus

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -17,8 +17,8 @@
         <input type="text" id="ghOwner" placeholder="your-github-username" spellcheck="false" autocomplete="username" />
       </label>
       <label for="ghToken">
-        GitHub Token <span class="hint">(optional, for private repos)</span>
-        <input type="password" id="ghToken" placeholder="ghp_..." spellcheck="false" autocomplete="current-password" />
+        GitHub Token <span id="ghTokenHint" class="hint">(optional, for private repos)</span>
+        <input type="password" id="ghToken" placeholder="ghp_..." spellcheck="false" autocomplete="current-password" aria-describedby="ghTokenHint" />
       </label>
     </section>
 

--- a/popup.js
+++ b/popup.js
@@ -143,6 +143,7 @@ resetBtn.addEventListener('click', () => {
   resetBtn.style.display = 'none'
   progressSection.style.display = 'none'
   summarySection.style.display = 'none'
+  startBtn.focus()
 })
 
 // --- Listen for state changes ---

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -72,7 +72,10 @@ function setupPopupSandbox() {
       checked: false,
       disabled: false,
       scrollHeight: 0,
-      scrollTop: 0
+      scrollTop: 0,
+      focus: () => {
+        element.focused = true
+      }
     }
     return element
   }
@@ -358,5 +361,6 @@ describe('Button Event Handlers', () => {
     assert.strictEqual(elements['#startBtn'].disabled, false)
     assert.strictEqual(elements['#startBtn'].textContent, 'Start Archiving')
     assert.strictEqual(elements['#resetBtn'].style.display, 'none')
+    assert.strictEqual(elements['#startBtn'].focused, true)
   })
 })

--- a/utils.js
+++ b/utils.js
@@ -3,6 +3,7 @@
  * batchexecute responses can contain raw newlines inside strings which is
  * invalid JSON. This state machine escapes them.
  */
+// biome-ignore lint/correctness/noUnusedVariables: Used globally via importScripts
 function fixJsonControlChars(str) {
   // ⚡ Bolt Optimization: Bypass character-by-character processing loops with a
   // fast regex test for rare conditions (like JSON control characters).


### PR DESCRIPTION
💡 What:
- Added `aria-describedby` to the `ghToken` input field, linking it to the hint text in `popup.html`.
- Implemented programmatic focus management in `popup.js` by calling `startBtn.focus()` when the `resetBtn` is clicked.
- Updated `tests/popup.test.js` to add a `focus` mock method and verify the reset button focus behavior.

🎯 Why:
- The hint text for the GitHub token is important context. Linking it with `aria-describedby` ensures screen readers read it aloud when the input field is focused.
- Previously, clicking the 'Reset' button would hide the button, leaving keyboard focus on the document body. Programmatically moving focus to the 'Start Archiving' button maintains a smooth keyboard navigation flow.

♿ Accessibility:
- Improves screen reader experience by automatically announcing hint text.
- Prevents keyboard users from losing focus context after resetting the operation state.

---
*PR created automatically by Jules for task [17207776449961416349](https://jules.google.com/task/17207776449961416349) started by @n24q02m*