### PR TITLE
🎨 Palette: Fix progressive disclosure for Force option hint

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -19,3 +19,6 @@
 ## 2025-06-25 - Differentiating Loading vs Disabled States
 **Learning:** Using the same disabled styling (grayed out) for an active, processing state (e.g., when a button is clicked and waiting for an async operation) makes the UI feel unresponsive and "dead," confusing users about whether the action is actually occurring.
 **Action:** Always visually distinguish a loading state from a purely disabled state. If a button is disabled because it is busy (`[aria-busy="true"]`), maintain the primary visual context (like color) but indicate processing (e.g., cursor: wait, partial opacity). Additionally, add subtle interactive feedback like `transform: scale(0.98)` on active states to improve tactile feel.
+## 2025-06-25 - Progressive Disclosure Scope
+**Learning:** When using progressive disclosure to hide form settings, targeting the immediate `.parentElement` (like `input.parentElement`) leaves behind associated hint text and layout containers (like `.setting-row`) if they are siblings to the label, resulting in orphaned text and messy layout.
+**Action:** Always target the highest logical structural wrapper (e.g., using `.closest('.setting-row')`) when conditionally hiding settings to ensure all related structural and textual elements are hidden together.

--- a/popup.js
+++ b/popup.js
@@ -50,7 +50,7 @@ function updateOpModeUI(value) {
   // Progressive disclosure: hide archive-specific settings
   const isArchive = value === 'archive'
   const settingsSection = document.querySelector('.settings')
-  const forceCheckboxContainer = forceCheckbox.parentElement
+  const forceCheckboxContainer = forceCheckbox.closest('.setting-row')
 
   if (settingsSection) {
     settingsSection.style.display = isArchive ? 'block' : 'none'

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -107,7 +107,8 @@ function setupPopupSandbox() {
   }
 
   // Parent element for elements that use .parentElement in popup.js
-  elements['#force'].parentElement = createMockElement('div')
+  elements['#force'].closest = (sel) => (sel === '.setting-row' ? elements['.setting-row'] : null)
+  elements['.setting-row'] = createMockElement('div')
   elements['#progressFill'].parentElement = createMockElement('div')
 
   const opModeButtons = [
@@ -240,12 +241,12 @@ describe('setActiveOpMode', () => {
     // Archive mode (default or set)
     sandbox.setActiveOpMode('archive')
     assert.strictEqual(elements['.settings'].style.display, 'block')
-    assert.strictEqual(elements['#force'].parentElement.style.display, 'flex')
+    assert.strictEqual(elements['.setting-row'].style.display, 'flex')
 
     // Suggestions mode
     sandbox.setActiveOpMode('suggestions')
     assert.strictEqual(elements['.settings'].style.display, 'none')
-    assert.strictEqual(elements['#force'].parentElement.style.display, 'none')
+    assert.strictEqual(elements['.setting-row'].style.display, 'none')
   })
 })
 


### PR DESCRIPTION
💡 **What:** Modified `popup.js` to hide the entire `.setting-row` container when the "Force" option is hidden due to progressive disclosure, rather than just the immediate parent element of the checkbox.
🎯 **Why:** Previously, when switching away from the "Archive" mode, the "Force" option's descriptive hint text would remain visible (orphaned) on the screen because it was a sibling of the label inside the `.setting-row`, creating visual clutter and confusion.
♿ **Accessibility:** By hiding the entire logical group, screen readers will not inadvertently read orphaned hint text that is no longer relevant to the current operation mode.

---
*PR created automatically by Jules for task [12803640860437594513](https://jules.google.com/task/12803640860437594513) started by @n24q02m*