### PR TITLE
[TEST] Untested callBatchExecute Error Handling

### DIFF
--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -95,6 +95,7 @@ function setupEnvironment(initialStorage = {}) {
     globalThis.test_updateState = updateState;
     globalThis.test_addLog = addLog;
     globalThis.test_buildBatchRequest = buildBatchRequest;
+    globalThis.test_callBatchExecute = callBatchExecute;
     globalThis.test_runInPool = runInPool;
     globalThis.test_fixJsonControlChars = fixJsonControlChars;
     globalThis.test_findJsonEnd = findJsonEnd;
@@ -1133,5 +1134,33 @@ describe('KeepAlive', () => {
     assert.strictEqual(sandbox.test_clearedTimers.length, 1)
     assert.strictEqual(sandbox.test_clearedTimers[0], intervalId)
     assert.strictEqual(sandbox.test_getKeepAliveInterval(), null)
+  })
+})
+
+describe('callBatchExecute', () => {
+  it('should throw error when jFetch fails with HTTP error', async () => {
+    const { sandbox } = setupEnvironment()
+    sandbox.fetch = async () => ({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error'
+    })
+
+    const config = { accountNum: '0' }
+    await assert.rejects(sandbox.test_callBatchExecute('rpcId', {}, config), {
+      message: 'batchexecute rpcId failed: HTTP 500'
+    })
+  })
+
+  it('should throw error when fetch throws network error', async () => {
+    const { sandbox } = setupEnvironment()
+    sandbox.fetch = async () => {
+      throw new Error('Network Error')
+    }
+
+    const config = { accountNum: '0' }
+    await assert.rejects(sandbox.test_callBatchExecute('rpcId', {}, config), {
+      message: 'batchexecute rpcId failed: Network Error'
+    })
   })
 })


### PR DESCRIPTION
This PR adds unit test coverage for the error handling logic in the `callBatchExecute` function within `background.js`.

### Changes:
- Modified `tests/background.test.js` to expose `callBatchExecute` to the test environment.
- Added a new `describe('callBatchExecute')` block with tests for:
    - HTTP errors (e.g., 500 Internal Server Error).
    - Network/Fetch errors.
- Verified that the errors are rethrown with the expected context-prefixed message: `batchexecute <rpcId> failed: <original message>`.

These changes ensure that the error handling path in `callBatchExecute` is verified and protected against regressions.

---
*PR created automatically by Jules for task [508592456934034319](https://jules.google.com/task/508592456934034319) started by @n24q02m*