### PR TITLE
🎨 Palette: Improve active processing feedback

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,6 @@
 ## 2025-06-16 - Explicit Labels for Radio Groups
 **Learning:** Using invisible `aria-label`s on form control groups (like radio groups) when visual context is needed can cause confusion for sighted users.
 **Action:** Always provide explicit, visible `<label>` elements and link them directly to the group via `aria-labelledby` (e.g., `<label id="modeLabel">...` and `<div role="radiogroup" aria-labelledby="modeLabel">`) to ensure a clear visual and semantic hierarchy.
+## 2025-06-25 - Differentiating Loading vs Disabled States
+**Learning:** Using the same disabled styling (grayed out) for an active, processing state (e.g., when a button is clicked and waiting for an async operation) makes the UI feel unresponsive and "dead," confusing users about whether the action is actually occurring.
+**Action:** Always visually distinguish a loading state from a purely disabled state. If a button is disabled because it is busy (`[aria-busy="true"]`), maintain the primary visual context (like color) but indicate processing (e.g., cursor: wait, partial opacity). Additionally, add subtle interactive feedback like `transform: scale(0.98)` on active states to improve tactile feel.

--- a/popup.css
+++ b/popup.css
@@ -163,10 +163,20 @@ button.primary:hover {
   background: #22c55e;
 }
 
+button.primary:active:not(:disabled) {
+  transform: scale(0.98);
+}
+
 button.primary:disabled {
   background: #334155;
   color: #64748b;
   cursor: not-allowed;
+}
+
+button.primary:disabled[aria-busy="true"] {
+  background: rgba(74, 222, 128, 0.7);
+  color: #0f172a;
+  cursor: wait;
 }
 
 button.secondary {

--- a/popup.html
+++ b/popup.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <title>Jules Task Archiver</title>
     <link rel="stylesheet" href="popup.css" />
   </head>
   <body>


### PR DESCRIPTION
💡 **What:** 
- Added a `<title>` tag to `popup.html`.
- Updated `popup.css` to visually distinguish the active processing (loading) state of the primary button from the standard "dead/grayed out" disabled state.
- Added a subtle `:active:not(:disabled)` click animation to the primary button.

🎯 **Why:** 
When the user clicked "Start Archiving", the button was simply getting grayed out. This made the application look unresponsive and dead during long-running background operations. By using `[aria-busy="true"]` (which was already correctly set in `popup.js`), we can maintain the primary action color (with slight opacity and a wait cursor) so the user knows the application is actively processing their request. The click animation adds a tactile feel that was missing.

📸 **Visual Change:**
The primary button now turns semi-transparent green with a wait cursor when processing, instead of dark gray. 

♿ **Accessibility:**
- Added missing `<title>` tag to `popup.html` so screen readers can announce the context of the popup properly.
- Kept the UI semantics correct by utilizing `aria-busy` to drive the visual state changes.

---
*PR created automatically by Jules for task [8339809864786702344](https://jules.google.com/task/8339809864786702344) started by @n24q02m*