### PR TITLE
🎨 Palette: Improve interactive feedback and form submission

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -31,3 +31,7 @@
 ## 2026-06-09 - Empty State Feedback
 **Learning:** When a list or process finishes with zero results, an empty summary container gives no feedback, leaving the user wondering if it actually ran or failed silently.
 **Action:** Always provide a helpful empty state message explaining why no results might have occurred, using styles consistent with other hints to offer guidance without showing as an error.
+
+## 2023-10-27 - Submit on Enter and Inline Error Feedback
+**Learning:** Keyboard users often type inside input fields and instinctively hit 'Enter' to submit. If this is not intercepted to trigger the primary action button, it breaks their workflow and requires them to manually navigate to the button. Furthermore, error states that only change the color of a progress bar without changing the text color make the error state less scannable.
+**Action:** Always add a global `keydown` listener to catch 'Enter' presses on inputs and programmatically click the primary submit button. Use inline style manipulation (e.g. `element.style.color`) tied directly to the state logic to provide immediate visual feedback for errors without relying on complex CSS class management.

--- a/popup.js
+++ b/popup.js
@@ -106,7 +106,17 @@ chrome.storage.sync.get(['ghOwner', 'opMode', 'ghToken'], (syncData) => {
     if (localData.ghToken) ghTokenInput.value = localData.ghToken
   })
 })
+
+// --- Submit on Enter for inputs ---
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter' && e.target.tagName === 'INPUT' && !startBtn.disabled) {
+    e.preventDefault()
+    startBtn.click()
+  }
+})
+
 // --- Save settings on change ---
+
 ghOwnerInput.addEventListener('change', () => {
   chrome.storage.sync.set({ ghOwner: ghOwnerInput.value.trim() })
 })
@@ -156,6 +166,7 @@ startBtn.addEventListener('click', async () => {
   currentInfo.textContent = 'Starting...'
   progressFill.style.width = '0%'
   progressFill.style.background = '' // Reset error color if present
+  currentInfo.style.color = '' // Reset error color if present
   logPre.textContent = ''
 
   chrome.runtime.sendMessage({ action: 'START', options })
@@ -222,6 +233,7 @@ function renderState(state) {
     } else {
       currentInfo.textContent = `Error: ${state.error}`
       progressFill.style.background = '#f87171'
+      currentInfo.style.color = '#f87171'
     }
   }
 }

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -173,6 +173,7 @@ function createMockDocument(elements, opModeButtons, radioStates) {
       return { forEach: () => {} }
     },
     createElement: (tag) => createMockElement(tag),
+    addEventListener: () => {},
     createDocumentFragment: () => {
       const frag = createMockElement('documentfragment')
       frag.nodeType = 11

--- a/tests/security.test.js
+++ b/tests/security.test.js
@@ -64,6 +64,7 @@ describe('Security: ghToken Storage Cleanup', () => {
     }
 
     const document = {
+      addEventListener: () => {},
       querySelector: () => ({
         addEventListener: () => {},
         querySelectorAll: () => [],


### PR DESCRIPTION
💡 What: Added a "Submit on Enter" shortcut when typing in input fields and turned error text red.
🎯 Why: Keyboard users can now seamlessly trigger the operation after entering values (like GitHub token) without taking their hands off the keys to find the submit button. Coloring the error text red matches the progress bar and makes it immediately clear that the operation failed.
📸 Before/After: Visual change sets the error text color to `#f87171`.
♿ Accessibility: Improved keyboard support and scannability of error states.

---
*PR created automatically by Jules for task [3293765790401478624](https://jules.google.com/task/3293765790401478624) started by @n24q02m*