### PR TITLE
[TEST] Missing edge case tests for runInPool

### DIFF
--- a/background.js
+++ b/background.js
@@ -85,7 +85,7 @@ async function runInPool(items, limit, worker) {
     }
   }
 
-  const poolSize = items.length > 0 ? Math.max(1, Math.min(Math.floor(limit), items.length)) : 0
+  const poolSize = items.length > 0 ? Math.max(1, Math.min(Math.floor(limit) || 1, items.length)) : 0
   const pool = []
   for (let i = 0; i < poolSize; i++) {
     pool.push(drain())

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -324,6 +324,18 @@ describe('runInPool', () => {
       { message: 'worker failed' }
     )
   })
+
+  it('should handle NaN limit by using a minimum concurrency of 1', async () => {
+    const { sandbox } = setupEnvironment()
+    const results = await sandbox.test_runInPool([1, 2, 3], NaN, async (n) => n * 2)
+    assert.deepStrictEqual(results, [2, 4, 6])
+  })
+
+  it('should handle negative limit by using a minimum concurrency of 1', async () => {
+    const { sandbox } = setupEnvironment()
+    const results = await sandbox.test_runInPool([1, 2, 3], -5, async (n) => n * 2)
+    assert.deepStrictEqual(results, [2, 4, 6])
+  })
 })
 
 describe('isSuggestionEnabled', () => {


### PR DESCRIPTION
Analyzed and fixed missing edge case tests for the `runInPool` concurrency limiter in `background.js`.

**Changes:**
- Added unit tests for `NaN` and negative concurrency limits in `tests/background.test.js`.
- Updated the `poolSize` calculation in `background.js` to robustly handle non-numeric or non-positive `limit` values by defaulting to a minimum concurrency of 1 for non-empty item sets.
- Verified that the fix prevents the function from returning an array of empty items when an invalid limit is provided.
- Ensured all existing tests pass and coding standards (Biome) are maintained.

---
*PR created automatically by Jules for task [14885279592292531185](https://jules.google.com/task/14885279592292531185) started by @n24q02m*