### PR TITLE
🎨 Palette: Improve accessibility of radio groups

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -10,3 +10,6 @@
 ## 2025-06-15 - Inaccessible Tooltips on Form Controls
 **Learning:** Using native HTML `title` attributes for hints on form controls (like checkboxes) creates significant accessibility barriers. They are completely inaccessible on touch devices and often skipped or read unreliably by screen readers compared to explicitly linked text.
 **Action:** Always replace `title` attributes with visible, inline helper text (e.g., `<span class="hint">`) and link it directly to the input field using `aria-describedby` so the hint is always discoverable and correctly announced by assistive technologies.
+## 2025-06-16 - Explicit Labels for Radio Groups
+**Learning:** Using invisible `aria-label`s on form control groups (like radio groups) when visual context is needed can cause confusion for sighted users.
+**Action:** Always provide explicit, visible `<label>` elements and link them directly to the group via `aria-labelledby` (e.g., `<label id="modeLabel">...` and `<div role="radiogroup" aria-labelledby="modeLabel">`) to ensure a clear visual and semantic hierarchy.

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/popup.html
+++ b/popup.html
@@ -38,9 +38,12 @@
           <button type="button" data-value="suggestions" aria-pressed="false">Start Suggestions</button>
         </div>
       </div>
-      <div class="radio-group" role="radiogroup" aria-label="Execution Mode">
-        <label><input type="radio" name="mode" value="dry" checked /> Dry Run</label>
-        <label><input type="radio" name="mode" value="run" /> Run</label>
+      <div class="setting-row">
+        <label id="execModeLabel">Execution Mode</label>
+        <div class="radio-group" role="radiogroup" aria-labelledby="execModeLabel">
+          <label><input type="radio" name="mode" value="dry" checked /> Dry Run</label>
+          <label><input type="radio" name="mode" value="run" /> Run</label>
+        </div>
       </div>
       <div class="setting-row">
         <label class="checkbox">
@@ -49,9 +52,12 @@
         </label>
         <span class="hint" id="forceHint" style="display: block; margin-left: 20px; margin-top: 2px;">Archive tasks even if they have matching open Pull Requests</span>
       </div>
-      <div class="radio-group" role="radiogroup" aria-label="Scope">
-        <label><input type="radio" name="scope" value="current" /> Current tab</label>
-        <label><input type="radio" name="scope" value="all" checked /> All Jules tabs</label>
+      <div class="setting-row">
+        <label id="scopeLabel">Scope</label>
+        <div class="radio-group" role="radiogroup" aria-labelledby="scopeLabel">
+          <label><input type="radio" name="scope" value="current" /> Current tab</label>
+          <label><input type="radio" name="scope" value="all" checked /> All Jules tabs</label>
+        </div>
       </div>
     </section>
 

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -401,4 +401,11 @@ describe('popup.html accessibility', () => {
       'token input should reference the hint via aria-describedby'
     )
   })
+
+  it('should use explicit visible labels for radio groups via aria-labelledby', () => {
+    assert.ok(popupHtml.includes('id="execModeLabel"'), 'execModeLabel should exist')
+    assert.ok(popupHtml.includes('aria-labelledby="execModeLabel"'), 'mode radiogroup should use aria-labelledby')
+    assert.ok(popupHtml.includes('id="scopeLabel"'), 'scopeLabel should exist')
+    assert.ok(popupHtml.includes('aria-labelledby="scopeLabel"'), 'scope radiogroup should use aria-labelledby')
+  })
 })


### PR DESCRIPTION
### 💡 What
Replaced invisible `aria-label`s with explicit, visible `<label>` elements for the "Execution Mode" and "Scope" radio groups in `popup.html`, properly linking them via `aria-labelledby`.

### 🎯 Why
Invisible labels on form control groups can cause confusion for sighted users who lack the visual context of what the grouping represents. Providing explicit labels ensures a clearer visual hierarchy and improves usability. 

### 📸 Before/After
See attached frontend verification screenshot for the final result showing the aligned, visible labels "Execution Mode" and "Scope".

### ♿ Accessibility
Improved semantics and visual context for radio groups. Using `aria-labelledby` creates a stronger, standards-compliant link between the visible text and the form group for assistive technologies.

---
*PR created automatically by Jules for task [18249894347848504672](https://jules.google.com/task/18249894347848504672) started by @n24q02m*