### PR TITLE
fix: run unit tests in CI to enforce the test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,27 @@ jobs:
             console.log('manifest.json valid: v' + m.version);
           "
 
+  test:
+    name: Unit Tests
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+
+      - name: Run unit tests
+        run: node --test
+
   dependency-review:
     name: Dependency Review
     if: github.event_name == 'pull_request'


### PR DESCRIPTION
## Problem
The CI `Lint & Format` job ran Biome + manifest validation but never executed the `node:test` suite (`package.json` `test` script = `node --test`). A green CI therefore did **not** prove the 201 unit tests passed — a gap surfaced while clearing the bot-PR backlog (several `[TEST]`-labeled PRs had to be verified by running `node --test` locally because CI would not catch a broken test).

## Fix
Add a dedicated **Unit Tests** job to `ci.yml` that runs `node --test` on every PR and push, using pinned `actions/setup-node@v4` (Node 22), matching the repo's SHA-pinning + harden-runner convention.

## Verification
`node --test` locally on this branch: **201 pass / 0 fail** (58 suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)