### PR TITLE
[TEST] Missing Error Test: getOpenPRs Input Validation

### DIFF
--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -784,6 +784,23 @@ describe('getOpenPRs', () => {
     assert.strictEqual(cached.length, 1)
     assert.strictEqual(cached[0].title, 'PR')
   })
+  it('should return empty array and log warning on invalid input types', async () => {
+    const { sandbox } = setupEnvironment()
+    sandbox.test_prCache.clear()
+
+    // Test null owner
+    let prs = await sandbox.test_getOpenPRs(null, 'repo', null)
+    assert.strictEqual(prs.length, 0)
+    assert.ok(sandbox.test_state().log.some((msg) => msg.includes('Owner and repo must be strings')))
+
+    // Test undefined repo
+    prs = await sandbox.test_getOpenPRs('owner', undefined, null)
+    assert.strictEqual(prs.length, 0)
+
+    // Test number repo
+    prs = await sandbox.test_getOpenPRs('owner', 123, null)
+    assert.strictEqual(prs.length, 0)
+  })
 })
 
 describe('taskHasOpenPR', () => {


### PR DESCRIPTION
This PR adds missing test coverage for input validation in the `getOpenPRs` function within `background.js`.

The tests verify that:
- Passing `null`, `undefined`, or a number as `owner` or `repo` triggers the internal error handling.
- A warning message is logged to the application state when such invalid inputs are provided.
- The function returns an empty array as a safe fallback instead of throwing an unhandled exception.

These tests ensure the robustness of the PR checking logic against malformed data.

---
*PR created automatically by Jules for task [5689322413105226019](https://jules.google.com/task/5689322413105226019) started by @n24q02m*