### PR TITLE
[TEST] Untested function: trimLog

### DIFF
--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -98,6 +98,8 @@ function setupEnvironment(initialStorage = {}) {
     globalThis.test_state = () => state;
     globalThis.test_updateState = updateState;
     globalThis.test_addLog = addLog;
+    globalThis.test_trimLog = trimLog;
+    globalThis.test_MAX_LOG_LINES = MAX_LOG_LINES;
     globalThis.test_buildBatchRequest = buildBatchRequest;
     globalThis.test_callBatchExecute = callBatchExecute;
     globalThis.test_runInPool = runInPool;
@@ -1822,5 +1824,35 @@ describe('safeListSources', () => {
     assert.strictEqual(result, null)
     const state = sandbox.test_state()
     assert.ok(state.log.some((l) => l.includes('[test-label] ERROR listing sources: API error')))
+  })
+})
+
+describe('trimLog Internal', () => {
+  it('should not trim if log length is equal to MAX_LOG_LINES', () => {
+    const { sandbox } = setupEnvironment()
+    const max = sandbox.test_MAX_LOG_LINES
+    const state = sandbox.test_state()
+    state.log = Array.from({ length: max }, (_, i) => `line ${i}`)
+
+    sandbox.test_trimLog()
+
+    assert.strictEqual(state.log.length, max)
+    assert.strictEqual(state.log[0], 'line 0')
+    assert.strictEqual(state.log[max - 1], `line ${max - 1}`)
+  })
+
+  it('should trim oldest entries if log length exceeds MAX_LOG_LINES', () => {
+    const { sandbox } = setupEnvironment()
+    const max = sandbox.test_MAX_LOG_LINES
+    const state = sandbox.test_state()
+    // Create max + 10 entries
+    state.log = Array.from({ length: max + 10 }, (_, i) => `line ${i}`)
+
+    sandbox.test_trimLog()
+
+    assert.strictEqual(state.log.length, max)
+    // Should have removed the first 10 entries
+    assert.strictEqual(state.log[0], 'line 10')
+    assert.strictEqual(state.log[max - 1], `line ${max + 9}`)
   })
 })


### PR DESCRIPTION
This PR adds unit test coverage for the `trimLog` function in `background.js`.

Summary of changes:
- Exported `trimLog` and `MAX_LOG_LINES` to the `vm` sandbox in `tests/background.test.js`.
- Added a new test suite `trimLog Internal` to verify:
    - No trimming occurs when the log length is within the limit.
    - Oldest entries are correctly spliced out when the log length exceeds the limit.
- Verified all tests pass and ensured compliance with repository linting/formatting rules.

---
*PR created automatically by Jules for task [10335833359049156208](https://jules.google.com/task/10335833359049156208) started by @n24q02m*