### PR TITLE
🎨 Palette: Add helpful empty state for task processing summary

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,6 @@
 ## 2026-10-25 - Dark Mode Contrast and State Transitions
 **Learning:** Subtle helper text (like `.hint` or `.version`) and secondary UI elements can easily fail WCAG AA contrast guidelines on dark backgrounds if generic "gray" colors are reused without checking. Additionally, interactive elements without state transitions feel jarring and unresponsive, reducing perceived quality.
 **Action:** Always verify color contrast on dark backgrounds using `#94a3b8` or lighter instead of darker grays like `#64748b`. Always add CSS `transition` properties (e.g., `background-color`, `border-color`, `transform`) to interactive elements like buttons to provide smooth, delightful visual feedback.
+## 2026-06-09 - Empty State Feedback
+**Learning:** When a list or process finishes with zero results, an empty summary container gives no feedback, leaving the user wondering if it actually ran or failed silently.
+**Action:** Always provide a helpful empty state message explaining why no results might have occurred, using styles consistent with other hints to offer guidance without showing as an error.

--- a/popup.js
+++ b/popup.js
@@ -228,10 +228,17 @@ function renderState(state) {
 
 // --- Render summary (safe DOM methods, no innerHTML) ---
 function renderSummary(results) {
-  if (!results?.length) return
-
   summarySection.style.display = 'block'
   summaryDiv.textContent = ''
+
+  if (!results?.length) {
+    const emptyDiv = document.createElement('div')
+    emptyDiv.className = 'hint'
+    emptyDiv.style.marginTop = '4px'
+    emptyDiv.textContent = 'No items were processed. Try checking your scope or if tasks exist.'
+    summaryDiv.appendChild(emptyDiv)
+    return
+  }
 
   // ⚡ Bolt Optimization: Use DocumentFragment to batch DOM insertions.
   // This prevents redundant browser reflows/repaints when processing large

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -313,7 +313,10 @@ describe('renderSummary', () => {
     const summaryDiv = elements['#summary']
     assert.strictEqual(summaryDiv.children.length, 1)
     assert.strictEqual(summaryDiv.children[0].className, 'hint')
-    assert.strictEqual(summaryDiv.children[0].textContent, 'No items were processed. Try checking your scope or if tasks exist.')
+    assert.strictEqual(
+      summaryDiv.children[0].textContent,
+      'No items were processed. Try checking your scope or if tasks exist.'
+    )
   })
 
   it('should create elements for each result and a total', () => {

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -304,6 +304,18 @@ describe('renderState', () => {
 })
 
 describe('renderSummary', () => {
+  it('should render an empty state message when no results are processed', () => {
+    const { sandbox, elements } = setupPopupSandbox()
+    vm.runInContext(popupJs, sandbox)
+
+    sandbox.renderSummary([])
+
+    const summaryDiv = elements['#summary']
+    assert.strictEqual(summaryDiv.children.length, 1)
+    assert.strictEqual(summaryDiv.children[0].className, 'hint')
+    assert.strictEqual(summaryDiv.children[0].textContent, 'No items were processed. Try checking your scope or if tasks exist.')
+  })
+
   it('should create elements for each result and a total', () => {
     const { sandbox, elements } = setupPopupSandbox()
     vm.runInContext(popupJs, sandbox)


### PR DESCRIPTION
💡 What: Added an empty state message to the summary section in the popup when no results are processed.
🎯 Why: Previously, if the operation finished but processed 0 items (e.g. scope had no tasks), the summary section would either be blank or missing, leaving the user with no visual feedback that it actually completed correctly.
📸 Before/After: Visual empty state with `.hint` text indicating "No items were processed. Try checking your scope or if tasks exist."
♿ Accessibility: Uses existing clear UI patterns (.hint) rather than hiding elements or flashing red errors, avoiding user panic.

---
*PR created automatically by Jules for task [9454741151893550447](https://jules.google.com/task/9454741151893550447) started by @n24q02m*