### PR TITLE
⚡ Bolt: Eliminate intermediate string allocation in batchexecute parser

### DIFF
--- a/background.js
+++ b/background.js
@@ -98,12 +98,12 @@ async function callBatchExecute(rpcId, payload, config) {
  * Find the end of the outermost JSON array using bracket balancing.
  * Handles control chars inside strings by skipping them.
  */
-function findJsonEnd(str) {
+function findJsonEnd(str, startPos = 0) {
   // ⚡ Bolt Optimization: Use String.prototype.indexOf('"') to fast-forward
   // through string literals instead of character-by-character iteration.
   // This avoids huge JS overhead for large string payloads.
   let depth = 0
-  for (let i = 0; i < str.length; i++) {
+  for (let i = startPos; i < str.length; i++) {
     const ch = str[i]
     if (ch === '"') {
       while (true) {
@@ -147,13 +147,17 @@ function parseResponse(text, rpcId) {
   // Skip byte-length line
   const firstNewline = text.indexOf('\n', pos)
   if (firstNewline === -1) throw new Error('Invalid batchexecute response')
-  const data = text.substring(firstNewline + 1)
+
+  // ⚡ Bolt Optimization: By passing `startPos` directly to `findJsonEnd`, we avoid
+  // allocating a massive intermediate substring (`text.substring(firstNewline + 1)`)
+  // just to search for the JSON boundary, drastically reducing memory allocations and GC overhead.
+  const startPos = firstNewline + 1
 
   // Find valid JSON boundary
-  const jsonEnd = findJsonEnd(data)
+  const jsonEnd = findJsonEnd(text, startPos)
   if (jsonEnd === -1) throw new Error('Could not find JSON boundary in response')
 
-  const jsonStr = data.substring(0, jsonEnd)
+  const jsonStr = text.substring(startPos, jsonEnd)
   const fixed = fixJsonControlChars(jsonStr)
   const outer = JSON.parse(fixed)
 

--- a/utils.js
+++ b/utils.js
@@ -3,6 +3,7 @@
  * batchexecute responses can contain raw newlines inside strings which is
  * invalid JSON. This state machine escapes them.
  */
+// biome-ignore lint/correctness/noUnusedVariables: Used globally via importScripts
 function fixJsonControlChars(str) {
   // ⚡ Bolt Optimization: Bypass character-by-character processing loops with a
   // fast regex test for rare conditions (like JSON control characters).


### PR DESCRIPTION
💡 What: Updated `findJsonEnd` to accept a `startPos` parameter, allowing `parseResponse` to search for the JSON boundary without allocating a massive intermediate substring.
🎯 Why: `batchexecute` responses can be multi-megabyte strings. Slicing the entire payload just to search for the end bracket creates unnecessary memory pressure and garbage collection overhead.
📊 Impact: Eliminates a redundant O(N) memory allocation and copy per RPC response parsing cycle, reducing memory spikes and improving parsing latency.
🔬 Measurement: Verified using an isolated benchmark demonstrating reduced execution time for large payloads, and ensured correctness with targeted tests (`node --test --test-name-pattern="parseResponse" tests/background.test.js`).

---
*PR created automatically by Jules for task [8807578483431902860](https://jules.google.com/task/8807578483431902860) started by @n24q02m*