### PR TITLE
[TEST] Untested function: injectMainWorldScript

### DIFF
--- a/content.js
+++ b/content.js
@@ -118,4 +118,5 @@ if (typeof globalThis !== 'undefined' && globalThis.TEST_MODE) {
   globalThis.test_extractConfig = extractConfig
   globalThis.test_getAccountNum = getAccountNum
   globalThis.test_getAccountLabel = getAccountLabel
+  globalThis.test_injectMainWorldScript = injectMainWorldScript
 }

--- a/tests/content_injection.test.js
+++ b/tests/content_injection.test.js
@@ -69,11 +69,112 @@ describe('content.js script injection', () => {
     // Assertions
     assert.ok(scriptCreated, 'Script should be created')
     assert.strictEqual(scriptCreated.src, 'chrome-extension://id/main-world.js')
-    assert.ok(appendedTo, 'Script should be appended to document')
+    assert.strictEqual(appendedTo, 'head', 'Should prefer head if available')
 
     // Simulate onload
     assert.strictEqual(removed, false)
     scriptCreated.onload()
     assert.strictEqual(removed, true, 'Script should be removed after onload')
+  })
+
+  it('should fallback to documentElement if document.head is missing', () => {
+    let scriptCreated = null
+    let appendedTo = null
+
+    const chrome = {
+      runtime: {
+        getURL: (p) => `chrome-extension://id/${p}`,
+        onMessage: { addListener: () => {} }
+      }
+    }
+
+    const document = {
+      createElement: (tag) => {
+        if (tag === 'script') {
+          scriptCreated = {
+            src: '',
+            onload: null,
+            remove: () => {}
+          }
+          return scriptCreated
+        }
+      },
+      head: null,
+      documentElement: {
+        appendChild: (_el) => {
+          appendedTo = 'documentElement'
+        }
+      }
+    }
+
+    const window = {
+      addEventListener: () => {},
+      location: { origin: 'https://example.com' }
+    }
+
+    const sandbox = {
+      chrome,
+      document,
+      window,
+      console,
+      setTimeout,
+      clearTimeout,
+      Date,
+      Promise,
+      URL,
+      location: window.location
+    }
+
+    vm.createContext(sandbox)
+    vm.runInContext(contentJsCode, sandbox)
+
+    assert.ok(scriptCreated, 'Script should be created')
+    assert.strictEqual(appendedTo, 'documentElement', 'Should fallback to documentElement')
+  })
+
+  it('should allow manual reinjection via test_injectMainWorldScript in TEST_MODE', () => {
+    let scriptCreatedCount = 0
+
+    const chrome = {
+      runtime: {
+        getURL: (p) => `chrome-extension://id/${p}`,
+        onMessage: { addListener: () => {} }
+      }
+    }
+
+    const document = {
+      createElement: (tag) => {
+        if (tag === 'script') {
+          scriptCreatedCount++
+          return { src: '', onload: null, remove: () => {} }
+        }
+      },
+      head: { appendChild: () => {} },
+      documentElement: { appendChild: () => {} }
+    }
+
+    const sandbox = {
+      chrome,
+      document,
+      window: { addEventListener: () => {}, location: { origin: 'https://example.com' } },
+      console,
+      setTimeout,
+      clearTimeout,
+      Date,
+      Promise,
+      URL,
+      TEST_MODE: true
+    }
+    sandbox.globalThis = sandbox
+    sandbox.location = sandbox.window.location
+
+    vm.createContext(sandbox)
+    vm.runInContext(contentJsCode, sandbox)
+
+    const initialCount = scriptCreatedCount
+    assert.ok(initialCount >= 1, 'Should have injected at least once on load')
+
+    sandbox.test_injectMainWorldScript()
+    assert.strictEqual(scriptCreatedCount, initialCount + 1, 'Should have injected again manually')
   })
 })


### PR DESCRIPTION
This PR addresses the untested function `injectMainWorldScript` in `content.js`.

### Changes:
1.  **Exposed `injectMainWorldScript`**: Added `test_injectMainWorldScript` to `globalThis` in `TEST_MODE` within `content.js` to allow isolated unit testing.
2.  **Expanded Test Suite**: Updated `tests/content_injection.test.js` with new test cases:
    - Verifies that the script is injected into `document.head` by default.
    - Verifies fallback to `document.documentElement` if `document.head` is null.
    - Verifies that the script tag is removed from the DOM after the `onload` event.
    - Verifies manual reinjection capability via the exposed test helper.

### Verification:
- Ran `node --test tests/content_injection.test.js`: All 3 tests passed.
- Ran full suite `pnpm test`: All 203 tests passed.
- Linting: `npx @biomejs/biome check .` passed with no issues.

---
*PR created automatically by Jules for task [2655873437364426724](https://jules.google.com/task/2655873437364426724) started by @n24q02m*