### PR TITLE
fix: discover Suggestions repos from connected sources, not tasks

### DIFF
--- a/background.js
+++ b/background.js
@@ -392,6 +392,16 @@ async function listSuggestions(repo, config) {
   }, [])
 }
 
+// List the account's connected repos (sources) directly, independent of tasks.
+// Response shape (YqkSHd): result[0] is an array of source entries whose [0]
+// is the "github/owner/repo" id. Deriving repos from tasks instead meant that
+// archiving every task hid all repos from Suggestions.
+async function listSources(config) {
+  const result = await callBatchExecute('YqkSHd', [null, 'source_status=SOURCE_STATUS_ACTIVE'], config)
+  if (!result?.[0]) return []
+  return result[0].map((s) => s?.[0]).filter((src) => typeof src === 'string' && src.startsWith('github/'))
+}
+
 // =============================================================================
 // Prompt Builder
 // =============================================================================
@@ -553,27 +563,23 @@ async function processSuggestionsForTab(tab, options) {
     addLog(`[${label}] Tip: Click Start on any suggestion in Jules UI to capture config.`)
   }
 
-  // Get repos from existing tasks
-  addLog(`[${label}] Fetching task list to discover repos...`)
-  let tasks
+  // Discover connected repos directly (independent of tasks). Deriving repos
+  // from active tasks meant archiving all tasks hid every repo from Suggestions.
+  addLog(`[${label}] Fetching connected repos...`)
+  let repos
   try {
-    tasks = await listTasks('', config)
+    repos = await listSources(config)
   } catch (e) {
-    addLog(`[${label}] ERROR listing tasks: ${e.message}`)
+    addLog(`[${label}] ERROR listing sources: ${e.message}`)
     return 0
   }
 
-  const repoSet = new Set()
-  for (const t of tasks) {
-    if (t.source) repoSet.add(t.source)
-  }
-  const repos = [...repoSet]
   if (repos.length === 0) {
-    addLog(`[${label}] No repos found from tasks.`)
+    addLog(`[${label}] No connected repos found.`)
     return 0
   }
 
-  addLog(`[${label}] Found ${repos.length} repos: ${repos.join(', ')}`)
+  addLog(`[${label}] Found ${repos.length} connected repos`)
 
   addLog(`\n[${label}] Fetching suggestions for ${repos.length} repos concurrently...`)
   const allSuggestions = await runInPool(repos, PER_ACCOUNT_CONCURRENCY, (repo) =>

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -138,6 +138,7 @@ function setupEnvironment(initialStorage = {}) {
     globalThis.test_stopKeepAlive = stopKeepAlive;
     globalThis.test_getKeepAliveInterval = () => keepAliveInterval;
     globalThis.test_listSuggestions = listSuggestions;
+    globalThis.test_listSources = listSources;
     globalThis.test_ensureContentScript = ensureContentScript;
     globalThis.test_getTabConfig = getTabConfig;
   `
@@ -295,6 +296,29 @@ describe('runInPool', () => {
     const { sandbox } = setupEnvironment()
     const results = await sandbox.test_runInPool(['a', 'b', 'c'], 2, async (item, idx) => `${item}${idx}`)
     assert.deepStrictEqual(results, ['a0', 'b1', 'c2'])
+  })
+})
+
+describe('listSources', () => {
+  it('extracts github sources from a YqkSHd response (independent of tasks)', async () => {
+    const { sandbox } = setupEnvironment()
+    sandbox.callBatchExecute = async () => [
+      [
+        ['github/n24q02m/.github', [[false, '.github', 'n24q02m']], [1], [1], 1],
+        ['github/n24q02m/Aiora', [[true, 'Aiora', 'n24q02m']], [1], [1], 1],
+        ['not-a-github-source', [[]], [1], [1], 1],
+        [null, [[]], [1], [1], 1]
+      ]
+    ]
+    const repos = await sandbox.test_listSources({})
+    assert.deepStrictEqual(repos, ['github/n24q02m/.github', 'github/n24q02m/Aiora'])
+  })
+
+  it('returns [] when the response has no sources', async () => {
+    const { sandbox } = setupEnvironment()
+    sandbox.callBatchExecute = async () => null
+    // JSON.stringify avoids cross-VM Array realm mismatch in deepStrictEqual.
+    assert.strictEqual(JSON.stringify(await sandbox.test_listSources({})), '[]')
   })
 })
 

--- a/tests/perf.test.js
+++ b/tests/perf.test.js
@@ -78,11 +78,12 @@ describe('Orchestrator Performance Optimization', () => {
       }
     })
 
-    // Mock dependencies
-    let listTasksCalled = 0
-    sandbox.listTasks = async () => {
-      listTasksCalled++
-      return [{ source: 'github/owner/repo1' }, { source: 'github/owner/repo2' }]
+    // Mock dependencies. Repos are now discovered via listSources (connected
+    // repos), independent of tasks.
+    let listSourcesCalled = 0
+    sandbox.listSources = async () => {
+      listSourcesCalled++
+      return ['github/owner/repo1', 'github/owner/repo2']
     }
 
     let listSuggestionsCount = 0
@@ -109,7 +110,7 @@ describe('Orchestrator Performance Optimization', () => {
 
     await sandbox.processSuggestionsForTab(tab, options)
 
-    assert.strictEqual(listTasksCalled, 1, 'listTasks should be called once')
+    assert.strictEqual(listSourcesCalled, 1, 'listSources should be called once')
     assert.strictEqual(listSuggestionsCount, 2, 'listSuggestions should be called for each repo')
     assert.strictEqual(
       startSuggestionCount,


### PR DESCRIPTION
## Problem

Start Suggestions discovered its repo list from **active tasks** (`listTasks` -> `source`). So after archiving every task, an account had no tasks -> no repos discovered -> Suggestions did nothing, even though the repos were still connected to Jules. Archiving tasks should have nothing to do with which repos can receive suggestions.

**Verified against the live API** (via CDP on the logged-in browser): account `u/1`, which showed `No repos found from tasks`, still has **73 connected repos**.

## Fix

Discover repos via the `YqkSHd` "list sources" RPC with payload `[null, "source_status=SOURCE_STATUS_ACTIVE"]`. Its `result[0][i][0]` is the `github/owner/repo` id, returned independent of tasks. `processSuggestionsForTab` now calls `listSources(config)` instead of deriving repos from `listTasks`.

## Verification

- 187 unit tests pass (new `listSources` parse tests; `processSuggestionsForTab` perf test updated to the sources-based discovery).
- Live: `listSources` returns 73 repos for both an account with tasks (u/2) and one with none (u/1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)