### PR TITLE
[PERF] Throttle State Updates in Loops (Tasks)

### DIFF
--- a/background.js
+++ b/background.js
@@ -665,18 +665,20 @@ async function processSuggestionsForTab(tab, options) {
   // Flatten (repo, suggestion) pairs across all repos so the pool stays
   // saturated instead of draining one repo at a time.
   const work = []
+  const discoveryLogs = []
   for (const { repo, suggestions, error } of allSuggestions) {
     if (error) {
-      addLog(`\n[${label}] ERROR fetching suggestions for ${repo}: ${error}`)
+      discoveryLogs.push(`\n[${label}] ERROR fetching suggestions for ${repo}: ${error}`)
       continue
     }
     if (suggestions.length === 0) {
-      addLog(`\n[${label}] ${repo}: No suggestions found`)
+      discoveryLogs.push(`\n[${label}] ${repo}: No suggestions found`)
       continue
     }
-    addLog(`\n[${label}] ${repo}: Found ${suggestions.length} suggestions`)
+    discoveryLogs.push(`\n[${label}] ${repo}: Found ${suggestions.length} suggestions`)
     for (const s of suggestions) work.push({ repo, s })
   }
+  if (discoveryLogs.length > 0) addLog(discoveryLogs.join(''))
 
   if (work.length === 0) {
     addLog(`\n[${label}] TOTAL: 0 suggestions started`)
@@ -705,6 +707,7 @@ async function processSuggestionsForTab(tab, options) {
   }
 
   let totalStarted = 0
+  let lastUpdate = 0
   await runInPool(toStart, PER_ACCOUNT_CONCURRENCY, async ({ repo, s }) => {
     if (state.status === 'cancelled') return
 
@@ -713,12 +716,19 @@ async function processSuggestionsForTab(tab, options) {
       return
     }
 
-    updateState({ currentRepo: repo.replace(/^github\//, '') })
+    const now = Date.now()
+    if (now - lastUpdate > 500) {
+      updateState({ currentRepo: repo.replace(/^github\//, '') })
+      lastUpdate = now
+    }
     try {
       await globalLimit(() => withRetry(() => startSuggestion(s, repo, config, startConfig)))
       totalStarted++
       state.progress.archived += 1
-      updateState({})
+      if (Date.now() - lastUpdate > 500) {
+        updateState({})
+        lastUpdate = Date.now()
+      }
       addLog(`  Started [${label}] ${s.title}`)
     } catch (err) {
       addLog(`  [!] Failed to start "${s.title}": ${err.message}`)
@@ -1038,10 +1048,11 @@ async function processTab(tab, options) {
       return owner && repoName ? getOpenPRs(owner, repoName, ghToken) : Promise.resolve([])
     })
 
+    const prLogs = []
     for (let i = 0; i < repoEntries.length; i++) {
       const [repo, repoTasks] = repoEntries[i]
       const openPRs = allPRs[i]
-      addLog(`  ${repo}: ${repoTasks.length} tasks, ${openPRs.length} open PRs`)
+      prLogs.push(`  ${repo}: ${repoTasks.length} tasks, ${openPRs.length} open PRs`)
 
       for (const task of repoTasks) {
         // A task whose title matches an open PR is likely still active work,
@@ -1049,12 +1060,13 @@ async function processTab(tab, options) {
         // failed runs, which never opened one) are archived.
         if (taskHasOpenPR(task, openPRs)) {
           toSkip.push(task)
-          addLog(`    SKIP [${task.id}] ${task.title} (matching open PR)`)
+          prLogs.push(`    SKIP [${task.id}] ${task.title} (matching open PR)`)
         } else {
           toArchive.push(task)
         }
       }
     }
+    if (prLogs.length > 0) addLog(prLogs.join('\n'))
   }
 
   if (toSkip.length > 0) {
@@ -1073,12 +1085,14 @@ async function processTab(tab, options) {
   if (options.dryRun) {
     addLog(`[${label}] DRY RUN - would archive ${totalTasks} tasks`)
     const archiveByRepo = groupTasksByRepo(toArchive)
+    const dryRunLogs = []
     for (const [repo, repoTasks] of archiveByRepo) {
-      addLog(`  ${repo}: ${repoTasks.length} tasks`)
+      dryRunLogs.push(`  ${repo}: ${repoTasks.length} tasks`)
       for (const t of repoTasks) {
-        addLog(`    [${t.id}] ${t.title} (state=${t.state})`)
+        dryRunLogs.push(`    [${t.id}] ${t.title} (state=${t.state})`)
       }
     }
+    if (dryRunLogs.length > 0) addLog(dryRunLogs.join('\n'))
     return 0
   }
 
@@ -1088,16 +1102,25 @@ async function processTab(tab, options) {
   updateState({})
 
   let grandTotal = 0
+  let lastUpdate = 0
 
   // Flatten across repos: one pool over every task keeps the fan-out saturated
   // instead of idling between per-repo batches. Each network call passes through
   // the shared global limiter so all accounts together stay under budget.
   await runInPool(toArchive, PER_ACCOUNT_CONCURRENCY, async (task) => {
+    const now = Date.now()
+    if (now - lastUpdate > 500) {
+      updateState({ currentRepo: task.repo || '(no repo)' })
+      lastUpdate = now
+    }
     try {
       await globalLimit(() => archiveTaskWithRetry(task.id, config))
       grandTotal++
       state.progress.archived += 1
-      updateState({ currentRepo: task.repo || '(no repo)' })
+      if (Date.now() - lastUpdate > 500) {
+        updateState({})
+        lastUpdate = Date.now()
+      }
       addLog(`  Archived [${label}] [${task.id}] ${task.title}`)
     } catch (e) {
       addLog(`  ERROR [${label}] archiving ${task.id}: ${e.message}`)

--- a/tests/perf.test.js
+++ b/tests/perf.test.js
@@ -166,14 +166,14 @@ describe('Throttling Optimization', () => {
     // Mock 10 tasks to archive
     const tasks = []
     for (let i = 0; i < 10; i++) {
-        tasks.push({ id: `t${i}`, title: `Task ${i}`, state: 3, source: 'github/owner/repo' })
+      tasks.push({ id: `t${i}`, title: `Task ${i}`, state: 3, source: 'github/owner/repo' })
     }
     sandbox.listTasks = async () => tasks
     sandbox.getOpenPRs = async () => []
 
     sandbox.archiveTaskWithRetry = async () => {
-        // Fast execution to trigger throttling
-        return Promise.resolve()
+      // Fast execution to trigger throttling
+      return Promise.resolve()
     }
 
     const tab = { id: 123, url: 'https://jules.google.com/u/0/' }

--- a/tests/perf.test.js
+++ b/tests/perf.test.js
@@ -150,3 +150,41 @@ describe('Orchestrator Performance Optimization', () => {
     assert.strictEqual(archiveTaskCount, 2, 'archiveTask should be called for each task')
   })
 })
+
+describe('Throttling Optimization', () => {
+  it('processTab should throttle updateState calls', async () => {
+    const sandbox = setupEnvironment()
+    let updateStateCalls = 0
+    const originalUpdateState = sandbox.updateState
+    sandbox.updateState = (patch) => {
+      updateStateCalls++
+      return originalUpdateState(patch)
+    }
+
+    sandbox.getTabConfig = async () => ({ at: 'at', bl: 'bl_v1', fsid: 'fsid', accountNum: '0' })
+
+    // Mock 10 tasks to archive
+    const tasks = []
+    for (let i = 0; i < 10; i++) {
+        tasks.push({ id: `t${i}`, title: `Task ${i}`, state: 3, source: 'github/owner/repo' })
+    }
+    sandbox.listTasks = async () => tasks
+    sandbox.getOpenPRs = async () => []
+
+    sandbox.archiveTaskWithRetry = async () => {
+        // Fast execution to trigger throttling
+        return Promise.resolve()
+    }
+
+    const tab = { id: 123, url: 'https://jules.google.com/u/0/' }
+    const options = { force: true }
+
+    await sandbox.processTab(tab, options)
+
+    // 1 call for prepareTab
+    // 1 call for initial progress
+    // Some calls for loop (should be fewer than 20 if throttled)
+    // 1 call for finalize
+    assert.ok(updateStateCalls < 10, `Too many updateState calls: ${updateStateCalls}`)
+  })
+})


### PR DESCRIPTION
This PR optimizes performance in the background service worker by throttling state updates and batching logs within task processing loops.

### 💡 What
- Batches repository discovery logs and PR check logs into local arrays, calling `addLog` once with a joined string.
- Implements a 500ms throttle for `updateState` calls within the concurrent `runInPool` workers in both `processSuggestionsForTab` and `processTab`.

### 🎯 Why
Writing to extension storage (`chrome.storage.session`) or triggering UI re-renders via `updateState` within high-frequency loops can hit quota limits and cause the extension UI to freeze. Coalescing these updates keeps the extension responsive during bulk archival or suggestion runs.

### 📊 Impact
Significant reduction in the number of storage writes and message broadcasts during bulk operations.

### 🔬 Measurement
Added a new test case in `tests/perf.test.js` that verifies the number of `updateState` calls is significantly lower than the number of tasks processed when tasks execute quickly.

---
*PR created automatically by Jules for task [644387133693775350](https://jules.google.com/task/644387133693775350) started by @n24q02m*