### PR TITLE
🎨 Palette: [UX improvement] Submit on enter in text inputs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -31,3 +31,6 @@
 ## 2026-06-09 - Empty State Feedback
 **Learning:** When a list or process finishes with zero results, an empty summary container gives no feedback, leaving the user wondering if it actually ran or failed silently.
 **Action:** Always provide a helpful empty state message explaining why no results might have occurred, using styles consistent with other hints to offer guidance without showing as an error.
+## 2026-10-26 - Enter Key Form Submission
+**Learning:** For interfaces with multiple text inputs (e.g., token or username fields), users naturally expect to press the 'Enter' key to trigger the primary action rather than having to manually tab to or click the submit button. A lack of this behavior feels clunky and non-standard.
+**Action:** Always intercept 'Enter' keypresses within text inputs using a global 'keydown' listener to programmatically trigger the primary submit button, improving keyboard accessibility and overall user experience.

--- a/popup.js
+++ b/popup.js
@@ -175,6 +175,16 @@ resetBtn.addEventListener('click', () => {
   startBtn.focus()
 })
 
+// --- Handle Enter key to submit ---
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter' && e.target.tagName === 'INPUT' && (e.target.type === 'text' || e.target.type === 'password')) {
+    e.preventDefault()
+    if (!startBtn.disabled) {
+      startBtn.click()
+    }
+  }
+})
+
 // --- Listen for state changes ---
 chrome.storage.onChanged.addListener((changes) => {
   if (!changes.archiveState) return

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -158,6 +158,8 @@ function createMockChrome(syncStorage, localStorage, sessionStorage, listeners) 
  */
 function createMockDocument(elements, opModeButtons, radioStates) {
   return {
+    addEventListener: (_event, _handler) => {},
+    dispatchEvent: (_event) => {},
     querySelector: (sel) => {
       if (sel === 'input[name="mode"]:checked') return { value: radioStates.mode }
       if (sel === 'input[name="scope"]:checked') return { value: radioStates.scope }
@@ -371,6 +373,37 @@ describe('Initialization and Storage', () => {
       assert.strictEqual(elements['#ghOwner'].value, 'some-owner')
       done()
     }, 10)
+  })
+})
+
+describe('Keyboard Accessibility', () => {
+  it('should trigger startBtn click when Enter is pressed inside a text input', () => {
+    const { sandbox, elements } = setupPopupSandbox()
+    let startBtnClicked = false
+    elements['#startBtn'].click = () => {
+      startBtnClicked = true
+    }
+
+    // Manually register the listener in our sandbox document mockup
+    let keydownListener = null
+    sandbox.document.addEventListener = (event, handler) => {
+      if (event === 'keydown') keydownListener = handler
+    }
+
+    vm.runInContext(popupJs, sandbox)
+
+    // Simulate Enter keydown on an input
+    const mockEvent = {
+      key: 'Enter',
+      target: { tagName: 'INPUT', type: 'text' },
+      preventDefault: () => {}
+    }
+
+    if (keydownListener) {
+      keydownListener(mockEvent)
+    }
+
+    assert.strictEqual(startBtnClicked, true, 'startBtn should be clicked on Enter')
   })
 })
 

--- a/tests/security.test.js
+++ b/tests/security.test.js
@@ -64,6 +64,12 @@ describe('Security: ghToken Storage Cleanup', () => {
     }
 
     const document = {
+      addEventListener: () => {},
+      dispatchEvent: () => {},
+      addEventListener: () => {},
+      dispatchEvent: () => {},
+      addEventListener: () => {},
+      dispatchEvent: () => {},
       querySelector: () => ({
         addEventListener: () => {},
         querySelectorAll: () => [],


### PR DESCRIPTION
🎨 Palette: Submit on enter in text inputs

💡 What: Added a global keydown event listener to trigger the primary submit action when the 'Enter' key is pressed while focused inside text or password input fields. Also updated test sandboxes to safely mock `addEventListener` to avoid regressions.
🎯 Why: Users expect standard form submission behavior. Requiring them to manually tab to or click the "Start" button after typing in their GitHub username or token disrupts the workflow and introduces friction.
♿ Accessibility: Improves keyboard navigation support and standardizes control behaviors for users relying on keyboard input.

---
*PR created automatically by Jules for task [10273778016376710536](https://jules.google.com/task/10273778016376710536) started by @n24q02m*