### PR TITLE
🎨 Palette: Hide orphaned form hints during progressive disclosure

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -19,3 +19,6 @@
 ## 2025-06-25 - Differentiating Loading vs Disabled States
 **Learning:** Using the same disabled styling (grayed out) for an active, processing state (e.g., when a button is clicked and waiting for an async operation) makes the UI feel unresponsive and "dead," confusing users about whether the action is actually occurring.
 **Action:** Always visually distinguish a loading state from a purely disabled state. If a button is disabled because it is busy (`[aria-busy="true"]`), maintain the primary visual context (like color) but indicate processing (e.g., cursor: wait, partial opacity). Additionally, add subtle interactive feedback like `transform: scale(0.98)` on active states to improve tactile feel.
+## 2025-07-28 - Progressive Disclosure for Form Inputs
+**Learning:** When using progressive disclosure to hide form inputs (like checkboxes), targeting just the input or its immediate parent can leave sibling elements, such as descriptive hint texts, orphaned and visible on the screen.
+**Action:** Always target the highest logical wrapper element (like `.closest('.setting-row')`) when hiding inputs to ensure the entire input group, including its label and hints, is hidden or shown together.

--- a/popup.js
+++ b/popup.js
@@ -50,13 +50,13 @@ function updateOpModeUI(value) {
   // Progressive disclosure: hide archive-specific settings
   const isArchive = value === 'archive'
   const settingsSection = document.querySelector('.settings')
-  const forceCheckboxContainer = forceCheckbox.parentElement
+  const forceCheckboxContainer = forceCheckbox.closest('.setting-row')
 
   if (settingsSection) {
     settingsSection.style.display = isArchive ? 'block' : 'none'
   }
   if (forceCheckboxContainer) {
-    forceCheckboxContainer.style.display = isArchive ? 'flex' : 'none'
+    forceCheckboxContainer.style.display = isArchive ? 'block' : 'none'
   }
 
   // Context-aware start button text

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -110,6 +110,8 @@ function setupPopupSandbox() {
   elements['#force'].parentElement = createMockElement('div')
   elements['#progressFill'].parentElement = createMockElement('div')
 
+  elements['#force'].closest = (sel) => sel === '.setting-row' ? elements['#force'].parentElement : null
+
   const opModeButtons = [
     createMockElement('button', { dataset: { value: 'archive' } }),
     createMockElement('button', { dataset: { value: 'suggestions' } })
@@ -240,12 +242,12 @@ describe('setActiveOpMode', () => {
     // Archive mode (default or set)
     sandbox.setActiveOpMode('archive')
     assert.strictEqual(elements['.settings'].style.display, 'block')
-    assert.strictEqual(elements['#force'].parentElement.style.display, 'flex')
+    assert.strictEqual(elements['#force'].closest('.setting-row').style.display, 'block')
 
     // Suggestions mode
     sandbox.setActiveOpMode('suggestions')
     assert.strictEqual(elements['.settings'].style.display, 'none')
-    assert.strictEqual(elements['#force'].parentElement.style.display, 'none')
+    assert.strictEqual(elements['#force'].closest('.setting-row').style.display, 'none')
   })
 })
 

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -110,7 +110,7 @@ function setupPopupSandbox() {
   elements['#force'].parentElement = createMockElement('div')
   elements['#progressFill'].parentElement = createMockElement('div')
 
-  elements['#force'].closest = (sel) => sel === '.setting-row' ? elements['#force'].parentElement : null
+  elements['#force'].closest = (sel) => (sel === '.setting-row' ? elements['#force'].parentElement : null)
 
   const opModeButtons = [
     createMockElement('button', { dataset: { value: 'archive' } }),


### PR DESCRIPTION
💡 **What:** Modified `popup.js` to target `.closest('.setting-row')` instead of `.parentElement` when toggling the display of the `force` checkbox. Also updated its layout to `block` instead of `flex` when visible to properly align the input and its associated hint text.
🎯 **Why:** Previously, in multi-mode environments (Archive vs Suggestions), progressive disclosure logic only hid the direct parent of the `force` input. This left sibling descriptive text elements orphaned and visible in the UI when they shouldn't be, causing visual clutter.
📸 **Before/After:** The 'Start Suggestions' tab no longer incorrectly displays the 'Archive every task, ignoring state...' hint text floating below the 'Execution Mode' options.
♿ **Accessibility:** This ensures the UI accurately reflects what state the user is configuring, preventing confusion for sighted and screen reader users alike.

---
*PR created automatically by Jules for task [14859806473632766738](https://jules.google.com/task/14859806473632766738) started by @n24q02m*