### PR TITLE
fix: resolve security, performance and accessibility backlog

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -38,13 +38,13 @@ jobs:
       version: ${{ steps.release.outputs.version }}
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
         with:
           egress-policy: audit
 
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ vars.CI_APP_ID }}
           private-key: ${{ secrets.CI_APP_KEY }}
@@ -76,13 +76,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
         with:
           egress-policy: audit
 
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ vars.CI_APP_ID }}
           private-key: ${{ secrets.CI_APP_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
         with:
           egress-policy: audit
 
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
         with:
           egress-policy: audit
 
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
         with:
           egress-policy: audit
 

--- a/background.js
+++ b/background.js
@@ -12,6 +12,10 @@ importScripts('utils.js')
 
 const JULES_ORIGIN = 'https://jules.google.com'
 
+// Max number of in-flight network operations. Caps fan-out so a tab with many
+// repos/tasks does not fire hundreds of simultaneous fetches at once.
+const API_CONCURRENCY = 5
+
 function extractAccountNum(url) {
   try {
     const parts = new URL(url).pathname.split('/')
@@ -44,6 +48,31 @@ async function jFetch(url, options = {}) {
     throw new Error(`HTTP ${res.status}`)
   }
   return res
+}
+
+/**
+ * Run `worker` over every item with at most `limit` tasks in flight at once.
+ * Results are returned in input order. Unlike `Promise.all(items.map(...))`,
+ * this bounds concurrency so large fan-outs cannot overwhelm the network.
+ */
+async function runInPool(items, limit, worker) {
+  const results = new Array(items.length)
+  let cursor = 0
+
+  async function drain() {
+    while (cursor < items.length) {
+      const index = cursor++
+      results[index] = await worker(items[index], index)
+    }
+  }
+
+  const poolSize = Math.min(limit, items.length)
+  const pool = []
+  for (let i = 0; i < poolSize; i++) {
+    pool.push(drain())
+  }
+  await Promise.all(pool)
+  return results
 }
 
 // =============================================================================
@@ -97,13 +126,17 @@ async function callBatchExecute(rpcId, payload, config) {
 /**
  * Find the end of the outermost JSON array using bracket balancing.
  * Handles control chars inside strings by skipping them.
+ *
+ * `startPos` lets callers scan a slice of a larger string without first
+ * allocating a substring copy — important for multi-MB batchexecute payloads.
+ * The returned index is absolute (relative to the start of `str`).
  */
-function findJsonEnd(str) {
+function findJsonEnd(str, startPos = 0) {
   // ⚡ Bolt Optimization: Use String.prototype.indexOf('"') to fast-forward
   // through string literals instead of character-by-character iteration.
   // This avoids huge JS overhead for large string payloads.
   let depth = 0
-  for (let i = 0; i < str.length; i++) {
+  for (let i = startPos; i < str.length; i++) {
     const ch = str[i]
     if (ch === '"') {
       while (true) {
@@ -147,13 +180,14 @@ function parseResponse(text, rpcId) {
   // Skip byte-length line
   const firstNewline = text.indexOf('\n', pos)
   if (firstNewline === -1) throw new Error('Invalid batchexecute response')
-  const data = text.substring(firstNewline + 1)
+  const dataStart = firstNewline + 1
 
-  // Find valid JSON boundary
-  const jsonEnd = findJsonEnd(data)
+  // ⚡ Bolt Optimization: Scan for the JSON boundary directly in `text` using an
+  // offset instead of allocating a `data` substring copy of the whole payload.
+  const jsonEnd = findJsonEnd(text, dataStart)
   if (jsonEnd === -1) throw new Error('Could not find JSON boundary in response')
 
-  const jsonStr = data.substring(0, jsonEnd)
+  const jsonStr = text.substring(dataStart, jsonEnd)
   const fixed = fixJsonControlChars(jsonStr)
   const outer = JSON.parse(fixed)
 
@@ -451,12 +485,11 @@ async function processSuggestionsForTab(tab, options) {
   addLog(`[${label}] Found ${repos.length} repos: ${repos.join(', ')}`)
 
   addLog(`\n[${label}] Fetching suggestions for ${repos.length} repos concurrently...`)
-  const suggestionFetches = repos.map((repo) =>
+  const allSuggestions = await runInPool(repos, API_CONCURRENCY, (repo) =>
     listSuggestions(repo, config)
       .then((suggestions) => ({ repo, suggestions }))
       .catch((e) => ({ repo, error: e.message }))
   )
-  const allSuggestions = await Promise.all(suggestionFetches)
 
   let totalStarted = 0
   for (const { repo, suggestions, error } of allSuggestions) {
@@ -478,33 +511,31 @@ async function processSuggestionsForTab(tab, options) {
     const prevTotal = state.progress.total
     let processedInRepo = 0
 
-    await Promise.all(
-      suggestions.map(async (s) => {
-        if (state.status === 'cancelled') return
+    await runInPool(suggestions, API_CONCURRENCY, async (s) => {
+      if (state.status === 'cancelled') return
 
-        if (options.dryRun) {
-          addLog(`  [DRY] Would start: ${s.title} (${s.categorySlug})`)
-        } else {
-          addLog(`  Starting: ${s.title}...`)
-          try {
-            await startSuggestion(s, repo, config, startConfig)
-            addLog(`  Started: ${s.title}`)
-            totalStarted++
-          } catch (err) {
-            addLog(`  [!] Failed to start "${s.title}": ${err.message}`)
-          }
+      if (options.dryRun) {
+        addLog(`  [DRY] Would start: ${s.title} (${s.categorySlug})`)
+      } else {
+        addLog(`  Starting: ${s.title}...`)
+        try {
+          await startSuggestion(s, repo, config, startConfig)
+          addLog(`  Started: ${s.title}`)
+          totalStarted++
+        } catch (err) {
+          addLog(`  [!] Failed to start "${s.title}": ${err.message}`)
         }
+      }
 
-        processedInRepo++
-        updateState({
-          progress: {
-            ...state.progress,
-            archived: totalStarted,
-            total: prevTotal + processedInRepo
-          }
-        })
+      processedInRepo++
+      updateState({
+        progress: {
+          ...state.progress,
+          archived: totalStarted,
+          total: prevTotal + processedInRepo
+        }
       })
-    )
+    })
   }
 
   addLog(`\n[${label}] TOTAL: ${totalStarted} suggestions started`)
@@ -761,14 +792,13 @@ async function processTab(tab, options) {
     for (const task of candidates) toArchive.push(task)
   } else {
     addLog(`\n[${label}] Checking open PRs per task...`)
-    // Fetch open PRs concurrently for all repos
+    // Fetch open PRs concurrently for all repos (bounded)
     const repoEntries = [...byRepo.entries()]
-    const prFetches = repoEntries.map(([_repo, repoTasks]) => {
+    const allPRs = await runInPool(repoEntries, API_CONCURRENCY, ([_repo, repoTasks]) => {
       const owner = repoTasks[0]?.owner || ghOwner || ''
       const repoName = repoTasks[0]?.repoName || ''
       return owner && repoName ? getOpenPRs(owner, repoName, ghToken) : Promise.resolve([])
     })
-    const allPRs = await Promise.all(prFetches)
 
     for (let i = 0; i < repoEntries.length; i++) {
       const [repo, repoTasks] = repoEntries[i]
@@ -833,25 +863,23 @@ async function processTab(tab, options) {
     updateState({ currentRepo: repo })
     addLog(`\n[${label}] -> ${repo} (${repoTasks.length} tasks)`)
 
-    await Promise.all(
-      repoTasks.map(async (task) => {
-        try {
-          await archiveTask(task.id, config)
-          grandTotal++
-          addLog(`  Archived: [${task.id}] ${task.title}`)
+    await runInPool(repoTasks, API_CONCURRENCY, async (task) => {
+      try {
+        await archiveTask(task.id, config)
+        grandTotal++
+        addLog(`  Archived: [${task.id}] ${task.title}`)
 
-          updateState({
-            progress: {
-              ...state.progress,
-              archived: grandTotal,
-              total: totalTasks
-            }
-          })
-        } catch (e) {
-          addLog(`  ERROR archiving ${task.id}: ${e.message}`)
-        }
-      })
-    )
+        updateState({
+          progress: {
+            ...state.progress,
+            archived: grandTotal,
+            total: totalTasks
+          }
+        })
+      } catch (e) {
+        addLog(`  ERROR archiving ${task.id}: ${e.message}`)
+      }
+    })
   }
 
   addLog(`\n[${label}] TOTAL: ${grandTotal} archived`)

--- a/content.js
+++ b/content.js
@@ -18,9 +18,16 @@ function injectMainWorldScript() {
 }
 injectMainWorldScript()
 
+// Reject messages that did not originate from this page's own window/origin.
+// The MAIN world script and isolated world share the same window and origin,
+// so anything failing these checks is a cross-origin/cross-frame spoof attempt.
+function isTrustedMessage(event) {
+  return event.source === window && event.origin === window.location.origin
+}
+
 // Listen for messages from MAIN world script
 window.addEventListener('message', (event) => {
-  if (event.source !== window) return
+  if (!isTrustedMessage(event)) return
   if (event.data?.type === 'JULES_ARCHIVER_CONFIG') {
     cachedConfig = event.data.config
   }
@@ -45,7 +52,7 @@ function extractConfig() {
 
     const timeout = setTimeout(() => resolve(cachedConfig), 2000)
     const handler = (event) => {
-      if (event.source !== window) return
+      if (!isTrustedMessage(event)) return
       if (event.data?.type !== 'JULES_ARCHIVER_CONFIG') return
       window.removeEventListener('message', handler)
       clearTimeout(timeout)

--- a/main-world.js
+++ b/main-world.js
@@ -67,9 +67,12 @@ if (!window.__julesArchiver) {
 // Broadcast config immediately (WIZ_global_data should be ready by document_idle)
 broadcastConfig()
 
-// Also listen for explicit re-extract requests from content.js
+// Also listen for explicit re-extract requests from content.js.
+// Only honour requests from this page's own window/origin — a cross-origin
+// frame must not be able to trigger config broadcasts.
 window.addEventListener('message', (event) => {
   if (event.source !== window) return
+  if (event.origin !== window.location.origin) return
   if (event.data?.type === 'JULES_REQUEST_CONFIG') {
     broadcastConfig()
   }

--- a/popup.html
+++ b/popup.html
@@ -17,8 +17,15 @@
         <input type="text" id="ghOwner" placeholder="your-github-username" spellcheck="false" autocomplete="username" />
       </label>
       <label for="ghToken">
-        GitHub Token <span class="hint">(optional, for private repos)</span>
-        <input type="password" id="ghToken" placeholder="ghp_..." spellcheck="false" autocomplete="current-password" />
+        GitHub Token <span class="hint" id="ghTokenHint">(optional, for private repos)</span>
+        <input
+          type="password"
+          id="ghToken"
+          placeholder="ghp_..."
+          spellcheck="false"
+          autocomplete="current-password"
+          aria-describedby="ghTokenHint"
+        />
       </label>
     </section>
 

--- a/popup.js
+++ b/popup.js
@@ -143,6 +143,9 @@ resetBtn.addEventListener('click', () => {
   resetBtn.style.display = 'none'
   progressSection.style.display = 'none'
   summarySection.style.display = 'none'
+  // Move focus back to the primary action so keyboard users are not stranded
+  // on the now-hidden Reset button.
+  startBtn.focus()
 })
 
 // --- Listen for state changes ---

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -53,8 +53,10 @@ function setupEnvironment(initialStorage = {}) {
     chrome: chromeMock,
     fetch: async () => ({ ok: true, json: async () => [], text: async () => ")]}'\n\n4\n[[]]" }),
     setTimeout,
-    setInterval,
-    clearInterval,
+    // No-op timer mocks: the real keepAlive interval would otherwise keep the
+    // Node event loop alive and hang the test process after all tests pass.
+    setInterval: () => 0,
+    clearInterval: () => {},
     Math,
     Date,
     JSON,
@@ -82,6 +84,7 @@ function setupEnvironment(initialStorage = {}) {
     globalThis.test_updateState = updateState;
     globalThis.test_addLog = addLog;
     globalThis.test_buildBatchRequest = buildBatchRequest;
+    globalThis.test_runInPool = runInPool;
     globalThis.test_fixJsonControlChars = fixJsonControlChars;
     globalThis.test_findJsonEnd = findJsonEnd;
     globalThis.test_parseResponse = parseResponse;
@@ -179,6 +182,68 @@ describe('findJsonEnd', () => {
     const { sandbox } = setupEnvironment()
     assert.strictEqual(sandbox.test_findJsonEnd('[["a"'), -1)
   })
+
+  it('should scan from startPos and return an absolute index', () => {
+    const { sandbox } = setupEnvironment()
+    // 6-char prefix (byte-length line) followed by the JSON array
+    assert.strictEqual(sandbox.test_findJsonEnd('1234\n\n[["a","b"]]tail', 6), 17)
+  })
+
+  it('should ignore brackets located before startPos', () => {
+    const { sandbox } = setupEnvironment()
+    // The leading "]]]" must not corrupt depth counting when skipped
+    assert.strictEqual(sandbox.test_findJsonEnd(']]]["x"]', 3), 8)
+  })
+
+  it('should treat startPos=0 the same as the default', () => {
+    const { sandbox } = setupEnvironment()
+    assert.strictEqual(sandbox.test_findJsonEnd('[["a","b"]]extra', 0), 11)
+  })
+})
+
+describe('runInPool', () => {
+  it('should run the worker over every item and preserve order', async () => {
+    const { sandbox } = setupEnvironment()
+    const results = await sandbox.test_runInPool([1, 2, 3, 4], 2, async (n) => n * 10)
+    assert.deepStrictEqual(results, [10, 20, 30, 40])
+  })
+
+  it('should never exceed the concurrency limit', async () => {
+    const { sandbox } = setupEnvironment()
+    let inFlight = 0
+    let peak = 0
+    const worker = async () => {
+      inFlight++
+      peak = Math.max(peak, inFlight)
+      await new Promise((r) => setTimeout(r, 5))
+      inFlight--
+    }
+    await sandbox.test_runInPool([1, 2, 3, 4, 5, 6, 7, 8], 3, worker)
+    assert.ok(peak <= 3, `peak concurrency ${peak} should not exceed 3`)
+    assert.strictEqual(peak, 3, 'pool should saturate the limit')
+  })
+
+  it('should return an empty array for empty input', async () => {
+    const { sandbox } = setupEnvironment()
+    let called = 0
+    const results = await sandbox.test_runInPool([], 5, async () => {
+      called++
+    })
+    assert.deepStrictEqual(results, [])
+    assert.strictEqual(called, 0)
+  })
+
+  it('should handle a limit larger than the item count', async () => {
+    const { sandbox } = setupEnvironment()
+    const results = await sandbox.test_runInPool([1, 2], 10, async (n) => n + 1)
+    assert.deepStrictEqual(results, [2, 3])
+  })
+
+  it('should pass the item index to the worker', async () => {
+    const { sandbox } = setupEnvironment()
+    const results = await sandbox.test_runInPool(['a', 'b', 'c'], 2, async (item, idx) => `${item}${idx}`)
+    assert.deepStrictEqual(results, ['a0', 'b1', 'c2'])
+  })
 })
 
 describe('parseResponse', () => {
@@ -187,6 +252,21 @@ describe('parseResponse', () => {
     const response = ')]}\'\n\n100\n[["wrb.fr","p1Takd","[[\\"task1\\",\\"task2\\"]]",null,null,null,"generic"]]'
     const result = sandbox.test_parseResponse(response, 'p1Takd')
     assert.deepStrictEqual(result, [['task1', 'task2']])
+  })
+
+  it('should parse correctly when trailing data follows the JSON array', () => {
+    const { sandbox } = setupEnvironment()
+    // A second chunk (byte-length line + sibling array) must be ignored by the
+    // offset-based boundary scan.
+    const response = ')]}\'\n\n55\n[["wrb.fr","Tjmm5c","[[\\"ok\\"]]",null,null,null,"generic"]]\n12\n[["di",99]]'
+    const result = sandbox.test_parseResponse(response, 'Tjmm5c')
+    assert.deepStrictEqual(result, [['ok']])
+  })
+
+  it('should return null when the rpcId is not present', () => {
+    const { sandbox } = setupEnvironment()
+    const response = ')]}\'\n\n40\n[["wrb.fr","p1Takd","[[]]",null,null,null,"generic"]]'
+    assert.strictEqual(sandbox.test_parseResponse(response, 'Rja83d'), null)
   })
 })
 

--- a/tests/content_extract.test.js
+++ b/tests/content_extract.test.js
@@ -53,6 +53,7 @@ function setupEnvironment() {
       lastPostMessage = data
     },
     location: {
+      origin: 'https://jules.google.com',
       href: 'https://jules.google.com/u/0/session'
     }
   }
@@ -69,8 +70,8 @@ function setupEnvironment() {
     URL,
     location: window.location,
     // Helpers for testing
-    fireMessage: (data) => {
-      const event = { source: window, data }
+    fireMessage: (data, origin = 'https://jules.google.com') => {
+      const event = { source: window, origin, data }
       const handlers = [...(listeners.get('message') || [])]
       handlers.forEach((fn) => {
         fn(event)

--- a/tests/main-world.test.js
+++ b/tests/main-world.test.js
@@ -12,6 +12,10 @@ function setupSandbox(initialWizData = {}) {
 
   const windowMock = {
     WIZ_global_data: initialWizData,
+    location: {
+      origin: 'https://jules.google.com',
+      href: 'https://jules.google.com/u/0/'
+    },
     postMessage: (data, targetOrigin) => {
       messages.push({ data, targetOrigin })
     },
@@ -103,6 +107,7 @@ describe('main-world.js', () => {
     // Simulate request message
     const event = {
       source: windowMock,
+      origin: 'https://jules.google.com',
       data: { type: 'JULES_REQUEST_CONFIG' }
     }
     listeners.message.forEach((l) => {
@@ -111,6 +116,27 @@ describe('main-world.js', () => {
 
     assert.strictEqual(messages.length, 2)
     assert.strictEqual(messages[1].data.type, 'JULES_ARCHIVER_CONFIG')
+  })
+
+  it('should ignore JULES_REQUEST_CONFIG from a foreign origin', () => {
+    const { sandbox, messages, listeners, windowMock } = setupSandbox({
+      SNlM0e: 'at-token'
+    })
+
+    vm.runInContext(mainWorldJs, sandbox)
+    assert.strictEqual(messages.length, 1)
+
+    // Same window object, but a spoofed cross-origin value
+    const event = {
+      source: windowMock,
+      origin: 'https://evil.example.com',
+      data: { type: 'JULES_REQUEST_CONFIG' }
+    }
+    listeners.message.forEach((l) => {
+      l(event)
+    })
+
+    assert.strictEqual(messages.length, 1, 'foreign-origin request must not trigger a broadcast')
   })
 
   it('should ignore JULES_REQUEST_CONFIG from other sources', () => {

--- a/tests/origin_validation.test.js
+++ b/tests/origin_validation.test.js
@@ -7,10 +7,29 @@ const vm = require('node:vm')
 const contentJs = fs.readFileSync(path.join(__dirname, '../content.js'), 'utf8')
 const mainWorldJs = fs.readFileSync(path.join(__dirname, '../main-world.js'), 'utf8')
 
+const PAGE_ORIGIN = 'https://jules.google.com'
+
 function setupSandbox() {
   const postMessages = []
+  const runtimeMessages = []
+  const listeners = {}
+
+  // An explicit window object: `event.source === window` identity checks only
+  // work if the same object is used both inside the script and by the test.
+  const windowObj = {
+    location: { origin: PAGE_ORIGIN, href: `${PAGE_ORIGIN}/u/0/` },
+    postMessage: (data, origin) => {
+      postMessages.push({ data, origin })
+    },
+    addEventListener: (type, handler) => {
+      listeners[type] = handler
+    },
+    removeEventListener: () => {}
+  }
+  windowObj.window = windowObj
+
   const sandbox = {
-    window: {},
+    window: windowObj,
     document: {
       createElement: () => ({
         src: '',
@@ -18,33 +37,20 @@ function setupSandbox() {
         remove: () => {}
       }),
       head: { appendChild: () => {} },
-      documentElement: { appendChild: () => {} },
-      addEventListener: (type, handler) => {
-        if (!sandbox.window.listeners) sandbox.window.listeners = {}
-        sandbox.window.listeners[type] = handler
-      }
+      documentElement: { appendChild: () => {} }
     },
-    location: {
-      origin: 'https://jules.google.com',
-      href: 'https://jules.google.com/u/0/'
-    },
+    location: windowObj.location,
     chrome: {
       runtime: {
-        getURL: (path) => `chrome-extension://id/${path}`,
-        sendMessage: () => {},
+        getURL: (p) => `chrome-extension://id/${p}`,
+        sendMessage: (msg) => {
+          runtimeMessages.push(msg)
+        },
         onMessage: {
           addListener: () => {}
         }
       }
     },
-    postMessage: (data, origin) => {
-      postMessages.push({ data, origin })
-    },
-    addEventListener: (type, handler) => {
-      if (!sandbox.listeners) sandbox.listeners = {}
-      sandbox.listeners[type] = handler
-    },
-    removeEventListener: () => {},
     setTimeout: (fn) => fn(),
     clearTimeout: () => {},
     console,
@@ -52,9 +58,8 @@ function setupSandbox() {
     URLSearchParams,
     Date
   }
-  sandbox.window = sandbox
   vm.createContext(sandbox)
-  return { sandbox, postMessages }
+  return { sandbox, windowObj, listeners, postMessages, runtimeMessages }
 }
 
 describe('Origin Validation Security', () => {
@@ -63,8 +68,6 @@ describe('Origin Validation Security', () => {
 
     vm.runInContext(contentJs, sandbox)
 
-    // Trigger extractConfig by calling the GET_CONFIG handler if we can,
-    // or since extractConfig is at top level in the sandbox, we can call it.
     if (sandbox.extractConfig) {
       sandbox.extractConfig()
     }
@@ -80,5 +83,91 @@ describe('Origin Validation Security', () => {
 
     const wildcards = postMessages.filter((m) => m.origin === '*')
     assert.strictEqual(wildcards.length, 0, 'Found wildcard origin in main-world.js postMessage')
+  })
+})
+
+describe('content.js message handler origin checks', () => {
+  it('should relay JULES_START_CONFIG from the trusted same-origin window', () => {
+    const { sandbox, windowObj, listeners, runtimeMessages } = setupSandbox()
+    vm.runInContext(contentJs, sandbox)
+
+    listeners.message({
+      source: windowObj,
+      origin: PAGE_ORIGIN,
+      data: { type: 'JULES_START_CONFIG', config: { capturedAt: 1 } }
+    })
+
+    assert.strictEqual(runtimeMessages.length, 1)
+    assert.strictEqual(runtimeMessages[0].action, 'CACHE_START_CONFIG')
+  })
+
+  it('should ignore a message from a foreign origin', () => {
+    const { sandbox, windowObj, listeners, runtimeMessages } = setupSandbox()
+    vm.runInContext(contentJs, sandbox)
+
+    listeners.message({
+      source: windowObj,
+      origin: 'https://evil.example.com',
+      data: { type: 'JULES_START_CONFIG', config: { capturedAt: 1 } }
+    })
+
+    assert.strictEqual(runtimeMessages.length, 0, 'foreign-origin message must not be relayed')
+  })
+
+  it('should ignore a message whose source is not this window', () => {
+    const { sandbox, listeners, runtimeMessages } = setupSandbox()
+    vm.runInContext(contentJs, sandbox)
+
+    listeners.message({
+      source: {},
+      origin: PAGE_ORIGIN,
+      data: { type: 'JULES_START_CONFIG', config: { capturedAt: 1 } }
+    })
+
+    assert.strictEqual(runtimeMessages.length, 0, 'cross-frame message must not be relayed')
+  })
+})
+
+describe('main-world.js message handler origin checks', () => {
+  it('should re-broadcast config for a trusted same-origin request', () => {
+    const { sandbox, windowObj, listeners, postMessages } = setupSandbox()
+    vm.runInContext(mainWorldJs, sandbox)
+
+    const initialCount = postMessages.length // initial broadcast on load
+    listeners.message({
+      source: windowObj,
+      origin: PAGE_ORIGIN,
+      data: { type: 'JULES_REQUEST_CONFIG' }
+    })
+
+    assert.strictEqual(postMessages.length, initialCount + 1, 'trusted request should trigger a broadcast')
+  })
+
+  it('should not broadcast for a foreign-origin request', () => {
+    const { sandbox, windowObj, listeners, postMessages } = setupSandbox()
+    vm.runInContext(mainWorldJs, sandbox)
+
+    const initialCount = postMessages.length
+    listeners.message({
+      source: windowObj,
+      origin: 'https://evil.example.com',
+      data: { type: 'JULES_REQUEST_CONFIG' }
+    })
+
+    assert.strictEqual(postMessages.length, initialCount, 'foreign-origin request must not trigger a broadcast')
+  })
+
+  it('should not broadcast for a request from a different window', () => {
+    const { sandbox, listeners, postMessages } = setupSandbox()
+    vm.runInContext(mainWorldJs, sandbox)
+
+    const initialCount = postMessages.length
+    listeners.message({
+      source: {},
+      origin: PAGE_ORIGIN,
+      data: { type: 'JULES_REQUEST_CONFIG' }
+    })
+
+    assert.strictEqual(postMessages.length, initialCount, 'cross-frame request must not trigger a broadcast')
   })
 })

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -67,10 +67,14 @@ function setupPopupSandbox() {
       },
       querySelectorAll: (_sel) => [],
       querySelector: (_sel) => null,
+      focus: () => {
+        element.focused = true
+      },
       textContent: '',
       value: '',
       checked: false,
       disabled: false,
+      focused: false,
       scrollHeight: 0,
       scrollTop: 0
     }
@@ -358,5 +362,28 @@ describe('Button Event Handlers', () => {
     assert.strictEqual(elements['#startBtn'].disabled, false)
     assert.strictEqual(elements['#startBtn'].textContent, 'Start Archiving')
     assert.strictEqual(elements['#resetBtn'].style.display, 'none')
+  })
+
+  it('should move keyboard focus to startBtn after reset', () => {
+    const { sandbox, elements } = setupPopupSandbox()
+    sandbox.chrome.runtime.sendMessage = () => {}
+
+    vm.runInContext(popupJs, sandbox)
+
+    assert.strictEqual(elements['#startBtn'].focused, false)
+    elements['#resetBtn'].dispatchEvent('click')
+    assert.strictEqual(elements['#startBtn'].focused, true, 'focus should return to the primary action')
+  })
+})
+
+describe('popup.html accessibility', () => {
+  const popupHtml = fs.readFileSync(path.join(__dirname, '../popup.html'), 'utf8')
+
+  it('should link the GitHub token input to its hint via aria-describedby', () => {
+    assert.ok(popupHtml.includes('id="ghTokenHint"'), 'token hint span should have an id')
+    assert.ok(
+      popupHtml.includes('aria-describedby="ghTokenHint"'),
+      'token input should reference the hint via aria-describedby'
+    )
   })
 })


### PR DESCRIPTION
## Summary

Consolidates the distinct substantive changes from the 33 open bot/Renovate PRs into clean, tested commits.

- **fix: postMessage origin validation** — `content.js` and `main-world.js` message handlers now reject any message whose `source` is not this window or whose `origin` is not the page origin, blocking cross-origin/cross-frame spoofing.
- **feat: bound batchexecute API concurrency** — adds a `runInPool` bounded worker pool and caps fan-out at 5 concurrent requests; **trims `parseResponse` memory** by scanning the JSON boundary in-place via an offset instead of allocating a substring copy of the multi-MB payload.
- **fix: popup accessibility** — return keyboard focus to the primary action after Reset, and link the GitHub-token input to its hint via `aria-describedby`.
- **fix(ci): bump pinned `harden-runner` and `create-github-app-token` digests**.

New/extended tests cover spoofed vs. trusted origins, the concurrency cap, offset-based parsing, and popup focus.

Supersedes the Jules bot PRs #303–#334 and Renovate PRs #307, #313.

## Test plan

- [x] `node --test` — 124/124 pass
- [x] `biome check` — no new findings

https://claude.ai/code/session_01USTAfaQs3ZtdhxvBrz44DJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01USTAfaQs3ZtdhxvBrz44DJ)_