### PR TITLE
🎨 Palette: Fix layout shift and logical flow of Operation mode

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -19,3 +19,6 @@
 ## 2025-06-25 - Differentiating Loading vs Disabled States
 **Learning:** Using the same disabled styling (grayed out) for an active, processing state (e.g., when a button is clicked and waiting for an async operation) makes the UI feel unresponsive and "dead," confusing users about whether the action is actually occurring.
 **Action:** Always visually distinguish a loading state from a purely disabled state. If a button is disabled because it is busy (`[aria-busy="true"]`), maintain the primary visual context (like color) but indicate processing (e.g., cursor: wait, partial opacity). Additionally, add subtle interactive feedback like `transform: scale(0.98)` on active states to improve tactile feel.
+## 2025-07-15 - Directional Progressive Disclosure
+**Learning:** When using progressive disclosure to hide/show UI sections based on a toggle state, the controlled sections must always be placed *below* the controlling toggle. If sections above the toggle are hidden, it causes a jarring layout shift that yanks the toggle out from under the user's cursor/finger, breaking visual continuity.
+**Action:** Always structure multi-mode UIs top-to-bottom: primary mode selectors first, followed by the context-specific settings they control.

--- a/popup.html
+++ b/popup.html
@@ -11,6 +11,16 @@
       <span class="version">v2.0</span>
     </header>
 
+    <section class="operation-mode">
+      <div class="setting-row">
+        <label id="opModeLabel">Operation</label>
+        <div class="segmented" id="opMode" role="group" aria-labelledby="opModeLabel">
+          <button type="button" data-value="archive" class="active" aria-pressed="true">Archive Tasks</button>
+          <button type="button" data-value="suggestions" aria-pressed="false">Start Suggestions</button>
+        </div>
+      </div>
+    </section>
+
     <section class="settings">
       <h2>Settings</h2>
       <label for="ghOwner">
@@ -32,13 +42,6 @@
 
     <section class="options">
       <h2>Options</h2>
-      <div class="setting-row">
-        <label id="opModeLabel">Operation</label>
-        <div class="segmented" id="opMode" role="group" aria-labelledby="opModeLabel">
-          <button type="button" data-value="archive" class="active" aria-pressed="true">Archive Tasks</button>
-          <button type="button" data-value="suggestions" aria-pressed="false">Start Suggestions</button>
-        </div>
-      </div>
       <div class="setting-row">
         <label id="execModeLabel">Execution Mode</label>
         <div class="radio-group" role="radiogroup" aria-labelledby="execModeLabel">


### PR DESCRIPTION
💡 What: Moved the Operation mode selector to the top of the UI, above the Settings section.
🎯 Why: Previously, changing the operation mode would hide the Settings section located *above* it, causing the clicked control to suddenly jump up the screen. Placing the primary mode selector at the top prevents this jarring layout shift and establishes a better top-to-bottom logical flow (since Operation mode dictates which settings are needed).
♿ Accessibility: Improves visual stability for screen magnifiers and keyboard focus retention.

---
*PR created automatically by Jules for task [1112216849919060642](https://jules.google.com/task/1112216849919060642) started by @n24q02m*