### PR TITLE
fix: respect per-repo Suggestions toggle and daily session limit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ popup.js (UI) <-> background.js (batchexecute client) <-> content.js (token extr
 
 Two operation modes:
 1. **Archive Tasks** -- ListTasks (p1Takd) -> check GitHub PRs -> ArchiveTask (Tjmm5c)
-2. **Start Suggestions** -- ListTasks -> discover repos -> ListSuggestions (hQP40d) -> StartSuggestion (Rja83d)
+2. **Start Suggestions** -- ListSources (YqkSHd) filtered to Suggestions-enabled repos -> ListSuggestions (hQP40d) per repo -> cap to remaining daily quota (KQOO7) -> StartSuggestion (Rja83d). Only repos whose per-repo Suggestions toggle is ON are touched; the daily session limit is never exceeded.
 
 Content script extracts auth tokens (SNlM0e, cfb2h, FdrFJe) from `WIZ_global_data` via MAIN world script injection. Also observes fetch() for Rja83d calls to capture model config and experiment IDs.
 
@@ -35,8 +35,13 @@ Background service worker makes all API calls. No DOM automation.
 
 - `p1Takd` -- ListTasks (filter, state)
 - `Tjmm5c` -- ArchiveTask (taskId, action)
-- `hQP40d` -- ListSuggestions (repo)
+- `tqq5v` -- PauseTask / stop a running session (taskId)
+- `YqkSHd` -- ListSources (connected repos); row `[5][2][0] === 2` => Suggestions toggle ON
+- `hQP40d` -- ListSuggestions (repo); returns the raw pool, does NOT respect the toggle
+- `e4motb` -- SetSuggestionsToggle (repo, [2]=enable / [1]=disable)
 - `Rja83d` -- StartSuggestion (prompt, model config, repo, experiment IDs)
+- `UTrvy` -- Suggestions-repo counter `[max, enabled, free]` (e.g. `[5,3,2]` = 3/5 repos enabled)
+- `KQOO7` -- Daily session quota `[usedToday, [windowSeconds], dailyLimit, ...]`
 
 ## Development
 

--- a/background.js
+++ b/background.js
@@ -277,6 +277,25 @@ const TASK = {
 // is protected by default rather than silently archived.
 const ARCHIVABLE_STATES = new Set([2, 4, 12])
 
+// Source (connected repo) row layout from YqkSHd.
+// [5] is a per-repo Suggestions block: [bool, bool, [TOGGLE], [bool]] where
+// TOGGLE === 2 means the repo's Suggestions toggle is ON, 1/absent means OFF.
+// This mirrors the e4motb write RPC (payload [2]=enable, [1]=disable) and was
+// verified 2026-06-04 against Jules' own "X / 5 repo max" counter (UTrvy) across
+// all 5 accounts: the enabled-repo count matched UTrvy exactly every time.
+const SOURCE = {
+  ID: 0,
+  SUGGESTION_BLOCK: 5
+}
+const SUGGESTION_TOGGLE_ON = 2
+
+// A Jules account may enable Suggestions on at most 5 repos. The extension must
+// only start suggestions on those, never on every connected source.
+function isSuggestionEnabled(row) {
+  const block = row?.[SOURCE.SUGGESTION_BLOCK]
+  return Array.isArray(block) && Array.isArray(block[2]) && block[2][0] === SUGGESTION_TOGGLE_ON
+}
+
 function parseTask(raw) {
   const source = raw[TASK.SOURCE] || ''
   const parts = source.split('/')
@@ -392,14 +411,30 @@ async function listSuggestions(repo, config) {
   }, [])
 }
 
-// List the account's connected repos (sources) directly, independent of tasks.
-// Response shape (YqkSHd): result[0] is an array of source entries whose [0]
-// is the "github/owner/repo" id. Deriving repos from tasks instead meant that
-// archiving every task hid all repos from Suggestions.
-async function listSources(config) {
+// List the repos that have the Jules Suggestions toggle ENABLED for this account.
+// Response shape (YqkSHd): result[0] is an array of source rows whose [0] is the
+// "github/owner/repo" id and whose [5] block encodes the per-repo toggle.
+// Returning every connected source (not just enabled ones) is what caused the
+// extension to start hundreds of unwanted suggestion tasks across all repos.
+async function listSuggestionEnabledSources(config) {
   const result = await callBatchExecute('YqkSHd', [null, 'source_status=SOURCE_STATUS_ACTIVE'], config)
   if (!result?.[0]) return []
-  return result[0].map((s) => s?.[0]).filter((src) => typeof src === 'string' && src.startsWith('github/'))
+  return result[0]
+    .filter(
+      (row) => isSuggestionEnabled(row) && typeof row?.[SOURCE.ID] === 'string' && row[SOURCE.ID].startsWith('github/')
+    )
+    .map((row) => row[SOURCE.ID])
+}
+
+// Jules caps suggestion sessions per account per day. KQOO7 returns
+// [usedToday, [windowSeconds], dailyLimit, ...]; the extension must not start
+// more sessions than the remaining quota, or it blows past the limit (observed
+// 268/100). Returns null if the shape is unrecognised so callers can no-op the
+// guard rather than block the run.
+async function getDailySessionQuota(config) {
+  const result = await callBatchExecute('KQOO7', [], config)
+  if (!Array.isArray(result) || typeof result[0] !== 'number' || typeof result[2] !== 'number') return null
+  return { used: result[0], limit: result[2], remaining: Math.max(0, result[2] - result[0]) }
 }
 
 // =============================================================================
@@ -563,23 +598,26 @@ async function processSuggestionsForTab(tab, options) {
     addLog(`[${label}] Tip: Click Start on any suggestion in Jules UI to capture config.`)
   }
 
-  // Discover connected repos directly (independent of tasks). Deriving repos
-  // from active tasks meant archiving all tasks hid every repo from Suggestions.
-  addLog(`[${label}] Fetching connected repos...`)
+  // Only repos whose Jules Suggestions toggle is ON. Enumerating every connected
+  // source instead caused the extension to start suggestions on repos the user
+  // never enabled (and blow past the daily session limit).
+  addLog(`[${label}] Fetching Suggestions-enabled repos...`)
   let repos
   try {
-    repos = await listSources(config)
+    repos = await listSuggestionEnabledSources(config)
   } catch (e) {
     addLog(`[${label}] ERROR listing sources: ${e.message}`)
     return 0
   }
 
   if (repos.length === 0) {
-    addLog(`[${label}] No connected repos found.`)
+    addLog(`[${label}] No repos have Suggestions enabled. Nothing to do.`)
     return 0
   }
 
-  addLog(`[${label}] Found ${repos.length} connected repos`)
+  addLog(
+    `[${label}] ${repos.length} repo(s) with Suggestions enabled: ${repos.map((r) => r.replace(/^github\//, '')).join(', ')}`
+  )
 
   addLog(`\n[${label}] Fetching suggestions for ${repos.length} repos concurrently...`)
   const allSuggestions = await runInPool(repos, PER_ACCOUNT_CONCURRENCY, (repo) =>
@@ -609,13 +647,29 @@ async function processSuggestionsForTab(tab, options) {
     return 0
   }
 
+  // Respect Jules' daily session limit: never start more suggestions than the
+  // account's remaining quota. Each started suggestion consumes one session.
+  let toStart = work
+  const quota = await getDailySessionQuota(config)
+  if (quota) {
+    addLog(`\n[${label}] Daily sessions: ${quota.used}/${quota.limit} used, ${quota.remaining} remaining`)
+    if (quota.remaining === 0) {
+      addLog(`[${label}] Daily limit reached. Starting 0 suggestions.`)
+      return 0
+    }
+    if (work.length > quota.remaining) {
+      addLog(`[${label}] Capping ${work.length} suggestions to ${quota.remaining} (daily limit)`)
+      toStart = work.slice(0, quota.remaining)
+    }
+  }
+
   if (!options.dryRun) {
-    state.progress.total += work.length
+    state.progress.total += toStart.length
     updateState({})
   }
 
   let totalStarted = 0
-  await runInPool(work, PER_ACCOUNT_CONCURRENCY, async ({ repo, s }) => {
+  await runInPool(toStart, PER_ACCOUNT_CONCURRENCY, async ({ repo, s }) => {
     if (state.status === 'cancelled') return
 
     if (options.dryRun) {

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -138,7 +138,9 @@ function setupEnvironment(initialStorage = {}) {
     globalThis.test_stopKeepAlive = stopKeepAlive;
     globalThis.test_getKeepAliveInterval = () => keepAliveInterval;
     globalThis.test_listSuggestions = listSuggestions;
-    globalThis.test_listSources = listSources;
+    globalThis.test_listSuggestionEnabledSources = listSuggestionEnabledSources;
+    globalThis.test_isSuggestionEnabled = isSuggestionEnabled;
+    globalThis.test_getDailySessionQuota = getDailySessionQuota;
     globalThis.test_ensureContentScript = ensureContentScript;
     globalThis.test_getTabConfig = getTabConfig;
   `
@@ -299,26 +301,69 @@ describe('runInPool', () => {
   })
 })
 
-describe('listSources', () => {
-  it('extracts github sources from a YqkSHd response (independent of tasks)', async () => {
+describe('isSuggestionEnabled', () => {
+  it('treats toggle value 2 as enabled', () => {
+    const { sandbox } = setupEnvironment()
+    assert.strictEqual(sandbox.test_isSuggestionEnabled(['id', [[]], [1], [1], 1, [true, true, [2], [true]]]), true)
+  })
+
+  it('treats toggle value 1, null block, or missing block as disabled', () => {
+    const { sandbox } = setupEnvironment()
+    assert.strictEqual(sandbox.test_isSuggestionEnabled(['id', [[]], [1], [1], 1, [true, true, [1], [true]]]), false)
+    assert.strictEqual(sandbox.test_isSuggestionEnabled(['id', [[]], [1], [1], 1, [null, null, [1]]]), false)
+    assert.strictEqual(sandbox.test_isSuggestionEnabled(['id', [[]], [1], [1], 1]), false)
+  })
+})
+
+describe('listSuggestionEnabledSources', () => {
+  it('returns only github repos whose Suggestions toggle is ON', async () => {
     const { sandbox } = setupEnvironment()
     sandbox.callBatchExecute = async () => [
       [
-        ['github/n24q02m/.github', [[false, '.github', 'n24q02m']], [1], [1], 1],
-        ['github/n24q02m/Aiora', [[true, 'Aiora', 'n24q02m']], [1], [1], 1],
-        ['not-a-github-source', [[]], [1], [1], 1],
-        [null, [[]], [1], [1], 1]
+        ['github/n24q02m/on-a', [[true, 'on-a', 'n24q02m']], [1], [1], 1, [true, true, [2], [true]]],
+        ['github/n24q02m/off-toggle', [[true, 'off-toggle', 'n24q02m']], [1], [1], 1, [true, true, [1], [true]]],
+        ['github/n24q02m/off-noblock', [[true, 'off-noblock', 'n24q02m']], [1], [1], 1],
+        ['github/n24q02m/on-b', [[true, 'on-b', 'n24q02m']], [1], [1], 1, [true, true, [2], [true]]],
+        ['not-a-github-source', [[]], [1], [1], 1, [true, true, [2], [true]]],
+        [null, [[]], [1], [1], 1, [true, true, [2], [true]]]
       ]
     ]
-    const repos = await sandbox.test_listSources({})
-    assert.deepStrictEqual(repos, ['github/n24q02m/.github', 'github/n24q02m/Aiora'])
+    const repos = await sandbox.test_listSuggestionEnabledSources({})
+    assert.deepStrictEqual(repos, ['github/n24q02m/on-a', 'github/n24q02m/on-b'])
   })
 
   it('returns [] when the response has no sources', async () => {
     const { sandbox } = setupEnvironment()
     sandbox.callBatchExecute = async () => null
     // JSON.stringify avoids cross-VM Array realm mismatch in deepStrictEqual.
-    assert.strictEqual(JSON.stringify(await sandbox.test_listSources({})), '[]')
+    assert.strictEqual(JSON.stringify(await sandbox.test_listSuggestionEnabledSources({})), '[]')
+  })
+})
+
+describe('getDailySessionQuota', () => {
+  it('parses KQOO7 into used/limit/remaining', async () => {
+    const { sandbox } = setupEnvironment()
+    sandbox.callBatchExecute = async () => [13, [86400], 100, 1, 2]
+    // JSON.stringify avoids cross-VM realm mismatch in deepStrictEqual.
+    assert.strictEqual(
+      JSON.stringify(await sandbox.test_getDailySessionQuota({})),
+      JSON.stringify({ used: 13, limit: 100, remaining: 87 })
+    )
+  })
+
+  it('clamps remaining at 0 when over the limit', async () => {
+    const { sandbox } = setupEnvironment()
+    sandbox.callBatchExecute = async () => [268, [86400], 100]
+    assert.strictEqual(
+      JSON.stringify(await sandbox.test_getDailySessionQuota({})),
+      JSON.stringify({ used: 268, limit: 100, remaining: 0 })
+    )
+  })
+
+  it('returns null for an unrecognised shape', async () => {
+    const { sandbox } = setupEnvironment()
+    sandbox.callBatchExecute = async () => null
+    assert.strictEqual(await sandbox.test_getDailySessionQuota({}), null)
   })
 })
 

--- a/tests/perf.test.js
+++ b/tests/perf.test.js
@@ -78,13 +78,16 @@ describe('Orchestrator Performance Optimization', () => {
       }
     })
 
-    // Mock dependencies. Repos are now discovered via listSources (connected
-    // repos), independent of tasks.
+    // Mock dependencies. Repos are now discovered via listSuggestionEnabledSources
+    // (only repos whose Suggestions toggle is ON).
     let listSourcesCalled = 0
-    sandbox.listSources = async () => {
+    sandbox.listSuggestionEnabledSources = async () => {
       listSourcesCalled++
       return ['github/owner/repo1', 'github/owner/repo2']
     }
+
+    // No daily-limit cap for this pool-saturation test.
+    sandbox.getDailySessionQuota = async () => null
 
     let listSuggestionsCount = 0
     sandbox.listSuggestions = async (_repo) => {
@@ -110,7 +113,7 @@ describe('Orchestrator Performance Optimization', () => {
 
     await sandbox.processSuggestionsForTab(tab, options)
 
-    assert.strictEqual(listSourcesCalled, 1, 'listSources should be called once')
+    assert.strictEqual(listSourcesCalled, 1, 'listSuggestionEnabledSources should be called once')
     assert.strictEqual(listSuggestionsCount, 2, 'listSuggestions should be called for each repo')
     assert.strictEqual(
       startSuggestionCount,


### PR DESCRIPTION
## Vấn đề
Start Suggestions liệt kê **mọi** connected source (YqkSHd) và start **mọi** suggestion trên từng repo, bỏ qua toggle Suggestions per-repo và daily session limit. Kết quả: ~684 task ngoài ý muốn trên các repo chưa bật suggestion, vượt cap 100/ngày (quan sát 268/100).

## Sửa
- `listSources` -> `listSuggestionEnabledSources`: chỉ giữ repo có toggle BẬT (source row `[5][2][0] === 2`, verify khớp counter `UTrvy` "X/5" trên cả 5 account).
- Thêm `getDailySessionQuota` (`KQOO7`) + cap số suggestion start theo quota còn lại; hết quota -> start 0.
- Document RPC `YqkSHd`/`e4motb`/`tqq5v`/`UTrvy`/`KQOO7`.

## Test
- 192/192 unit tests pass; `biome lint` clean.
- Detector verify live vs UTrvy + UI screenshots trên 5 account: match 100%.

Đi kèm commit trước (`20942da`) chuyển discovery từ tasks sang sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)