### PR TITLE
[FIX] Duplicate Map Grouping Logic

### DIFF
--- a/background.js
+++ b/background.js
@@ -315,6 +315,15 @@ function isArchivable(task) {
   // A null/undefined state is emitted for one class of completed tasks.
   return task.state == null || ARCHIVABLE_STATES.has(task.state)
 }
+function groupTasksByRepo(tasks) {
+  const map = new Map()
+  for (const t of tasks) {
+    const key = t.repo || '(no repo)'
+    if (!map.has(key)) map.set(key, [])
+    map.get(key).push(t)
+  }
+  return map
+}
 
 async function listTasks(filter, config) {
   const payload = [filter, 4]
@@ -998,12 +1007,7 @@ async function processTab(tab, options) {
     }
 
     // Group candidates by repo for per-repo open-PR lookups.
-    const byRepo = new Map()
-    for (const task of candidates) {
-      const key = task.repo || '(no repo)'
-      if (!byRepo.has(key)) byRepo.set(key, [])
-      byRepo.get(key).push(task)
-    }
+    const byRepo = groupTasksByRepo(candidates)
 
     addLog(`\n[${label}] Checking open PRs per task...`)
     const { ghOwner } = await chrome.storage.sync.get(['ghOwner'])
@@ -1051,12 +1055,7 @@ async function processTab(tab, options) {
 
   if (options.dryRun) {
     addLog(`[${label}] DRY RUN - would archive ${totalTasks} tasks`)
-    const archiveByRepo = new Map()
-    for (const t of toArchive) {
-      const key = t.repo || '(no repo)'
-      if (!archiveByRepo.has(key)) archiveByRepo.set(key, [])
-      archiveByRepo.get(key).push(t)
-    }
+    const archiveByRepo = groupTasksByRepo(toArchive)
     for (const [repo, repoTasks] of archiveByRepo) {
       addLog(`  ${repo}: ${repoTasks.length} tasks`)
       for (const t of repoTasks) {

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -108,6 +108,7 @@ function setupEnvironment(initialStorage = {}) {
     globalThis.test_findJsonEnd = findJsonEnd;
     globalThis.test_parseResponse = parseResponse;
     globalThis.test_parseTask = parseTask;
+    globalThis.test_groupTasksByRepo = groupTasksByRepo;
     globalThis.test_isArchivable = isArchivable;
     globalThis.test_TASK = TASK;
     globalThis.test_ARCHIVABLE_STATES = ARCHIVABLE_STATES;
@@ -1643,5 +1644,20 @@ describe('ensureContentScript', () => {
     await assert.rejects(sandbox.test_ensureContentScript(tabId), {
       message: 'Content script failed to initialize within 3s'
     })
+  })
+})
+
+describe('groupTasksByRepo Internal', () => {
+  it('should correctly group tasks using the internal function', () => {
+    const { sandbox } = setupEnvironment()
+    const tasks = [
+      { id: '1', repo: 'repo-1' },
+      { id: '2', repo: 'repo-2' },
+      { id: '3', repo: 'repo-1' }
+    ]
+    const result = sandbox.test_groupTasksByRepo(tasks)
+    assert.strictEqual(result.size, 2)
+    assert.strictEqual(result.get('repo-1').length, 2)
+    assert.strictEqual(result.get('repo-2').length, 1)
   })
 })


### PR DESCRIPTION
Refactored the duplicated task grouping logic in background.js into a centralized \`groupTasksByRepo\` utility function. This improvement:
- Eliminates 6 lines of redundant code in \`processTab\`.
- Centralizes the logic for repository-based task grouping.
- Ensures consistency in the fallback label '(no repo)'.

Verified via updated unit tests in \`tests/background.test.js\` and confirmed all tests pass.

---
*PR created automatically by Jules for task [5490954262017303011](https://jules.google.com/task/5490954262017303011) started by @n24q02m*