### PR TITLE
🎨 Palette: Improve keyboard flow and screen reader hints

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,7 @@
 ## 2025-05-08 - Transient Error State Visuals & Input Noise
 **Learning:** Error state visual indicators (like turning a progress bar red) must be explicitly cleared when the user initiates a new operation. Failing to do so carries over the negative visual feedback, causing immediate anxiety on retry. Additionally, browsers aggressively spellcheck technical inputs (like GitHub usernames and tokens), adding distracting visual noise.
 **Action:** Always verify that state reset functions clear *all* dynamically applied error styles, not just structural changes like width or text. Apply `spellcheck="false"` to non-prose inputs.
+
+## 2026-05-20 - Maintaining Keyboard Navigation and Screen Reader Flow
+**Learning:** When hiding elements currently in focus (like a reset button), keyboard focus resets to the body, breaking navigation for keyboard/screen reader users. Additionally, field hints shouldn't be separated visually from their inputs without linking them via `aria-describedby`.
+**Action:** Always programmatically shift focus (e.g., `element.focus()`) to the next logical step when hiding a focused element. Link visual hint text to inputs using `aria-describedby` so screen readers announce the supplemental info on focus.

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/popup.html
+++ b/popup.html
@@ -17,8 +17,8 @@
         <input type="text" id="ghOwner" placeholder="your-github-username" spellcheck="false" autocomplete="username" />
       </label>
       <label for="ghToken">
-        GitHub Token <span class="hint">(optional, for private repos)</span>
-        <input type="password" id="ghToken" placeholder="ghp_..." spellcheck="false" autocomplete="current-password" />
+        GitHub Token <span id="ghTokenHint" class="hint">(optional, for private repos)</span>
+        <input type="password" id="ghToken" placeholder="ghp_..." spellcheck="false" autocomplete="current-password" aria-describedby="ghTokenHint" />
       </label>
     </section>
 

--- a/popup.js
+++ b/popup.js
@@ -143,6 +143,7 @@ resetBtn.addEventListener('click', () => {
   resetBtn.style.display = 'none'
   progressSection.style.display = 'none'
   summarySection.style.display = 'none'
+  startBtn.focus()
 })
 
 // --- Listen for state changes ---

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -72,7 +72,11 @@ function setupPopupSandbox() {
       checked: false,
       disabled: false,
       scrollHeight: 0,
-      scrollTop: 0
+      scrollTop: 0,
+      focused: false,
+      focus: () => {
+        element.focused = true
+      }
     }
     return element
   }
@@ -358,5 +362,6 @@ describe('Button Event Handlers', () => {
     assert.strictEqual(elements['#startBtn'].disabled, false)
     assert.strictEqual(elements['#startBtn'].textContent, 'Start Archiving')
     assert.strictEqual(elements['#resetBtn'].style.display, 'none')
+    assert.strictEqual(elements['#startBtn'].focused, true, 'Focus should be shifted to startBtn')
   })
 })

--- a/utils.js
+++ b/utils.js
@@ -3,6 +3,7 @@
  * batchexecute responses can contain raw newlines inside strings which is
  * invalid JSON. This state machine escapes them.
  */
+// biome-ignore lint/correctness/noUnusedVariables: Used globally via importScripts
 function fixJsonControlChars(str) {
   // ⚡ Bolt Optimization: Bypass character-by-character processing loops with a
   // fast regex test for rare conditions (like JSON control characters).


### PR DESCRIPTION
💡 **What**
* Added `id="ghTokenHint"` and `aria-describedby="ghTokenHint"` to the GitHub Token input to directly link the visual hint to the input field.
* Added `startBtn.focus()` logic when the popup resets, properly redirecting user focus.

🎯 **Why**
* **Context**: When hiding interactive elements that currently have focus (like the Reset button), keyboard focus normally defaults back to the `body`. This completely breaks the keyboard navigation and screen reader flow for the user. Additionally, field hints in the DOM are not inherently associated with their inputs for non-visual users.
* **Benefit**: These small accessibility improvements ensure a much smoother, uninterrupted experience for keyboard-centric and screen-reader users, adhering strictly to the UX micro-improvement philosophy.

📸 **Before/After**
* *Visual change*: No visual change; this is a purely functional accessibility improvement.

♿ **Accessibility**
* Screen readers will now announce the `(optional, for private repos)` hint directly when the token field receives focus.
* Keyboard-only users can now smoothly tab forward after resetting an operation without having to re-navigate from the top of the document.

---
*PR created automatically by Jules for task [16963932608445839286](https://jules.google.com/task/16963932608445839286) started by @n24q02m*