### PR TITLE
🎨 Palette: [UX] Improve form accessibility and keyboard focus flow

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,10 @@
 ## 2025-05-08 - Transient Error State Visuals & Input Noise
 **Learning:** Error state visual indicators (like turning a progress bar red) must be explicitly cleared when the user initiates a new operation. Failing to do so carries over the negative visual feedback, causing immediate anxiety on retry. Additionally, browsers aggressively spellcheck technical inputs (like GitHub usernames and tokens), adding distracting visual noise.
 **Action:** Always verify that state reset functions clear *all* dynamically applied error styles, not just structural changes like width or text. Apply `spellcheck="false"` to non-prose inputs.
+## 2025-05-18 - Input Helper Text Accessibility
+**Learning:** Screen readers won't automatically read supplemental helper text (like "optional, for private repos") next to inputs unless explicitly linked.
+**Action:** Always link visual hint text to input fields using `aria-describedby` (referencing the hint element's ID) to ensure screen reader users get the full context when focusing the input.
+
+## 2025-05-18 - Keyboard Focus Flow on Hidden Elements
+**Learning:** When hiding a currently focused element (e.g., hiding a reset button after clicking it via `display: none`), keyboard focus defaults back to the document body, breaking the user's navigation flow.
+**Action:** When programmatically hiding an active element, always explicitly shift focus to the next logical element (e.g., `element.focus()`) to maintain keyboard accessibility.

--- a/popup.html
+++ b/popup.html
@@ -17,8 +17,8 @@
         <input type="text" id="ghOwner" placeholder="your-github-username" spellcheck="false" autocomplete="username" />
       </label>
       <label for="ghToken">
-        GitHub Token <span class="hint">(optional, for private repos)</span>
-        <input type="password" id="ghToken" placeholder="ghp_..." spellcheck="false" autocomplete="current-password" />
+        GitHub Token <span id="ghTokenHint" class="hint">(optional, for private repos)</span>
+        <input type="password" id="ghToken" placeholder="ghp_..." spellcheck="false" autocomplete="current-password" aria-describedby="ghTokenHint" />
       </label>
     </section>
 

--- a/popup.js
+++ b/popup.js
@@ -143,6 +143,7 @@ resetBtn.addEventListener('click', () => {
   resetBtn.style.display = 'none'
   progressSection.style.display = 'none'
   summarySection.style.display = 'none'
+  startBtn.focus()
 })
 
 // --- Listen for state changes ---

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -72,7 +72,11 @@ function setupPopupSandbox() {
       checked: false,
       disabled: false,
       scrollHeight: 0,
-      scrollTop: 0
+      scrollTop: 0,
+      focused: false,
+      focus: () => {
+        element.focused = true
+      }
     }
     return element
   }
@@ -358,5 +362,6 @@ describe('Button Event Handlers', () => {
     assert.strictEqual(elements['#startBtn'].disabled, false)
     assert.strictEqual(elements['#startBtn'].textContent, 'Start Archiving')
     assert.strictEqual(elements['#resetBtn'].style.display, 'none')
+    assert.strictEqual(elements['#startBtn'].focused, true, 'Start button should receive focus')
   })
 })


### PR DESCRIPTION
💡 **What:** 
- Added `aria-describedby` to the GitHub Token input to link it with its hint text.
- Added explicit programmatic focus (`startBtn.focus()`) when the Reset button is clicked and hidden.
- Updated the DOM mock in `popup.test.js` to support `.focus()` and verify this behavior.

🎯 **Why:** 
- **Accessibility:** Screen readers previously ignored the "(optional, for private repos)" hint because it wasn't semantically linked to the input field.
- **Usability:** Hiding an element that currently has keyboard focus (the Reset button) drops the focus to the `<body>`. Explicitly shifting focus to the "Start" button maintains a logical keyboard navigation flow.

♿ **Accessibility:**
- Improved screen reader context for optional inputs.
- Preserved keyboard navigation flow after state resets.

---
*PR created automatically by Jules for task [4546167858582897538](https://jules.google.com/task/4546167858582897538) started by @n24q02m*