### PR TITLE
🎨 Palette: Fix orphaned hint text during progressive disclosure

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -19,3 +19,6 @@
 ## 2025-06-25 - Differentiating Loading vs Disabled States
 **Learning:** Using the same disabled styling (grayed out) for an active, processing state (e.g., when a button is clicked and waiting for an async operation) makes the UI feel unresponsive and "dead," confusing users about whether the action is actually occurring.
 **Action:** Always visually distinguish a loading state from a purely disabled state. If a button is disabled because it is busy (`[aria-busy="true"]`), maintain the primary visual context (like color) but indicate processing (e.g., cursor: wait, partial opacity). Additionally, add subtle interactive feedback like `transform: scale(0.98)` on active states to improve tactile feel.
+## 2025-10-25 - Orphaned Hint Text in Progressive Disclosure
+**Learning:** Hiding form inputs via their direct `.parentElement` works for simple labels, but leaves sibling elements (like structural hints or descriptions) visible and orphaned on the screen if they share a higher-level container, causing layout clutter and confusing the user context.
+**Action:** Always target the highest logical structural wrapper (e.g., using `.closest('.setting-row')`) when applying progressive disclosure rules to ensure the input, its label, and any associated hint text or spacing are shown or hidden together as a single atomic unit.

--- a/popup.js
+++ b/popup.js
@@ -50,13 +50,13 @@ function updateOpModeUI(value) {
   // Progressive disclosure: hide archive-specific settings
   const isArchive = value === 'archive'
   const settingsSection = document.querySelector('.settings')
-  const forceCheckboxContainer = forceCheckbox.parentElement
+  const forceCheckboxContainer = forceCheckbox.closest('.setting-row')
 
   if (settingsSection) {
     settingsSection.style.display = isArchive ? 'block' : 'none'
   }
   if (forceCheckboxContainer) {
-    forceCheckboxContainer.style.display = isArchive ? 'flex' : 'none'
+    forceCheckboxContainer.style.display = isArchive ? 'block' : 'none'
   }
 
   // Context-aware start button text

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -94,6 +94,7 @@ function setupPopupSandbox() {
     '#ghOwner': createMockElement('input'),
     '#ghToken': createMockElement('input'),
     '#force': createMockElement('input', { type: 'checkbox' }),
+    '#forceRow': createMockElement('div'),
     '#startBtn': createMockElement('button'),
     'input[name="mode"]:checked': createMockElement('input', { value: 'dry' }),
     '#resetBtn': createMockElement('button'),
@@ -107,7 +108,10 @@ function setupPopupSandbox() {
   }
 
   // Parent element for elements that use .parentElement in popup.js
-  elements['#force'].parentElement = createMockElement('div')
+  elements['#force'].closest = (sel) => {
+    if (sel === '.setting-row') return elements['#forceRow']
+    return null
+  }
   elements['#progressFill'].parentElement = createMockElement('div')
 
   const opModeButtons = [
@@ -240,12 +244,12 @@ describe('setActiveOpMode', () => {
     // Archive mode (default or set)
     sandbox.setActiveOpMode('archive')
     assert.strictEqual(elements['.settings'].style.display, 'block')
-    assert.strictEqual(elements['#force'].parentElement.style.display, 'flex')
+    assert.strictEqual(elements['#forceRow'].style.display, 'block')
 
     // Suggestions mode
     sandbox.setActiveOpMode('suggestions')
     assert.strictEqual(elements['.settings'].style.display, 'none')
-    assert.strictEqual(elements['#force'].parentElement.style.display, 'none')
+    assert.strictEqual(elements['#forceRow'].style.display, 'none')
   })
 })
 


### PR DESCRIPTION
💡 **What:** The UX enhancement updates the DOM target for progressive disclosure in `popup.js` to hide the entire `.setting-row` wrapper instead of just the `.parentElement` of the checkbox.
🎯 **Why:** Previously, toggling execution modes (like 'Start Suggestions') hid the checkbox but left its descriptive hint text ("Archive tasks even if they have matching open Pull Requests") visible and orphaned. This fixes layout clutter and prevents user confusion by treating the input, label, and hint as a single logical unit.
📸 **Before/After:** Hint text is no longer visible when the 'Force' checkbox is hidden.
♿ **Accessibility:** Ensures cleaner UI reading order and reduces cognitive load by removing irrelevant contextual text.

---
*PR created automatically by Jules for task [10233167691770421204](https://jules.google.com/task/10233167691770421204) started by @n24q02m*