### PR TITLE
🎨 Palette: Improve form accessibility and dynamic focus flow

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,6 @@
 ## 2025-05-08 - Transient Error State Visuals & Input Noise
 **Learning:** Error state visual indicators (like turning a progress bar red) must be explicitly cleared when the user initiates a new operation. Failing to do so carries over the negative visual feedback, causing immediate anxiety on retry. Additionally, browsers aggressively spellcheck technical inputs (like GitHub usernames and tokens), adding distracting visual noise.
 **Action:** Always verify that state reset functions clear *all* dynamically applied error styles, not just structural changes like width or text. Apply `spellcheck="false"` to non-prose inputs.
+## 2025-05-16 - Screen Reader Hints & Dynamic Focus Management
+**Learning:** Supplemental form hints (like "optional, for private repos") are ignored by screen readers if they are just visually adjacent to inputs. Additionally, hiding a focused button (like a "Reset" button after clicking it) drops keyboard focus to the document body, breaking navigation flow.
+**Action:** Always link visual hint text to input fields using `aria-describedby` pointing to the hint's ID. When programmatically hiding an interactive element, always manually shift focus to the next logical element (e.g., `.focus()`) to maintain a continuous, accessible keyboard experience.

--- a/popup.html
+++ b/popup.html
@@ -17,8 +17,8 @@
         <input type="text" id="ghOwner" placeholder="your-github-username" spellcheck="false" autocomplete="username" />
       </label>
       <label for="ghToken">
-        GitHub Token <span class="hint">(optional, for private repos)</span>
-        <input type="password" id="ghToken" placeholder="ghp_..." spellcheck="false" autocomplete="current-password" />
+        GitHub Token <span id="ghTokenHint" class="hint">(optional, for private repos)</span>
+        <input type="password" id="ghToken" placeholder="ghp_..." spellcheck="false" autocomplete="current-password" aria-describedby="ghTokenHint" />
       </label>
     </section>
 

--- a/popup.js
+++ b/popup.js
@@ -143,6 +143,9 @@ resetBtn.addEventListener('click', () => {
   resetBtn.style.display = 'none'
   progressSection.style.display = 'none'
   summarySection.style.display = 'none'
+
+  // Shift focus back to start button after hiding the reset button
+  startBtn.focus()
 })
 
 // --- Listen for state changes ---

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -72,7 +72,11 @@ function setupPopupSandbox() {
       checked: false,
       disabled: false,
       scrollHeight: 0,
-      scrollTop: 0
+      scrollTop: 0,
+      focused: false,
+      focus: () => {
+        element.focused = true
+      }
     }
     return element
   }
@@ -358,5 +362,6 @@ describe('Button Event Handlers', () => {
     assert.strictEqual(elements['#startBtn'].disabled, false)
     assert.strictEqual(elements['#startBtn'].textContent, 'Start Archiving')
     assert.strictEqual(elements['#resetBtn'].style.display, 'none')
+    assert.strictEqual(elements['#startBtn'].focused, true)
   })
 })


### PR DESCRIPTION
### 💡 What
Added `aria-describedby` to the GitHub Token input linking it to its supplemental hint text. Also added a programmatic focus shift back to the "Start" button when the "Reset" button is clicked and hidden.

### 🎯 Why
- **Screen Readers:** Previously, the "optional, for private repos" text was only visually adjacent. Screen reader users would navigate to the token input and not hear this crucial context. `aria-describedby` explicitly links them.
- **Keyboard Navigation:** When a user clicks "Reset" (e.g., via keyboard), the button is hidden (`display: none`). Without explicit management, the browser drops keyboard focus to the `<body>` element, forcing keyboard-only users to tab from the top of the document all over again. Shifting focus back to the primary action button maintains flow.

### 📸 Before/After
*(Visual change is internal to focus state and screen reader output; no layout changes were made.)*

### ♿ Accessibility
- Improved screen reader context for the GitHub Token input.
- Maintained a continuous keyboard navigation flow during state transitions.

---
*PR created automatically by Jules for task [1757762318420815328](https://jules.google.com/task/1757762318420815328) started by @n24q02m*