### PR TITLE
🎨 Palette: Improve keyboard navigation and screen reader accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,6 +1,11 @@
 ## 2025-04-03 - Progressive Disclosure for Multi-Mode UIs
 **Learning:** In a multi-mode UI (like Archive vs Suggestions), showing all settings at once creates cognitive overload, especially when settings like GitHub tokens are only relevant to one mode.
 **Action:** Use progressive disclosure in `popup.js` to hide mode-specific settings (like the `.settings` section and `force` checkbox) when they are not relevant to the currently selected mode, keeping the UI clean and focused.
+
 ## 2025-05-08 - Transient Error State Visuals & Input Noise
 **Learning:** Error state visual indicators (like turning a progress bar red) must be explicitly cleared when the user initiates a new operation. Failing to do so carries over the negative visual feedback, causing immediate anxiety on retry. Additionally, browsers aggressively spellcheck technical inputs (like GitHub usernames and tokens), adding distracting visual noise.
 **Action:** Always verify that state reset functions clear *all* dynamically applied error styles, not just structural changes like width or text. Apply `spellcheck="false"` to non-prose inputs.
+
+## 2025-06-15 - Focus Traps and Accessible Helpers
+**Learning:** Hiding an active/focused element via `display: none` (like when clicking a Reset button that immediately hides itself) causes the browser to drop focus to the `<body>`, breaking keyboard navigation flow. Additionally, inline helper text adjacent to inputs is skipped by screen readers unless explicitly linked.
+**Action:** Programmatically shift focus to the next logical step (`element.focus()`) when hiding a focused element. Always link helper text to inputs using `aria-describedby` referencing an explicit ID.

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/popup.html
+++ b/popup.html
@@ -17,8 +17,8 @@
         <input type="text" id="ghOwner" placeholder="your-github-username" spellcheck="false" autocomplete="username" />
       </label>
       <label for="ghToken">
-        GitHub Token <span class="hint">(optional, for private repos)</span>
-        <input type="password" id="ghToken" placeholder="ghp_..." spellcheck="false" autocomplete="current-password" />
+        GitHub Token <span id="ghTokenHint" class="hint">(optional, for private repos)</span>
+        <input type="password" id="ghToken" aria-describedby="ghTokenHint" placeholder="ghp_..." spellcheck="false" autocomplete="current-password" />
       </label>
     </section>
 

--- a/popup.js
+++ b/popup.js
@@ -143,6 +143,7 @@ resetBtn.addEventListener('click', () => {
   resetBtn.style.display = 'none'
   progressSection.style.display = 'none'
   summarySection.style.display = 'none'
+  startBtn.focus() // Shift focus to the next logical element after hiding the active reset button
 })
 
 // --- Listen for state changes ---

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -72,7 +72,11 @@ function setupPopupSandbox() {
       checked: false,
       disabled: false,
       scrollHeight: 0,
-      scrollTop: 0
+      scrollTop: 0,
+      focused: false,
+      focus: () => {
+        element.focused = true
+      }
     }
     return element
   }
@@ -358,5 +362,6 @@ describe('Button Event Handlers', () => {
     assert.strictEqual(elements['#startBtn'].disabled, false)
     assert.strictEqual(elements['#startBtn'].textContent, 'Start Archiving')
     assert.strictEqual(elements['#resetBtn'].style.display, 'none')
+    assert.strictEqual(elements['#startBtn'].focused, true, 'Focus should be shifted to startBtn')
   })
 })

--- a/utils.js
+++ b/utils.js
@@ -3,6 +3,7 @@
  * batchexecute responses can contain raw newlines inside strings which is
  * invalid JSON. This state machine escapes them.
  */
+// biome-ignore lint/correctness/noUnusedVariables: Used globally via importScripts
 function fixJsonControlChars(str) {
   // ⚡ Bolt Optimization: Bypass character-by-character processing loops with a
   // fast regex test for rare conditions (like JSON control characters).


### PR DESCRIPTION
### 💡 What
- Added explicit `aria-describedby` linking for the GitHub Token hint text so screen readers announce it when the input is focused.
- Shifted keyboard focus to the "Start" button when the "Reset" button is clicked.
- Updated `popup.test.js` to support `.focus()` testing and added an assertion.
- Recorded UX learnings to `.Jules/palette.md`.

### 🎯 Why
- Inline helper text is often ignored by screen readers if not explicitly linked to the input field, leading to confusion.
- Clicking the Reset button hides it (`display: none`), which causes the browser to drop focus entirely (defaulting to the `<body>`). This breaks the navigation flow for keyboard users, who would then have to tab all the way back through the interface to start a new operation.

### ♿ Accessibility
- **Screen Readers:** Better context provided for the GitHub token field.
- **Keyboard Navigation:** Users can now seamlessly Reset and then immediately hit Enter to Start a new operation without breaking their flow.

---
*PR created automatically by Jules for task [16184513096176157788](https://jules.google.com/task/16184513096176157788) started by @n24q02m*