### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix API token leakage in jFetch

### DIFF
--- a/background.js
+++ b/background.js
@@ -46,6 +46,9 @@ async function jFetch(url, options = {}) {
   if (token) {
     if (typeof token !== 'string') throw new Error('Token must be a string')
     if (/[\r\n]/.test(token)) throw new Error('Invalid token: contains newline')
+    if (origin !== 'https://api.github.com') {
+      throw new Error('Security Error: Token can only be sent to GitHub API')
+    }
     headers.Authorization = `token ${token}`
   }
 

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -1116,7 +1116,7 @@ describe('jFetch', () => {
       return { ok: true }
     }
 
-    await sandbox.test_jFetch('https://jules.google.com/api/test', { token: 'valid-token' })
+    await sandbox.test_jFetch('https://api.github.com/api/test', { token: 'valid-token' })
     assert.strictEqual(capturedHeaders.Authorization, 'token valid-token')
   })
 })

--- a/tests/security.test.js
+++ b/tests/security.test.js
@@ -301,6 +301,14 @@ describe('jFetch SSRF Security', () => {
     const res2 = await sandbox.jFetch('https://api.github.com/repos/owner/repo')
     assert.strictEqual(res2.ok, true)
   })
+
+  it('should block requests with a token to non-GitHub origins', async () => {
+    const { sandbox } = setupEnvironment()
+
+    await assert.rejects(sandbox.jFetch('https://jules.google.com/u/1/tasks', { token: 'my-token' }), {
+      message: /Security Error: Token can only be sent to GitHub API/
+    })
+  })
 })
 
 describe('getTabConfig Path Traversal Security', () => {


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The central `jFetch` wrapper blindly injected the GitHub authentication token into the headers of any outgoing request if the token was present in the options, opening the door to potential credential leakage to non-GitHub domains if a caller passed a token inadvertently.
🎯 **Impact:** If `jFetch` were called with a token to `jules.google.com` or another origin, the GitHub token could be leaked in the headers, leading to unauthorized access to the user's GitHub account.
🔧 **Fix:** Added origin validation in `jFetch` to ensure tokens are only injected when communicating with `api.github.com`.
✅ **Verification:** Added a unit test in `tests/security.test.js` to verify that `jFetch` throws a `Security Error` when attempting to send a token to a non-GitHub domain. Run `node --test tests/security.test.js` to confirm.

---
*PR created automatically by Jules for task [2530987848853862955](https://jules.google.com/task/2530987848853862955) started by @n24q02m*