### PR TITLE
⚡ Bolt: Use DocumentFragment to batch DOM insertions in popup.js

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/popup.js
+++ b/popup.js
@@ -206,7 +206,12 @@ function renderSummary(results) {
   summarySection.style.display = 'block'
   summaryDiv.textContent = ''
 
+  // ⚡ Bolt Optimization: Use DocumentFragment to batch DOM insertions.
+  // This prevents redundant browser reflows/repaints when processing large
+  // numbers of repositories, improving performance during summary rendering.
+  const fragment = document.createDocumentFragment()
   let grand = 0
+
   for (const r of results) {
     grand += r.count
     const div = document.createElement('div')
@@ -216,13 +221,15 @@ function renderSummary(results) {
     } else {
       div.textContent = `${r.label}: ${r.count} processed`
     }
-    summaryDiv.appendChild(div)
+    fragment.appendChild(div)
   }
 
   const totalDiv = document.createElement('div')
   totalDiv.className = 'total'
   totalDiv.textContent = `TOTAL: ${grand} processed`
-  summaryDiv.appendChild(totalDiv)
+  fragment.appendChild(totalDiv)
+
+  summaryDiv.appendChild(fragment)
 }
 
 // --- Check for existing state on popup open ---

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -57,8 +57,17 @@ function setupPopupSandbox() {
       style: { display: '' },
       appendChild: (child) => {
         if (!element.children) element.children = []
-        element.children.push(child)
-        child.parentElement = element
+        if (child.nodeType === 11) {
+          // DocumentFragment
+          child.children.forEach((c) => {
+            element.children.push(c)
+            c.parentElement = element
+          })
+          child.children = [] // Clear fragment
+        } else {
+          element.children.push(child)
+          child.parentElement = element
+        }
       },
       remove: () => {
         if (element.parentElement?.children) {
@@ -120,7 +129,12 @@ function setupPopupSandbox() {
       }
       return { forEach: () => {} }
     },
-    createElement: (tag) => createMockElement(tag)
+    createElement: (tag) => createMockElement(tag),
+    createDocumentFragment: () => {
+      const frag = createMockElement('documentfragment')
+      frag.nodeType = 11
+      return frag
+    }
   }
 
   const chrome = {

--- a/utils.js
+++ b/utils.js
@@ -3,6 +3,7 @@
  * batchexecute responses can contain raw newlines inside strings which is
  * invalid JSON. This state machine escapes them.
  */
+// biome-ignore lint/correctness/noUnusedVariables: Used globally via importScripts
 function fixJsonControlChars(str) {
   // ⚡ Bolt Optimization: Bypass character-by-character processing loops with a
   // fast regex test for rare conditions (like JSON control characters).


### PR DESCRIPTION
💡 What: Implemented `document.createDocumentFragment()` in `popup.js`'s `renderSummary` function to batch append child elements, and updated the `tests/popup.test.js` DOM mock to accurately support fragment iteration and clearing. Also fixed an incidental unused variable linting warning in `utils.js` caused by `--unsafe` checks.
🎯 Why: Appending nodes one by one within a loop to a live DOM element (`summaryDiv`) triggers a browser reflow and repaint for each item. When processing many repositories, this causes unnecessary performance overhead in the UI thread.
📊 Impact: Eliminates O(N) reflows during summary rendering (where N is the number of processed repositories), reducing UI jank and making the popup feel snappier.
🔬 Measurement: Verify tests run via `pnpm test` and the extension renders the summary cleanly without visual tearing when processing multiple repos.

---
*PR created automatically by Jules for task [11338254331994539067](https://jules.google.com/task/11338254331994539067) started by @n24q02m*