### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix credential leakage in jFetch

### DIFF
--- a/background.js
+++ b/background.js
@@ -44,6 +44,9 @@ async function jFetch(url, options = {}) {
   const { token, headers = {}, ...rest } = options
 
   if (token) {
+    if (urlObj.origin !== 'https://api.github.com') {
+      throw new Error('Security Error: Cannot send GitHub token to non-GitHub origin')
+    }
     if (typeof token !== 'string') throw new Error('Token must be a string')
     if (/[\r\n]/.test(token)) throw new Error('Invalid token: contains newline')
     headers.Authorization = `token ${token}`

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -1090,10 +1090,19 @@ describe('jFetch', () => {
     })
   })
 
+  it('should throw a security error if token is provided with non-GitHub origin', async () => {
+    const { sandbox } = setupEnvironment()
+
+    await assert.rejects(() => sandbox.test_jFetch('https://jules.google.com/api/test', { token: 'valid-token' }), {
+      name: 'Error',
+      message: 'Security Error: Cannot send GitHub token to non-GitHub origin'
+    })
+  })
+
   it('should throw an error if token is not a string', async () => {
     const { sandbox } = setupEnvironment()
 
-    await assert.rejects(() => sandbox.test_jFetch('https://jules.google.com/api/test', { token: 123 }), {
+    await assert.rejects(() => sandbox.test_jFetch('https://api.github.com/api/test', { token: 123 }), {
       name: 'Error',
       message: 'Token must be a string'
     })
@@ -1102,7 +1111,7 @@ describe('jFetch', () => {
   it('should throw an error if token contains newlines', async () => {
     const { sandbox } = setupEnvironment()
 
-    await assert.rejects(() => sandbox.test_jFetch('https://jules.google.com/api/test', { token: 'invalid\ntoken' }), {
+    await assert.rejects(() => sandbox.test_jFetch('https://api.github.com/api/test', { token: 'invalid\ntoken' }), {
       name: 'Error',
       message: 'Invalid token: contains newline'
     })
@@ -1116,7 +1125,7 @@ describe('jFetch', () => {
       return { ok: true }
     }
 
-    await sandbox.test_jFetch('https://jules.google.com/api/test', { token: 'valid-token' })
+    await sandbox.test_jFetch('https://api.github.com/api/test', { token: 'valid-token' })
     assert.strictEqual(capturedHeaders.Authorization, 'token valid-token')
   })
 })


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The generic network utility wrapper `jFetch` allowed the GitHub token (`headers.Authorization = 'token ' + token`) to be attached to requests directed at non-GitHub origins (like `jules.google.com`), potentially leaking the token to other services.
🎯 Impact: An attacker or a misconfiguration could cause `jFetch` to hit a third-party or arbitrary URL, leaking the user's GitHub authentication token.
🔧 Fix: Updated `jFetch` to strictly validate the destination origin (`urlObj.origin === 'https://api.github.com'`) before attaching the GitHub token to the request headers.
✅ Verification: Ran `pnpm test` and `npx @biomejs/biome check .`. Added a specific test in `tests/background.test.js` to ensure the security error is thrown for non-GitHub origins when a token is provided. Updated existing token tests to use the correct `https://api.github.com` origin.

---
*PR created automatically by Jules for task [9796342838774490306](https://jules.google.com/task/9796342838774490306) started by @n24q02m*