### PR TITLE
🎨 Palette: [UX] Maintain keyboard focus when hiding reset button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,6 @@
 ## 2025-05-08 - Transient Error State Visuals & Input Noise
 **Learning:** Error state visual indicators (like turning a progress bar red) must be explicitly cleared when the user initiates a new operation. Failing to do so carries over the negative visual feedback, causing immediate anxiety on retry. Additionally, browsers aggressively spellcheck technical inputs (like GitHub usernames and tokens), adding distracting visual noise.
 **Action:** Always verify that state reset functions clear *all* dynamically applied error styles, not just structural changes like width or text. Apply `spellcheck="false"` to non-prose inputs.
+## 2025-10-24 - Focus Management on Hidden Elements
+**Learning:** Hiding an interactive element (e.g., `display: none` on `resetBtn`) that currently holds keyboard focus causes the browser to reset focus back to the document body, breaking the user's keyboard navigation flow.
+**Action:** When programmatically hiding the focused element, always manually shift focus (`element.focus()`) to the next logical element in the workflow (e.g., `startBtn`) to maintain accessibility. Ensure testing mock elements support `.focus()`.

--- a/popup.js
+++ b/popup.js
@@ -141,6 +141,7 @@ resetBtn.addEventListener('click', () => {
   startBtn.removeAttribute('aria-busy')
   startBtn.textContent = opMode === 'archive' ? 'Start Archiving' : 'Start Suggestions'
   resetBtn.style.display = 'none'
+  startBtn.focus() // Maintain keyboard flow
   progressSection.style.display = 'none'
   summarySection.style.display = 'none'
 })

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -72,7 +72,11 @@ function setupPopupSandbox() {
       checked: false,
       disabled: false,
       scrollHeight: 0,
-      scrollTop: 0
+      scrollTop: 0,
+      focused: false,
+      focus: () => {
+        element.focused = true
+      }
     }
     return element
   }
@@ -358,5 +362,6 @@ describe('Button Event Handlers', () => {
     assert.strictEqual(elements['#startBtn'].disabled, false)
     assert.strictEqual(elements['#startBtn'].textContent, 'Start Archiving')
     assert.strictEqual(elements['#resetBtn'].style.display, 'none')
+    assert.strictEqual(elements['#startBtn'].focused, true)
   })
 })


### PR DESCRIPTION
### 💡 What
Added `startBtn.focus()` when the `resetBtn` is hidden during the reset action.
Updated the mock environment in `tests/popup.test.js` to support checking focus states and verified the new behavior.
Recorded learning on focus management into `.Jules/palette.md`.

### 🎯 Why
When a user triggers an action (like reset) via keyboard, the `resetBtn` had focus. Immediately hiding this element (`display: none`) caused the browser to lose focus context and drop back to the root document (`<body>`), forcing the user to tab through the entire UI again. Managing focus programmatically prevents this usability regression.

### 📸 Before/After
*Before*: Hitting Enter on the "Reset" button resets the UI, and the next 'Tab' starts back at the top of the browser.
*After*: Hitting Enter on the "Reset" button resets the UI, and the focus gracefully lands on the "Start Archiving" (or Start Suggestions) button, maintaining continuity.

### ♿ Accessibility
Improves keyboard navigation (WCAG 2.1 Focus Order) by maintaining a logical and unbroken focus flow during dynamic UI state transitions.

---
*PR created automatically by Jules for task [14989031912869469064](https://jules.google.com/task/14989031912869469064) started by @n24q02m*