### PR TITLE
[TEST] Missing edge case tests for runInPool

### DIFF
--- a/background.js
+++ b/background.js
@@ -82,7 +82,7 @@ async function runInPool(items, limit, worker) {
     }
   }
 
-  const poolSize = Math.min(limit, items.length)
+  const poolSize = Math.min(Math.max(1, limit), items.length)
   const pool = []
   for (let i = 0; i < poolSize; i++) {
     pool.push(drain())

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -299,6 +299,28 @@ describe('runInPool', () => {
     const results = await sandbox.test_runInPool(['a', 'b', 'c'], 2, async (item, idx) => `${item}${idx}`)
     assert.deepStrictEqual(results, ['a0', 'b1', 'c2'])
   })
+
+  it('should treat a limit of 0 as 1', async () => {
+    const { sandbox } = setupEnvironment()
+    const results = await sandbox.test_runInPool([1, 2, 3], 0, async (n) => n * 10)
+    assert.deepStrictEqual(results, [10, 20, 30])
+  })
+
+  it('should handle a limit of 1 (sequential)', async () => {
+    const { sandbox } = setupEnvironment()
+    let inFlight = 0
+    let peak = 0
+    const worker = async (n) => {
+      inFlight++
+      peak = Math.max(peak, inFlight)
+      await new Promise((r) => setTimeout(r, 5))
+      inFlight--
+      return n * 10
+    }
+    const results = await sandbox.test_runInPool([1, 2, 3], 1, worker)
+    assert.strictEqual(peak, 1)
+    assert.deepStrictEqual(results, [10, 20, 30])
+  })
 })
 
 describe('isSuggestionEnabled', () => {


### PR DESCRIPTION
- Fix `runInPool` to handle non-positive concurrency limits by ensuring a minimum pool size of 1. This prevents the function from returning uninitialized results without executing tasks when a limit of 0 or less is provided.
- Added edge case tests in `tests/background.test.js` to verify behavior with `limit = 0` and `limit = 1`.
- Verified the fix with a reproduction script and by running the full test suite.

---
*PR created automatically by Jules for task [4077465983777551935](https://jules.google.com/task/4077465983777551935) started by @n24q02m*