### PR TITLE
🎨 Palette: Add visible labels for radio groups in settings

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -10,3 +10,6 @@
 ## 2025-06-15 - Inaccessible Tooltips on Form Controls
 **Learning:** Using native HTML `title` attributes for hints on form controls (like checkboxes) creates significant accessibility barriers. They are completely inaccessible on touch devices and often skipped or read unreliably by screen readers compared to explicitly linked text.
 **Action:** Always replace `title` attributes with visible, inline helper text (e.g., `<span class="hint">`) and link it directly to the input field using `aria-describedby` so the hint is always discoverable and correctly announced by assistive technologies.
+## 2025-06-20 - Avoid Invisible Labels on Form Groups
+**Learning:** Using invisible `aria-label`s on form control groups (like radio groups) when visual context is needed can cause confusion for sighted users, as they lack explicit visual cues regarding the purpose of the grouping.
+**Action:** Always provide explicit, visible `<label>` elements linked to the group via `aria-labelledby`, rather than relying solely on `aria-label` on the container, to ensure a clear visual hierarchy and layout consistency for all users.

--- a/popup.html
+++ b/popup.html
@@ -38,9 +38,12 @@
           <button type="button" data-value="suggestions" aria-pressed="false">Start Suggestions</button>
         </div>
       </div>
-      <div class="radio-group" role="radiogroup" aria-label="Execution Mode">
-        <label><input type="radio" name="mode" value="dry" checked /> Dry Run</label>
-        <label><input type="radio" name="mode" value="run" /> Run</label>
+      <div class="setting-row">
+        <label id="modeLabel">Execution Mode</label>
+        <div class="radio-group" role="radiogroup" aria-labelledby="modeLabel">
+          <label><input type="radio" name="mode" value="dry" checked /> Dry Run</label>
+          <label><input type="radio" name="mode" value="run" /> Run</label>
+        </div>
       </div>
       <div class="setting-row">
         <label class="checkbox">
@@ -49,9 +52,12 @@
         </label>
         <span class="hint" id="forceHint" style="display: block; margin-left: 20px; margin-top: 2px;">Archive tasks even if they have matching open Pull Requests</span>
       </div>
-      <div class="radio-group" role="radiogroup" aria-label="Scope">
-        <label><input type="radio" name="scope" value="current" /> Current tab</label>
-        <label><input type="radio" name="scope" value="all" checked /> All Jules tabs</label>
+      <div class="setting-row">
+        <label id="scopeLabel">Scope</label>
+        <div class="radio-group" role="radiogroup" aria-labelledby="scopeLabel">
+          <label><input type="radio" name="scope" value="current" /> Current tab</label>
+          <label><input type="radio" name="scope" value="all" checked /> All Jules tabs</label>
+        </div>
       </div>
     </section>
 


### PR DESCRIPTION
💡 What:
Replaced the invisible `aria-label` attributes on the "Execution Mode" and "Scope" radio groups with visible, explicit `<label>` elements linked via `aria-labelledby`. Wrapped them in `.setting-row` containers to match the existing "Operation" layout. Added a learning to `.Jules/palette.md`.

🎯 Why:
Using invisible `aria-label`s on form control groups leaves sighted users without clear contextual cues for the grouping's purpose. Providing explicit visible labels ensures a clear visual hierarchy and layout consistency, preventing cognitive ambiguity.

📸 Before/After:
*Before:* The "Dry Run" / "Run" and "Current tab" / "All Jules tabs" radio buttons floated below inputs without clear headings.
*After:* They now sit beneath explicit "Execution Mode" and "Scope" labels, consistent with the "Operation" settings above them.

♿ Accessibility:
Maintains accessibility for screen reader users by properly linking the new visible `<label>` text to the `role="radiogroup"` container using `aria-labelledby`, ensuring the context is always announced accurately without relying on invisible hints.

---
*PR created automatically by Jules for task [14363830500681961248](https://jules.google.com/task/14363830500681961248) started by @n24q02m*