### PR TITLE
🎨 Palette: Improve keyboard navigation and screen reader hints

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,7 @@
 ## 2025-05-08 - Transient Error State Visuals & Input Noise
 **Learning:** Error state visual indicators (like turning a progress bar red) must be explicitly cleared when the user initiates a new operation. Failing to do so carries over the negative visual feedback, causing immediate anxiety on retry. Additionally, browsers aggressively spellcheck technical inputs (like GitHub usernames and tokens), adding distracting visual noise.
 **Action:** Always verify that state reset functions clear *all* dynamically applied error styles, not just structural changes like width or text. Apply `spellcheck="false"` to non-prose inputs.
+
+## 2026-05-13 - Focus Management When Hiding Elements
+**Learning:** When hiding an active interactive element (like a 'Reset' button after click), the browser focus is often lost, defaulting to the document body. This leaves keyboard users stranded and forces them to tab through the entire UI again.
+**Action:** Always programmatically shift focus to the next logical element (e.g., the primary action button) before or immediately after hiding the focused element to maintain a seamless keyboard navigation flow.

--- a/popup.html
+++ b/popup.html
@@ -17,8 +17,8 @@
         <input type="text" id="ghOwner" placeholder="your-github-username" spellcheck="false" autocomplete="username" />
       </label>
       <label for="ghToken">
-        GitHub Token <span class="hint">(optional, for private repos)</span>
-        <input type="password" id="ghToken" placeholder="ghp_..." spellcheck="false" autocomplete="current-password" />
+        GitHub Token <span id="ghTokenHint" class="hint">(optional, for private repos)</span>
+        <input type="password" id="ghToken" placeholder="ghp_..." spellcheck="false" autocomplete="current-password" aria-describedby="ghTokenHint" />
       </label>
     </section>
 

--- a/popup.js
+++ b/popup.js
@@ -143,6 +143,7 @@ resetBtn.addEventListener('click', () => {
   resetBtn.style.display = 'none'
   progressSection.style.display = 'none'
   summarySection.style.display = 'none'
+  startBtn.focus() // Shift focus back to start button so keyboard users aren't left stranded when reset hides
 })
 
 // --- Listen for state changes ---

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -72,7 +72,11 @@ function setupPopupSandbox() {
       checked: false,
       disabled: false,
       scrollHeight: 0,
-      scrollTop: 0
+      scrollTop: 0,
+      focused: false,
+      focus: () => {
+        element.focused = true
+      }
     }
     return element
   }
@@ -358,5 +362,6 @@ describe('Button Event Handlers', () => {
     assert.strictEqual(elements['#startBtn'].disabled, false)
     assert.strictEqual(elements['#startBtn'].textContent, 'Start Archiving')
     assert.strictEqual(elements['#resetBtn'].style.display, 'none')
+    assert.strictEqual(elements['#startBtn'].focused, true, 'Start button should receive focus after reset')
   })
 })


### PR DESCRIPTION
**💡 What**:
Added two micro-UX/accessibility improvements to `popup.js` and `popup.html`. 
1. Added `aria-describedby` to the token input to link it to the adjacent hint text.
2. Programmatically shift focus back to the `startBtn` after `resetBtn` is hidden on click, instead of letting it drop to the document `<body>`.
Updated the test suite (`tests/popup.test.js`) to assert proper focus.

**🎯 Why**:
1. It helps screen reader users understand the token field logic (e.g. knowing it is optional).
2. It prevents keyboard users from getting stranded when interacting with the Reset button.

**📸 Before/After**:
The changes are strictly accessible and semantic, so visually the UI remains identical, but keyboard navigation now behaves gracefully.

**♿ Accessibility**:
Improved screen reader context for the GitHub Token input and enhanced keyboard navigation flow for users interacting without a mouse.

---
*PR created automatically by Jules for task [2138445324830072402](https://jules.google.com/task/2138445324830072402) started by @n24q02m*