### PR TITLE
🛡️ Sentinel: [HIGH] Fix credential leakage in jFetch

### DIFF
--- a/background.js
+++ b/background.js
@@ -44,6 +44,9 @@ async function jFetch(url, options = {}) {
   const { token, headers = {}, ...rest } = options
 
   if (token) {
+    if (origin !== 'https://api.github.com') {
+      throw new Error('Security Error: Refusing to send GitHub token to non-GitHub origin')
+    }
     if (typeof token !== 'string') throw new Error('Token must be a string')
     if (/[\r\n]/.test(token)) throw new Error('Invalid token: contains newline')
     headers.Authorization = `token ${token}`

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -1093,7 +1093,7 @@ describe('jFetch', () => {
   it('should throw an error if token is not a string', async () => {
     const { sandbox } = setupEnvironment()
 
-    await assert.rejects(() => sandbox.test_jFetch('https://jules.google.com/api/test', { token: 123 }), {
+    await assert.rejects(() => sandbox.test_jFetch('https://api.github.com/api/test', { token: 123 }), {
       name: 'Error',
       message: 'Token must be a string'
     })
@@ -1102,7 +1102,7 @@ describe('jFetch', () => {
   it('should throw an error if token contains newlines', async () => {
     const { sandbox } = setupEnvironment()
 
-    await assert.rejects(() => sandbox.test_jFetch('https://jules.google.com/api/test', { token: 'invalid\ntoken' }), {
+    await assert.rejects(() => sandbox.test_jFetch('https://api.github.com/api/test', { token: 'invalid\ntoken' }), {
       name: 'Error',
       message: 'Invalid token: contains newline'
     })
@@ -1116,7 +1116,7 @@ describe('jFetch', () => {
       return { ok: true }
     }
 
-    await sandbox.test_jFetch('https://jules.google.com/api/test', { token: 'valid-token' })
+    await sandbox.test_jFetch('https://api.github.com/api/test', { token: 'valid-token' })
     assert.strictEqual(capturedHeaders.Authorization, 'token valid-token')
   })
 })

--- a/tests/security.test.js
+++ b/tests/security.test.js
@@ -301,6 +301,14 @@ describe('jFetch SSRF Security', () => {
     const res2 = await sandbox.jFetch('https://api.github.com/repos/owner/repo')
     assert.strictEqual(res2.ok, true)
   })
+
+  it('should block sending token to non-GitHub origin', async () => {
+    const { sandbox } = setupEnvironment()
+
+    await assert.rejects(sandbox.jFetch('https://jules.google.com/u/1/tasks', { token: 'secret-token' }), {
+      message: /Security Error: Refusing to send GitHub token to non-GitHub origin/
+    })
+  })
 })
 
 describe('getTabConfig Path Traversal Security', () => {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `jFetch` utility blindly attached a GitHub authentication token to any allowed origin (including `jules.google.com`).
🎯 Impact: Potential credential leakage to non-GitHub services via SSRF or unchecked URLs.
🔧 Fix: Explicitly verified the origin is `https://api.github.com` before setting the `Authorization` header.
✅ Verification: Tested via unit tests in `tests/security.test.js`.

---
*PR created automatically by Jules for task [8386271471262277913](https://jules.google.com/task/8386271471262277913) started by @n24q02m*