### PR TITLE
🎨 Palette: Improve loading state visual feedback

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,6 @@
 ## 2025-06-16 - Explicit Labels for Radio Groups
 **Learning:** Using invisible `aria-label`s on form control groups (like radio groups) when visual context is needed can cause confusion for sighted users.
 **Action:** Always provide explicit, visible `<label>` elements and link them directly to the group via `aria-labelledby` (e.g., `<label id="modeLabel">...` and `<div role="radiogroup" aria-labelledby="modeLabel">`) to ensure a clear visual and semantic hierarchy.
+## 2025-06-21 - Visual Distinction for Loading States
+**Learning:** Using the same `:disabled` style for both a truly inactive button (e.g., waiting for valid input) and a button actively processing an async operation creates ambiguity. Users might think the action failed to start or is permanently blocked.
+**Action:** To visually distinguish a loading/processing state from a purely disabled state without breaking semantics, style elements using the `:disabled[aria-busy="true"]` CSS selector to maintain primary colors (often with slight opacity) and add a `wait` cursor, while keeping the standard `:disabled` selector for inactive elements.

--- a/popup.css
+++ b/popup.css
@@ -169,6 +169,13 @@ button.primary:disabled {
   cursor: not-allowed;
 }
 
+button.primary:disabled[aria-busy="true"] {
+  background: #4ade80;
+  opacity: 0.7;
+  color: #0f172a;
+  cursor: wait;
+}
+
 button.secondary {
   display: block;
   width: 100%;


### PR DESCRIPTION
💡 **What:** Added a specific CSS rule `button.primary:disabled[aria-busy="true"]` to `popup.css` to visually distinguish the primary action button when it is in a loading/processing state versus when it is merely disabled/inactive (e.g., waiting for input).

🎯 **Why:** Using the same `:disabled` grey-out style for both a truly inactive button and a button actively processing an async operation creates ambiguity. Users might think the action failed to start or is permanently blocked. This enhancement improves user feedback and confidence during background operations.

📸 **Before/After:** The button now retains its primary green color (with slight opacity) and shows a `wait` cursor instead of reverting to the inactive `#334155` grey with a `not-allowed` cursor when "Running...".

♿ **Accessibility:** Leverages the existing semantic `aria-busy="true"` attribute already being set by the JS logic to hook the new styles, ensuring visual improvements map directly to the accessible state.

---
*PR created automatically by Jules for task [18166908615848973973](https://jules.google.com/task/18166908615848973973) started by @n24q02m*