### PR TITLE
🎨 Palette: [UX improvement] Replace inaccessible tooltips with visible field hints

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 ## 2025-05-22 - Dynamic Action Button Context
 **Learning:** Using static text (e.g., 'Start Archiving') on a primary action button when multiple execution modes (e.g., 'Run' vs 'Dry Run') are available creates ambiguity and hesitation for the user. They may be unsure if clicking the button will actually modify data or just simulate the process.
 **Action:** Always implement context-aware dynamic text for primary action buttons that reflects both the operation type and the execution mode (e.g., 'Dry Run Archive' vs 'Start Archiving'). Attach event listeners to the mode selection inputs to update this text immediately when the user changes settings, ensuring clear, real-time feedback on what the primary action will do.
+## 2025-06-15 - Inaccessible Tooltips on Form Controls
+**Learning:** Using native HTML `title` attributes for hints on form controls (like checkboxes) creates significant accessibility barriers. They are completely inaccessible on touch devices and often skipped or read unreliably by screen readers compared to explicitly linked text.
+**Action:** Always replace `title` attributes with visible, inline helper text (e.g., `<span class="hint">`) and link it directly to the input field using `aria-describedby` so the hint is always discoverable and correctly announced by assistive technologies.

--- a/popup.html
+++ b/popup.html
@@ -42,10 +42,13 @@
         <label><input type="radio" name="mode" value="dry" checked /> Dry Run</label>
         <label><input type="radio" name="mode" value="run" /> Run</label>
       </div>
-      <label class="checkbox" title="Archive tasks even if they have matching open Pull Requests">
-        <input type="checkbox" id="force" />
-        Force (skip PR check)
-      </label>
+      <div class="setting-row">
+        <label class="checkbox">
+          <input type="checkbox" id="force" aria-describedby="forceHint" />
+          Force
+        </label>
+        <span class="hint" id="forceHint" style="display: block; margin-left: 20px; margin-top: 2px;">Archive tasks even if they have matching open Pull Requests</span>
+      </div>
       <div class="radio-group" role="radiogroup" aria-label="Scope">
         <label><input type="radio" name="scope" value="current" /> Current tab</label>
         <label><input type="radio" name="scope" value="all" checked /> All Jules tabs</label>
@@ -58,7 +61,7 @@
     <section id="progressSection" style="display: none">
       <h2>Progress</h2>
       <div id="currentInfo" class="current-info" aria-live="polite"></div>
-      <div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
+      <div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" aria-label="Operation progress">
         <div id="progressFill" class="progress-fill"></div>
       </div>
       <pre id="log" class="log" aria-live="off"></pre>


### PR DESCRIPTION
💡 **What:** Replaced the native `title` attribute on the "Force" checkbox with a visible inline hint linked via `aria-describedby`. Added an `aria-label` to the progress bar.
🎯 **Why:** Native HTML `title` attributes are an accessibility anti-pattern. They are completely inaccessible on touch devices and often skipped or read unreliably by screen readers compared to explicitly linked text.
📸 **Before/After:** (See frontend verification screenshots in PR comments)
♿ **Accessibility:** The hint text is now discoverable by all users. Screen readers will correctly announce "Force (Archive tasks even if they have matching open Pull Requests)" when the checkbox is focused, and the progress bar has proper context ("Operation progress").

---
*PR created automatically by Jules for task [930119739319273409](https://jules.google.com/task/930119739319273409) started by @n24q02m*