### PR TITLE
⚡ Bolt: Process tabs concurrently

### DIFF
--- a/background.js
+++ b/background.js
@@ -1135,18 +1135,16 @@ async function discoverTabs(options) {
 async function processAllTabs(tabs, options, isSuggestions) {
   // Process accounts in parallel. Per-account pools and the shared global
   // limiter keep total in-flight requests bounded; results preserve tab order.
-  return Promise.all(
-    tabs.map(async (tab) => {
-      const label = getTabLabel(tab)
-      try {
-        const count = isSuggestions ? await processSuggestionsForTab(tab, options) : await processTab(tab, options)
-        return { label, count }
-      } catch (e) {
-        addLog(`ERROR [${label}]: ${e.message}`)
-        return { label, count: 0, err: e.message }
-      }
-    })
-  )
+  return runInPool(tabs, API_CONCURRENCY, async (tab) => {
+    const label = getTabLabel(tab)
+    try {
+      const count = isSuggestions ? await processSuggestionsForTab(tab, options) : await processTab(tab, options)
+      return { label, count }
+    } catch (e) {
+      addLog(`ERROR [${label}]: ${e.message}`)
+      return { label, count: 0, err: e.message }
+    }
+  })
 }
 
 function finalizeOperation(results, isSuggestions) {


### PR DESCRIPTION
Updated \`processAllTabs\` in \`background.js\` to use \`runInPool\` with \`API_CONCURRENCY\` instead of \`Promise.all\`. 

### 💡 What
Replaced the unbounded \`Promise.all(tabs.map(...))\` pattern with a bounded concurrency pool using the existing \`runInPool\` utility.

### 🎯 Why
When a user has many Jules tabs open (e.g., across multiple Google accounts), processing them all simultaneously can lead to resource exhaustion, browser throttling, or hitting API rate limits too quickly. Bounding the concurrency to \`API_CONCURRENCY\` (5) ensures a steady, reliable throughput.

### 📊 Impact
Improved reliability and predictability of the "Archive All" and "Start Suggestions" operations when dealing with many accounts.

### 🔬 Measurement
Verified that the logic correctly limits active workers to \`API_CONCURRENCY\` using a targeted unit test.

---
*PR created automatically by Jules for task [15702637326983534692](https://jules.google.com/task/15702637326983534692) started by @n24q02m*