### PR TITLE
[TEST] Missing Error Test: parseResponse Invalid batchexecute response

### DIFF
--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -480,6 +480,20 @@ describe('parseResponse', () => {
     const response = ')]}\'\n\n40\n[["wrb.fr","p1Takd","[[]]",null,null,null,"generic"]]'
     assert.strictEqual(sandbox.test_parseResponse(response, 'Rja83d'), null)
   })
+
+  it('should throw when newline is missing after byte length', () => {
+    const { sandbox } = setupEnvironment()
+    const response = ')]}\' 100 [["wrb.fr","p1Takd","[[]]",null,null,null,"generic"]]'
+    assert.throws(() => sandbox.test_parseResponse(response, 'p1Takd'), { message: 'Invalid batchexecute response' })
+  })
+
+  it('should throw when JSON boundary is not found', () => {
+    const { sandbox } = setupEnvironment()
+    const response = ')]}\'\n\n100\n[["wrb.fr","p1Takd","[[]]",null,null,null,"generic"'
+    assert.throws(() => sandbox.test_parseResponse(response, 'p1Takd'), {
+      message: 'Could not find JSON boundary in response'
+    })
+  })
 })
 
 // =============================================================================


### PR DESCRIPTION
This PR adds unit test coverage for the error handling in 'parseResponse' within 'background.js'. Specifically, it verifies that the function correctly throws 'Invalid batchexecute response' when the payload structure is malformed and 'Could not find JSON boundary in response' when the JSON payload is incomplete. These tests ensure that the 'Bolt' optimized parser robustly handles invalid input as expected.

---
*PR created automatically by Jules for task [10605928284287644194](https://jules.google.com/task/10605928284287644194) started by @n24q02m*