### PR TITLE
🎨 Palette: Maintain keyboard focus flow on reset

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,6 @@
 ## 2025-05-08 - Transient Error State Visuals & Input Noise
 **Learning:** Error state visual indicators (like turning a progress bar red) must be explicitly cleared when the user initiates a new operation. Failing to do so carries over the negative visual feedback, causing immediate anxiety on retry. Additionally, browsers aggressively spellcheck technical inputs (like GitHub usernames and tokens), adding distracting visual noise.
 **Action:** Always verify that state reset functions clear *all* dynamically applied error styles, not just structural changes like width or text. Apply `spellcheck="false"` to non-prose inputs.
+## 2026-05-17 - Maintain Keyboard Focus Flow on Hidden Elements
+**Learning:** When a focused interactive element (like the Reset button) is programmatically hidden (e.g., `display: none`), keyboard focus defaults back to the document body, breaking the user's navigation flow and creating a frustrating experience for keyboard and screen reader users.
+**Action:** Always programmatically shift focus to the next logical interactive element (e.g., `startBtn.focus()`) when hiding the currently focused element.

--- a/popup.js
+++ b/popup.js
@@ -143,6 +143,7 @@ resetBtn.addEventListener('click', () => {
   resetBtn.style.display = 'none'
   progressSection.style.display = 'none'
   summarySection.style.display = 'none'
+  startBtn.focus()
 })
 
 // --- Listen for state changes ---

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -72,7 +72,10 @@ function setupPopupSandbox() {
       checked: false,
       disabled: false,
       scrollHeight: 0,
-      scrollTop: 0
+      scrollTop: 0,
+      focus: () => {
+        element.focused = true
+      }
     }
     return element
   }
@@ -358,5 +361,6 @@ describe('Button Event Handlers', () => {
     assert.strictEqual(elements['#startBtn'].disabled, false)
     assert.strictEqual(elements['#startBtn'].textContent, 'Start Archiving')
     assert.strictEqual(elements['#resetBtn'].style.display, 'none')
+    assert.strictEqual(elements['#startBtn'].focused, true)
   })
 })


### PR DESCRIPTION
**💡 What**
Added a single line of logic to `popup.js` to ensure the `startBtn` receives keyboard focus when the `resetBtn` is clicked (since the `resetBtn` is hidden immediately afterward).

**🎯 Why**
When the `resetBtn` is clicked, it hides itself via `display: none`. Standard browser behavior will reset focus to the document body when the currently focused element is hidden. This breaks keyboard navigation flow and can be disorienting for screen reader users. Manually shifting focus to the `startBtn` (which is typically the logical next step after a reset) ensures a smooth UX.

**📸 Before/After**
*Before:* Clicking 'Reset' returns focus to the top of the popup (`document.body`).
*After:* Clicking 'Reset' programmatically moves the `startBtn` into focus.

**♿ Accessibility**
Improves keyboard navigation and screen reader flow by explicitly handling focus when a focused interactive element is unmounted/hidden.

---
*PR created automatically by Jules for task [351493470987716538](https://jules.google.com/task/351493470987716538) started by @n24q02m*