### PR TITLE
🎨 Palette: Improve color contrast and button transitions

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -22,7 +22,9 @@
 ## 2026-06-06 - Structural Progressive Disclosure Targeting
 **Learning:** When using progressive disclosure to hide form inputs, targeting only the direct parent element can leave sibling elements (like structural wrappers, descriptive text, or styling boundaries) visible, causing layout issues and orphaned text. Furthermore, if the controlled section is visually placed above the controlling toggle, hiding the section causes the UI to jump, jarring the user experience.
 **Action:** Always target the highest logical structural wrapper (e.g., `.closest('.setting-row')`) rather than just the direct parent. Always position the controlling toggle structurally above the sections it controls to prevent jarring layout shifts when elements are hidden.
-
 ## 2026-06-07 - Contextual Helper Text
 **Learning:** Adding context-aware helper text (e.g. explaining what an optional field is used for) improves form usability.
 **Action:** Always include clear helper text for optional fields, especially when their usage might be ambiguous (e.g., used only for specific checks).
+## 2026-10-25 - Dark Mode Contrast and State Transitions
+**Learning:** Subtle helper text (like `.hint` or `.version`) and secondary UI elements can easily fail WCAG AA contrast guidelines on dark backgrounds if generic "gray" colors are reused without checking. Additionally, interactive elements without state transitions feel jarring and unresponsive, reducing perceived quality.
+**Action:** Always verify color contrast on dark backgrounds using `#94a3b8` or lighter instead of darker grays like `#64748b`. Always add CSS `transition` properties (e.g., `background-color`, `border-color`, `transform`) to interactive elements like buttons to provide smooth, delightful visual feedback.

--- a/popup.css
+++ b/popup.css
@@ -31,7 +31,7 @@ h1 {
 
 .version {
   font-size: 11px;
-  color: #64748b;
+  color: #94a3b8;
 }
 
 h2 {
@@ -77,7 +77,7 @@ input[type="password"]:focus {
 }
 
 .hint {
-  color: #64748b;
+  color: #94a3b8;
   font-size: 11px;
 }
 
@@ -157,6 +157,9 @@ button.primary {
   font-weight: 600;
   cursor: pointer;
   margin-bottom: 12px;
+  transition:
+    background-color 0.2s ease,
+    transform 0.1s ease;
 }
 
 button.primary:hover {
@@ -169,7 +172,7 @@ button.primary:active:not(:disabled) {
 
 button.primary:disabled {
   background: #334155;
-  color: #64748b;
+  color: #94a3b8;
   cursor: not-allowed;
 }
 
@@ -190,10 +193,13 @@ button.secondary {
   font-size: 12px;
   cursor: pointer;
   margin-bottom: 12px;
+  transition:
+    border-color 0.2s ease,
+    color 0.2s ease;
 }
 
 button.secondary:hover {
-  border-color: #64748b;
+  border-color: #94a3b8;
   color: #e2e8f0;
 }
 


### PR DESCRIPTION
💡 What:
- Updated the color of `.hint`, `.version`, and disabled primary button text from `#64748b` to a lighter `#94a3b8`.
- Added CSS transitions to `button.primary` (`background-color`, `transform`) and `button.secondary` (`border-color`, `color`).

🎯 Why:
- The previous gray text failed WCAG AA contrast guidelines against the dark `#16213e` and `#1a1a2e` backgrounds, making it difficult to read for users with visual impairments.
- Interactive elements without transitions feel jarring; adding them provides smooth visual feedback, making the UI feel more responsive and high-quality.

♿ Accessibility:
- Increased contrast ratio significantly improves legibility for screen readers and low-vision users.

---
*PR created automatically by Jules for task [12849951864092034999](https://jules.google.com/task/12849951864092034999) started by @n24q02m*