### PR TITLE
fix: prevent popup/service-worker freeze on large bulk runs

### DIFF
--- a/background.js
+++ b/background.js
@@ -627,29 +627,75 @@ const DEFAULT_STATE = {
   error: null
 }
 
-let state = { ...DEFAULT_STATE }
+// A bulk run can emit thousands of log lines (one per task across several
+// accounts). Cap the retained log so each persisted snapshot and popup render
+// stays bounded — otherwise the array grows without limit and every write
+// re-serializes the whole thing.
+const MAX_LOG_LINES = 2000
 
-const stateReadyPromise = chrome.storage.session.get('archiveState').then((data) => {
-  if (data.archiveState) {
-    state = data.archiveState
-    if (state.status === 'running') {
-      state.status = 'error'
-      state.error = 'Operation interrupted (browser killed service worker)'
-      state.log.push('\n[!] Service worker was terminated during operation.')
-      chrome.storage.session.set({ archiveState: state })
-    }
+let state = { ...DEFAULT_STATE }
+let pendingFlush = null
+
+function trimLog() {
+  if (state.log.length > MAX_LOG_LINES) {
+    state.log.splice(0, state.log.length - MAX_LOG_LINES)
   }
-})
+}
+
+// Persisting on every addLog/updateState writes the whole (growing) state to
+// chrome.storage.session per line — O(n^2) writes over a bulk run, plus an
+// onChanged event (and full popup re-render) each time, which froze both the
+// service worker and the popup. Coalesce rapid updates into one deferred write;
+// flush status transitions immediately so the popup always sees the terminal
+// state without waiting.
+function persistNow() {
+  if (pendingFlush) {
+    clearTimeout(pendingFlush)
+    pendingFlush = null
+  }
+  chrome.storage.session.set({ archiveState: state })
+}
+
+function persistSoon() {
+  if (pendingFlush) return
+  pendingFlush = setTimeout(() => {
+    pendingFlush = null
+    chrome.storage.session.set({ archiveState: state })
+  }, 150)
+}
 
 function updateState(patch) {
   Object.assign(state, patch)
-  chrome.storage.session.set({ archiveState: state })
+  // Status milestones (running/done/error/idle) are user-visible — flush right
+  // away; progress ticks and log spam coalesce into the deferred write.
+  if ('status' in patch) {
+    persistNow()
+  } else {
+    persistSoon()
+  }
 }
 
 function addLog(message) {
   state.log.push(message)
-  updateState({})
+  trimLog()
+  persistSoon()
 }
+
+const stateReadyPromise = chrome.storage.session.get('archiveState').then((data) => {
+  if (data.archiveState) {
+    state = data.archiveState
+    if (!Array.isArray(state.log)) state.log = []
+    // A previous (pre-cap) run may have persisted a huge log that freezes the
+    // popup on open; bound it defensively on load.
+    trimLog()
+    if (state.status === 'running') {
+      state.status = 'error'
+      state.error = 'Operation interrupted (browser killed service worker)'
+      state.log.push('\n[!] Service worker was terminated during operation.')
+      persistNow()
+    }
+  }
+})
 
 // =============================================================================
 // KeepAlive (unchanged from v1)

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -58,6 +58,7 @@ function setupEnvironment(initialStorage = {}) {
     chrome: chromeMock,
     fetch: async () => ({ ok: true, json: async () => [], text: async () => ")]}'\n\n4\n[[]]" }),
     setTimeout,
+    clearTimeout,
     // No-op timer mocks: the real keepAlive interval would otherwise keep the
     // Node event loop alive and hang the test process after all tests pass.
     setInterval: (fn, ms) => {
@@ -962,7 +963,7 @@ describe('state management', () => {
     assert.strictEqual(sessionSetData.length, 1)
   })
 
-  it('should add log messages and persist state', async () => {
+  it('should add log messages and persist state (coalesced)', async () => {
     const { sandbox, sessionSetData } = setupEnvironment({})
     await sandbox.test_stateReadyPromise
     await new Promise((resolve) => setTimeout(resolve, 10))
@@ -970,11 +971,38 @@ describe('state management', () => {
 
     sandbox.test_addLog('Processing task 1')
     const state = sandbox.test_state()
+    // In-memory state updates immediately...
     assert.strictEqual(state.log.length, 1)
     assert.strictEqual(state.log[0], 'Processing task 1')
+    // ...but the storage write is coalesced into a deferred flush.
+    await new Promise((resolve) => setTimeout(resolve, 200))
     assert.strictEqual(sessionSetData.length, 1)
     // Use JSON.stringify to avoid cross-VM reference issues with deepStrictEqual
     assert.strictEqual(JSON.stringify(sessionSetData[0].archiveState.log), JSON.stringify(['Processing task 1']))
+  })
+
+  it('caps the retained log at MAX_LOG_LINES, dropping the oldest lines', () => {
+    const { sandbox } = setupEnvironment({})
+    for (let i = 0; i < 2500; i++) sandbox.test_addLog(`line ${i}`)
+    const log = sandbox.test_state().log
+    assert.strictEqual(log.length, 2000)
+    assert.strictEqual(log[log.length - 1], 'line 2499')
+    assert.strictEqual(log[0], 'line 500') // oldest 500 lines dropped
+  })
+
+  it('coalesces a storm of log writes into a single storage write', async () => {
+    const { sandbox, sessionSetData } = setupEnvironment({})
+    await sandbox.test_stateReadyPromise
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    sessionSetData.length = 0
+
+    for (let i = 0; i < 500; i++) sandbox.test_addLog(`line ${i}`)
+    // No synchronous write-per-line storm (the O(n^2) freeze).
+    assert.strictEqual(sessionSetData.length, 0)
+    await new Promise((resolve) => setTimeout(resolve, 200))
+    // 500 rapid log lines collapse into one deferred flush.
+    assert.strictEqual(sessionSetData.length, 1)
+    assert.strictEqual(sessionSetData[0].archiveState.log.length, 500)
   })
 })
 


### PR DESCRIPTION
## Problem

After #384 made **Force** actually archive the full task list, running it (Dry Run + Force + all accounts) **froze the popup and service worker**. On accounts with hundreds of tasks (725 in testing), `addLog` persisted the entire growing `state` to `chrome.storage.session` on **every log line** — O(n²) writes, each firing an `onChanged` event and a full popup re-render. The oversized persisted state then re-froze the popup on every reopen, even after reinstall (session storage survives within a browser session).

This was a latent bug: before #384 Force archived 0 tasks, so the logging path never ran at scale.

## Fix

- **Coalesce** rapid state writes into a single deferred flush (150 ms). Status transitions (`running`/`done`/`error`) still flush immediately so the popup always sees terminal state without waiting.
- **Cap** the retained log at `MAX_LOG_LINES` (2000) and **trim an oversized log on load**, so a stuck pre-cap state self-recovers when the fixed worker starts.

## Verification

- 181 unit tests pass, including new tests that assert: log caps at 2000 (oldest dropped), and a 500-line write storm collapses into a single coalesced storage write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)