### PR TITLE
🎨 Palette: Shift focus after hiding Reset button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,6 @@
 ## 2025-05-08 - Transient Error State Visuals & Input Noise
 **Learning:** Error state visual indicators (like turning a progress bar red) must be explicitly cleared when the user initiates a new operation. Failing to do so carries over the negative visual feedback, causing immediate anxiety on retry. Additionally, browsers aggressively spellcheck technical inputs (like GitHub usernames and tokens), adding distracting visual noise.
 **Action:** Always verify that state reset functions clear *all* dynamically applied error styles, not just structural changes like width or text. Apply `spellcheck="false"` to non-prose inputs.
+## 2025-06-25 - Managing Focus for Hidden Interactive Elements
+**Learning:** When an interactive element that currently has focus is hidden (like `display: none`), focus often defaults to the document body or gets lost, which disrupts keyboard navigation flow and creates an accessibility issue for keyboard users.
+**Action:** When hiding a focused interactive element programmatically, ensure focus is deliberately shifted to the next logical or appropriate element in the tab sequence (e.g., calling `element.focus()`).

--- a/popup.js
+++ b/popup.js
@@ -143,6 +143,7 @@ resetBtn.addEventListener('click', () => {
   resetBtn.style.display = 'none'
   progressSection.style.display = 'none'
   summarySection.style.display = 'none'
+  startBtn.focus()
 })
 
 // --- Listen for state changes ---

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -72,7 +72,11 @@ function setupPopupSandbox() {
       checked: false,
       disabled: false,
       scrollHeight: 0,
-      scrollTop: 0
+      scrollTop: 0,
+      focused: false,
+      focus: () => {
+        element.focused = true
+      }
     }
     return element
   }
@@ -358,5 +362,6 @@ describe('Button Event Handlers', () => {
     assert.strictEqual(elements['#startBtn'].disabled, false)
     assert.strictEqual(elements['#startBtn'].textContent, 'Start Archiving')
     assert.strictEqual(elements['#resetBtn'].style.display, 'none')
+    assert.strictEqual(elements['#startBtn'].focused, true)
   })
 })


### PR DESCRIPTION
**💡 What**
Added a `.focus()` call to the `startBtn` element within the `resetBtn` click handler, shifting focus from the Reset button (which is being hidden via `display: none`) back to the primary action button. Extended `tests/popup.test.js` to assert element focus states and verified the logic is sound.

**🎯 Why**
When an interactive element that currently has focus is hidden from the DOM layout, standard browser behavior drops focus to the `<body>` element or loses it entirely. This creates a confusing and broken experience for keyboard-only or screen reader users, forcing them to manually tab back through the UI to regain their place.

**📸 Before/After**
The visual state remains exactly the same, but the internal accessible state now properly maintains flow:
- Before: Clicking "Reset" via keyboard leaves focus on the document body. Next `<Tab>` goes to the first focusable element.
- After: Clicking "Reset" via keyboard instantly focuses the "Start Archiving" button. Next `<Tab>` goes to the appropriate next logical element.

**♿ Accessibility**
Directly improves keyboard navigation predictability (WCAG 2.4.3 Focus Order) by guaranteeing focus is always managed when destroying or hiding interactive elements.

---
*PR created automatically by Jules for task [8157984796546576014](https://jules.google.com/task/8157984796546576014) started by @n24q02m*