### PR TITLE
🎨 Palette: Improve keyboard focus and screen reader hints

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,6 @@
 ## 2025-05-08 - Transient Error State Visuals & Input Noise
 **Learning:** Error state visual indicators (like turning a progress bar red) must be explicitly cleared when the user initiates a new operation. Failing to do so carries over the negative visual feedback, causing immediate anxiety on retry. Additionally, browsers aggressively spellcheck technical inputs (like GitHub usernames and tokens), adding distracting visual noise.
 **Action:** Always verify that state reset functions clear *all* dynamically applied error styles, not just structural changes like width or text. Apply `spellcheck="false"` to non-prose inputs.
+## 2026-05-15 - Focus Management on Transient Elements and ARIA hints
+**Learning:** Hiding an element that currently has keyboard focus (like clicking a reset button that then sets its own display to 'none') causes the focus to drop back to the document body. This breaks the user's keyboard navigation flow. Additionally, visual hints next to inputs should be explicitly linked via `aria-describedby` so screen readers announce them.
+**Action:** Whenever a focused interactive element is hidden or removed, programmatically shift focus to the next logical element (e.g., the primary action button). Always link visual hint text to inputs using `aria-describedby`.

--- a/popup.html
+++ b/popup.html
@@ -17,8 +17,8 @@
         <input type="text" id="ghOwner" placeholder="your-github-username" spellcheck="false" autocomplete="username" />
       </label>
       <label for="ghToken">
-        GitHub Token <span class="hint">(optional, for private repos)</span>
-        <input type="password" id="ghToken" placeholder="ghp_..." spellcheck="false" autocomplete="current-password" />
+        GitHub Token <span class="hint" id="ghTokenHint">(optional, for private repos)</span>
+        <input type="password" id="ghToken" placeholder="ghp_..." spellcheck="false" autocomplete="current-password" aria-describedby="ghTokenHint" />
       </label>
     </section>
 

--- a/popup.js
+++ b/popup.js
@@ -143,6 +143,7 @@ resetBtn.addEventListener('click', () => {
   resetBtn.style.display = 'none'
   progressSection.style.display = 'none'
   summarySection.style.display = 'none'
+  startBtn.focus()
 })
 
 // --- Listen for state changes ---

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -72,7 +72,10 @@ function setupPopupSandbox() {
       checked: false,
       disabled: false,
       scrollHeight: 0,
-      scrollTop: 0
+      scrollTop: 0,
+      focus: () => {
+        element.focused = true
+      }
     }
     return element
   }
@@ -358,5 +361,6 @@ describe('Button Event Handlers', () => {
     assert.strictEqual(elements['#startBtn'].disabled, false)
     assert.strictEqual(elements['#startBtn'].textContent, 'Start Archiving')
     assert.strictEqual(elements['#resetBtn'].style.display, 'none')
+    assert.strictEqual(elements['#startBtn'].focused, true)
   })
 })


### PR DESCRIPTION
### 💡 What
- Added `id="ghTokenHint"` to the GitHub Token hint span and linked it to the input field using `aria-describedby`.
- Added programmatic focus management (`startBtn.focus()`) when the reset button is clicked and hidden.
- Updated the testing framework to simulate focus (`.focused = true`) and verify the new behavior.

### 🎯 Why
- Screen readers previously wouldn't announce the "(optional, for private repos)" text when focusing on the GitHub Token input field, potentially confusing users about its necessity.
- Hiding an element (`resetBtn`) that currently holds keyboard focus causes focus to drop back to the document body, breaking the user's tab-navigation flow.

### 📸 Before/After
*(Visuals unchanged, screen reader and keyboard interactions improved)*

### ♿ Accessibility
- **Screen Readers:** Improved context for the GitHub Token field via `aria-describedby`.
- **Keyboard Navigation:** Preserved logical focus flow when transient UI elements are hidden.

---
*PR created automatically by Jules for task [7798227614036753784](https://jules.google.com/task/7798227614036753784) started by @n24q02m*