### PR TITLE
🎨 Palette: Use semantic `<fieldset>` for grouping inputs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -31,3 +31,6 @@
 ## 2026-06-09 - Empty State Feedback
 **Learning:** When a list or process finishes with zero results, an empty summary container gives no feedback, leaving the user wondering if it actually ran or failed silently.
 **Action:** Always provide a helpful empty state message explaining why no results might have occurred, using styles consistent with other hints to offer guidance without showing as an error.
+## 2025-06-25 - Use Native Semantic HTML Over Implicit ARIA Roles
+**Learning:** The "First Rule of ARIA" states that native HTML elements with built-in semantics should be preferred over retrofitting `<div>` elements with ARIA roles (like `role="group"` or `aria-labelledby`). Relying on ARIA attributes to group related inputs when native `<fieldset>` and `<legend>` tags are available misses an opportunity to provide a more robust semantic structure that works universally out-of-the-box for assistive technologies.
+**Action:** When grouping related UI form controls, always use `<fieldset>` and `<legend>` elements instead of generic `<div>` wrappers with `role="group"`. If visual adjustments are needed to maintain existing designs, apply simple CSS resets (e.g., `border: none; padding: 0; margin: 0`) to the `<fieldset>` rather than reverting to a `<div>`.

--- a/popup.css
+++ b/popup.css
@@ -50,7 +50,14 @@ section {
   border-radius: 6px;
 }
 
-label {
+fieldset {
+  border: none;
+  padding: 0;
+  margin: 0;
+}
+
+label,
+legend {
   display: block;
   font-size: 12px;
   color: #94a3b8;

--- a/popup.html
+++ b/popup.html
@@ -13,20 +13,20 @@
 
     <section class="options">
       <h2>Options</h2>
-      <div class="setting-row">
-        <label id="opModeLabel">Operation</label>
-        <div class="segmented" id="opMode" role="group" aria-labelledby="opModeLabel">
+      <fieldset class="setting-row">
+        <legend id="opModeLabel">Operation</legend>
+        <div class="segmented" id="opMode">
           <button type="button" data-value="archive" class="active" aria-pressed="true">Archive Tasks</button>
           <button type="button" data-value="suggestions" aria-pressed="false">Start Suggestions</button>
         </div>
-      </div>
-      <div class="setting-row">
-        <label id="execModeLabel">Execution Mode</label>
-        <div class="radio-group" role="radiogroup" aria-labelledby="execModeLabel">
+      </fieldset>
+      <fieldset class="setting-row">
+        <legend id="execModeLabel">Execution Mode</legend>
+        <div class="radio-group">
           <label><input type="radio" name="mode" value="dry" checked /> Dry Run</label>
           <label><input type="radio" name="mode" value="run" /> Run</label>
         </div>
-      </div>
+      </fieldset>
       <div class="setting-row">
         <label class="checkbox">
           <input type="checkbox" id="force" aria-describedby="forceHint" />
@@ -34,13 +34,13 @@
         </label>
         <span class="hint" id="forceHint" style="display: block; margin-left: 20px; margin-top: 2px;">Archive every task, ignoring state and matching open Pull Requests</span>
       </div>
-      <div class="setting-row">
-        <label id="scopeLabel">Scope</label>
-        <div class="radio-group" role="radiogroup" aria-labelledby="scopeLabel">
+      <fieldset class="setting-row">
+        <legend id="scopeLabel">Scope</legend>
+        <div class="radio-group">
           <label><input type="radio" name="scope" value="current" /> Current tab</label>
           <label><input type="radio" name="scope" value="all" checked /> All Jules tabs</label>
         </div>
-      </div>
+      </fieldset>
     </section>
 
     <section class="settings">

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -435,11 +435,10 @@ describe('popup.html accessibility', () => {
     )
   })
 
-  it('should use explicit visible labels for radio groups via aria-labelledby', () => {
+  it('should use explicit visible labels for radio groups or use fieldset/legend', () => {
     assert.ok(popupHtml.includes('id="execModeLabel"'), 'execModeLabel should exist')
-    assert.ok(popupHtml.includes('aria-labelledby="execModeLabel"'), 'mode radiogroup should use aria-labelledby')
+    assert.ok(popupHtml.includes('<fieldset') && popupHtml.includes('<legend'), 'mode should use fieldset/legend')
     assert.ok(popupHtml.includes('id="scopeLabel"'), 'scopeLabel should exist')
-    assert.ok(popupHtml.includes('aria-labelledby="scopeLabel"'), 'scope radiogroup should use aria-labelledby')
   })
 })
 


### PR DESCRIPTION
💡 What: Replaced `<div>` containers equipped with implicit ARIA attributes (`role="group"`, `aria-labelledby`) with native `<fieldset>` and `<legend>` HTML elements for grouping inputs in `popup.html`. Updated styling in `popup.css` to reset `fieldset` borders and padding to match existing layout, and updated test suite to enforce new semantic rules.
🎯 Why: The 'First Rule of ARIA' asserts that native HTML elements with built-in semantics should be preferred over retrofitting `<div>` elements with ARIA roles to provide a more robust experience for assistive technology users.
♿ Accessibility: Increased the semantic richness of grouped inputs, making them inherently more interpretable for screen readers out of the box without changing visual appearance.

---
*PR created automatically by Jules for task [15070431182785896527](https://jules.google.com/task/15070431182785896527) started by @n24q02m*