### PR TITLE
🎨 Palette: Add contextual helper text to GitHub Owner field

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -22,3 +22,7 @@
 ## 2026-06-06 - Structural Progressive Disclosure Targeting
 **Learning:** When using progressive disclosure to hide form inputs, targeting only the direct parent element can leave sibling elements (like structural wrappers, descriptive text, or styling boundaries) visible, causing layout issues and orphaned text. Furthermore, if the controlled section is visually placed above the controlling toggle, hiding the section causes the UI to jump, jarring the user experience.
 **Action:** Always target the highest logical structural wrapper (e.g., `.closest('.setting-row')`) rather than just the direct parent. Always position the controlling toggle structurally above the sections it controls to prevent jarring layout shifts when elements are hidden.
+
+## 2026-06-07 - Contextual Helper Text
+**Learning:** Adding context-aware helper text (e.g. explaining what an optional field is used for) improves form usability.
+**Action:** Always include clear helper text for optional fields, especially when their usage might be ambiguous (e.g., used only for specific checks).

--- a/popup.html
+++ b/popup.html
@@ -46,8 +46,8 @@
     <section class="settings">
       <h2>Settings</h2>
       <label for="ghOwner">
-        GitHub Owner
-        <input type="text" id="ghOwner" placeholder="your-github-username" spellcheck="false" autocomplete="username" />
+        GitHub Owner <span class="hint" id="ghOwnerHint">(optional, used for PR checks)</span>
+        <input type="text" id="ghOwner" placeholder="your-github-username" spellcheck="false" autocomplete="username" aria-describedby="ghOwnerHint" />
       </label>
       <label for="ghToken">
         GitHub Token <span class="hint" id="ghTokenHint">(optional, for private repos)</span>


### PR DESCRIPTION
💡 What: Added an inline helper text to the GitHub Owner field in the popup UI and linked it via `aria-describedby`.
🎯 Why: It wasn't completely clear what an optional GitHub Owner field was used for. Adding context improves form usability.
♿ Accessibility: Linked the hint using `aria-describedby` so screen readers correctly associate the context with the input.

---
*PR created automatically by Jules for task [11320055372108495132](https://jules.google.com/task/11320055372108495132) started by @n24q02m*