### PR TITLE
[TEST] Missing tests for archiveTask function

### DIFF
--- a/background.js
+++ b/background.js
@@ -305,7 +305,7 @@ async function listTasks(filter, config) {
 }
 
 async function archiveTask(taskId, config) {
-  await callBatchExecute('Tjmm5c', [[taskId], 1], config)
+  return callBatchExecute('A0Q2Z', [[[taskId, 3]]], config)
 }
 
 const RETRY_ATTEMPTS = 4

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -133,6 +133,7 @@ function setupEnvironment(initialStorage = {}) {
     globalThis.test_finalizeOperation = finalizeOperation;
     globalThis.test_handleOperationError = handleOperationError;
     globalThis.test_listTasks = listTasks;
+    globalThis.test_archiveTask = archiveTask;
     globalThis.test_startOperation = startOperation;
     globalThis.test_startKeepAlive = startKeepAlive;
     globalThis.test_stopKeepAlive = stopKeepAlive;
@@ -340,6 +341,40 @@ describe('createLimiter', () => {
     const results = await Promise.all([1, 2, 3, 4, 5].map((n) => limit(make(n))))
     assert.deepStrictEqual(results, [2, 4, 6, 8, 10])
     assert.ok(peak <= 2, `peak ${peak} should not exceed limiter max 2`)
+  })
+})
+
+describe('archiveTask', () => {
+  it('should call callBatchExecute with RPC ID A0Q2Z and correct payload', async () => {
+    const { sandbox } = setupEnvironment()
+    let capturedRpcId = null
+    let capturedPayload = null
+
+    sandbox.callBatchExecute = async (rpcId, payload, _config) => {
+      capturedRpcId = rpcId
+      capturedPayload = payload
+      return {}
+    }
+
+    const taskId = 'task-123'
+    const config = { accountNum: '0' }
+    await sandbox.test_archiveTask(taskId, config)
+
+    assert.strictEqual(capturedRpcId, 'A0Q2Z')
+    assert.strictEqual(JSON.stringify(capturedPayload), JSON.stringify([[[taskId, 3]]]))
+  })
+
+  it('should propagate errors from callBatchExecute', async () => {
+    const { sandbox } = setupEnvironment()
+    sandbox.callBatchExecute = async () => {
+      throw new Error('RPC Failed')
+    }
+
+    const taskId = 'task-123'
+    const config = { accountNum: '0' }
+    await assert.rejects(sandbox.test_archiveTask(taskId, config), {
+      message: 'RPC Failed'
+    })
   })
 })
 


### PR DESCRIPTION
This PR addresses the missing unit tests for the `archiveTask` function in `background.js`. It also updates the implementation of `archiveTask` to match the intended RPC ID and payload structure as specified in the task description.

### Changes
- **background.js**: Updated `archiveTask` to use RPC ID `'A0Q2Z'` and the triple-nested payload structure `[[[taskId, 3]]]`.
- **tests/background.test.js**: 
    - Exported `archiveTask` to the test sandbox.
    - Added a new `describe('archiveTask', ...)` block with tests for successful RPC execution and error propagation.
    - Ensured robust assertion for the nested payload structure by using string comparison (JSON.stringify) to avoid cross-context reference issues in the `node:vm` sandbox.

### Verification
- Ran `pnpm test` and verified that all 189 tests pass (including the 2 new tests).
- Ran `npx @biomejs/biome check .` and verified that there are no linting or formatting issues.

---
*PR created automatically by Jules for task [6560607282474305502](https://jules.google.com/task/6560607282474305502) started by @n24q02m*