### PR TITLE
🛡️ Sentinel: [Enhancement] Add explicit strict CSP to manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -21,6 +21,9 @@
       "matches": ["https://jules.google.com/*"]
     }
   ],
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'none';"
+  },
   "action": {
     "default_popup": "popup.html",
     "default_icon": {


### PR DESCRIPTION
🚨 **Severity:** Enhancement
💡 **Vulnerability:** Relying solely on platform defaults for Content Security Policy in Manifest V3 extensions misses the opportunity for a strong, explicit defense-in-depth mechanism. An explicit policy prevents future or accidental relaxations and guards against unexpected API interactions that might otherwise bypass the default CSP.
🎯 **Impact:** If standard defaults change or a complex API call unexpectedly relaxes the environment, the extension could be vulnerable to XSS attacks via injected scripts or objects.
🔧 **Fix:** Added a strict, explicit `"content_security_policy"` (`"script-src 'self'; object-src 'none';"`) to `manifest.json` specifically for extension pages. This locks down the execution environment, neutralizing a large class of injection vulnerabilities.
✅ **Verification:** Verified that the extension manifest loads without error, and tests correctly pass with the explicit policy in place. Evaluated using the `pnpm test` and `npx @biomejs/biome check .` commands.

---
*PR created automatically by Jules for task [8493598040679911780](https://jules.google.com/task/8493598040679911780) started by @n24q02m*