### PR TITLE
🎨 Palette: Add context-aware dynamic text for running state

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,6 @@
 ## 2025-06-16 - Explicit Labels for Radio Groups
 **Learning:** Using invisible `aria-label`s on form control groups (like radio groups) when visual context is needed can cause confusion for sighted users.
 **Action:** Always provide explicit, visible `<label>` elements and link them directly to the group via `aria-labelledby` (e.g., `<label id="modeLabel">...` and `<div role="radiogroup" aria-labelledby="modeLabel">`) to ensure a clear visual and semantic hierarchy.
+## 2025-06-25 - Context-Aware Loading States
+**Learning:** Using a generic loading indicator (like "⏳ Running...") on the primary action button during asynchronous operations can create user ambiguity, especially in multi-mode interfaces (e.g., Dry Run vs. Run, Archive vs. Suggestions). Users may feel uncertain about which specific action is being processed.
+**Action:** Always provide context-aware text during loading/processing states (e.g., "⏳ Dry Running Archive...") that dynamically reflects the user's selected configuration, assuring them the system is performing exactly what they intended.

--- a/popup.js
+++ b/popup.js
@@ -22,6 +22,18 @@ const summaryDiv = $('#summary')
 // --- Operation mode state ---
 let opMode = 'archive'
 
+function getRunningText() {
+  const modeRadio = document.querySelector('input[name="mode"]:checked')
+  const isDry = modeRadio && modeRadio.value === 'dry'
+  const isArchive = opMode === 'archive'
+
+  if (isArchive) {
+    return isDry ? '⏳ Dry Running Archive...' : '⏳ Running Archive...'
+  } else {
+    return isDry ? '⏳ Dry Running Suggestions...' : '⏳ Running Suggestions...'
+  }
+}
+
 // --- Operation mode selector ---
 function setActiveOpMode(value) {
   opMode = value
@@ -69,7 +81,7 @@ document.querySelectorAll('#opMode button').forEach((btn) => {
 // Update button text when execution mode changes
 document.querySelectorAll('input[name="mode"]').forEach((radio) => {
   radio.addEventListener('change', () => {
-    if (!startBtn.disabled && startBtn.textContent !== '⏳ Running...') {
+    if (!startBtn.disabled && !startBtn.textContent.startsWith('⏳')) {
       updateOpModeUI(opMode)
     }
   })
@@ -137,7 +149,7 @@ startBtn.addEventListener('click', async () => {
   // Reset UI
   startBtn.disabled = true
   startBtn.setAttribute('aria-busy', 'true')
-  startBtn.textContent = '⏳ Running...'
+  startBtn.textContent = getRunningText()
   resetBtn.style.display = 'none'
   progressSection.style.display = 'block'
   summarySection.style.display = 'none'
@@ -250,11 +262,15 @@ function renderSummary(results) {
 // --- Check for existing state on popup open ---
 chrome.runtime.sendMessage({ action: 'GET_STATE' }, (state) => {
   if (state && state.status !== 'idle') {
+    // Rehydrate opMode if it's available in the state options
+    if (state.options?.opMode) {
+      opMode = state.options.opMode
+    }
     renderState(state)
     if (state.status === 'running') {
       startBtn.disabled = true
       startBtn.setAttribute('aria-busy', 'true')
-      startBtn.textContent = '⏳ Running...'
+      startBtn.textContent = getRunningText()
     } else {
       resetBtn.style.display = 'block'
     }

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -359,7 +359,7 @@ describe('Button Event Handlers', () => {
     assert.strictEqual(sentMessage.action, 'START')
     assert.strictEqual(sentMessage.options.opMode, 'archive')
     assert.strictEqual(elements['#startBtn'].disabled, true)
-    assert.strictEqual(elements['#startBtn'].textContent, '⏳ Running...')
+    assert.strictEqual(elements['#startBtn'].textContent, '⏳ Dry Running Archive...')
   })
 
   it('should send RESET message when resetBtn is clicked', () => {


### PR DESCRIPTION
💡 What: Replaced the hardcoded "⏳ Running..." string with a dynamic, context-aware string on the primary action button (e.g. "⏳ Dry Running Archive...").
🎯 Why: In a multi-mode UI, using a generic loading indicator during async operations can create user ambiguity about what exactly the system is doing. Providing context-aware text reassures the user that their specific configuration is being executed.
📸 Before/After: Visual text change on the primary button during operation.
♿ Accessibility: N/A - visual enhancement for clarity.

---
*PR created automatically by Jules for task [4513815739954065960](https://jules.google.com/task/4513815739954065960) started by @n24q02m*