### PR TITLE
🎨 Palette: Distinct visual state for processing buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,6 @@
 ## 2025-06-16 - Explicit Labels for Radio Groups
 **Learning:** Using invisible `aria-label`s on form control groups (like radio groups) when visual context is needed can cause confusion for sighted users.
 **Action:** Always provide explicit, visible `<label>` elements and link them directly to the group via `aria-labelledby` (e.g., `<label id="modeLabel">...` and `<div role="radiogroup" aria-labelledby="modeLabel">`) to ensure a clear visual and semantic hierarchy.
+## 2026-05-30 - Distinct Visual State for Processing Buttons
+**Learning:** Using a standard `:disabled` gray-out state and `not-allowed` cursor for a button that triggered an ongoing async background task breaks semantics and causes user confusion, making the system appear broken or unresponsive while processing.
+**Action:** Always style active processing buttons distinctly from purely inactive ones. Use `:disabled[aria-busy="true"]` to maintain primary button identity (colors) while indicating the wait state with opacity and a `wait` cursor.

--- a/popup.css
+++ b/popup.css
@@ -169,6 +169,13 @@ button.primary:disabled {
   cursor: not-allowed;
 }
 
+button.primary:disabled[aria-busy="true"] {
+  background: #4ade80;
+  color: #0f172a;
+  opacity: 0.7;
+  cursor: wait;
+}
+
 button.secondary {
   display: block;
   width: 100%;


### PR DESCRIPTION
💡 **What:** Added distinct CSS rules for disabled primary buttons when `aria-busy="true"`.
🎯 **Why:** To provide clear semantic visual feedback that an operation is actively running in the background, preventing user confusion caused by standard inactive disabled styling.
📸 **Before/After:** The 'Running' button now retains its green primary styling and wait cursor instead of appearing grayed-out and forbidden.
♿ **Accessibility:** Maintains correct visual identity during ARIA busy states.

---
*PR created automatically by Jules for task [7353122060824883994](https://jules.google.com/task/7353122060824883994) started by @n24q02m*