### PR TITLE
🎨 Palette: Add focus management and accessibility hints

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,6 @@
 ## 2025-05-08 - Transient Error State Visuals & Input Noise
 **Learning:** Error state visual indicators (like turning a progress bar red) must be explicitly cleared when the user initiates a new operation. Failing to do so carries over the negative visual feedback, causing immediate anxiety on retry. Additionally, browsers aggressively spellcheck technical inputs (like GitHub usernames and tokens), adding distracting visual noise.
 **Action:** Always verify that state reset functions clear *all* dynamically applied error styles, not just structural changes like width or text. Apply `spellcheck="false"` to non-prose inputs.
+## 2026-05-14 - Focus Drop Prevention and aria-describedby
+**Learning:** Hiding an element that currently has focus (like a reset button after clicking it) drops the focus to the document body, breaking keyboard navigation. Additionally, hint text near inputs should be connected using `aria-describedby` so screen readers announce it when the input receives focus.
+**Action:** Always programmatically shift focus to the next logical element (e.g., `startBtn.focus()`) when hiding a focused element. Use `aria-describedby` to associate helper text with input fields.

--- a/popup.html
+++ b/popup.html
@@ -17,8 +17,8 @@
         <input type="text" id="ghOwner" placeholder="your-github-username" spellcheck="false" autocomplete="username" />
       </label>
       <label for="ghToken">
-        GitHub Token <span class="hint">(optional, for private repos)</span>
-        <input type="password" id="ghToken" placeholder="ghp_..." spellcheck="false" autocomplete="current-password" />
+        GitHub Token <span id="ghTokenHint" class="hint">(optional, for private repos)</span>
+        <input type="password" id="ghToken" placeholder="ghp_..." spellcheck="false" autocomplete="current-password" aria-describedby="ghTokenHint" />
       </label>
     </section>
 

--- a/popup.js
+++ b/popup.js
@@ -143,6 +143,7 @@ resetBtn.addEventListener('click', () => {
   resetBtn.style.display = 'none'
   progressSection.style.display = 'none'
   summarySection.style.display = 'none'
+  startBtn.focus() // Shift focus to prevent drop when resetBtn is hidden
 })
 
 // --- Listen for state changes ---

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -72,7 +72,10 @@ function setupPopupSandbox() {
       checked: false,
       disabled: false,
       scrollHeight: 0,
-      scrollTop: 0
+      scrollTop: 0,
+      focus: () => {
+        element.focused = true
+      }
     }
     return element
   }


### PR DESCRIPTION
### 💡 What
- Added `aria-describedby` to the `ghToken` input, explicitly linking it to its adjacent hint text (`#ghTokenHint`).
- Added programmatic focus management when resetting operations; focus now gracefully shifts from the disappearing `resetBtn` to the newly active `startBtn`.
- Updated test mocks to support `.focus()` calls.

### 🎯 Why
- **Contextual Awareness:** Screen reader users will now automatically hear the important context that the GitHub token is "(optional, for private repos)" when they focus the input, rather than having to discover it separately.
- **Keyboard Navigation:** Previously, when a user clicked the `resetBtn`, it would become hidden (`display: none`), causing the browser to "drop" focus back to the `<body>`. This forced keyboard users to start tabbing from the very beginning of the document again. Now, focus seamlessly hands off to the primary call-to-action, maintaining their workflow.

### 📸 Before/After
*(Visuals remain unchanged as these are structural/interactive fixes, but the screen reader and keyboard experience are significantly improved).*

### ♿ Accessibility
- **Screen Reader Support:** Improved form field context via `aria-describedby`.
- **Keyboard Navigation:** Preserved tab index flow by preventing dropped focus states.

---
*PR created automatically by Jules for task [16736089462777162332](https://jules.google.com/task/16736089462777162332) started by @n24q02m*