### PR TITLE
🎨 Palette: Replace generic div with semantic fieldset for form groups

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -31,3 +31,7 @@
 ## 2026-06-09 - Empty State Feedback
 **Learning:** When a list or process finishes with zero results, an empty summary container gives no feedback, leaving the user wondering if it actually ran or failed silently.
 **Action:** Always provide a helpful empty state message explaining why no results might have occurred, using styles consistent with other hints to offer guidance without showing as an error.
+
+## 2025-02-23 - Semantic Form Groups for Radio Buttons
+**Learning:** Generic `<div>` containers with custom roles are less accessible and semantic for grouping related radio buttons or segment controls compared to native `<fieldset>` and `<legend>` elements. Native elements automatically establish accessible context for screen readers when navigating between related inputs.
+**Action:** Always prefer native semantic HTML elements (`<fieldset>` and `<legend>`) over ARIA roles like `role="group"` on generic containers for improved accessibility without complex workarounds.

--- a/popup.css
+++ b/popup.css
@@ -43,6 +43,12 @@ h2 {
   margin-bottom: 8px;
 }
 
+fieldset {
+  border: none;
+  padding: 0;
+  margin: 0;
+}
+
 section {
   margin-bottom: 12px;
   padding: 10px;
@@ -50,7 +56,8 @@ section {
   border-radius: 6px;
 }
 
-label {
+label,
+legend {
   display: block;
   font-size: 12px;
   color: #94a3b8;
@@ -85,7 +92,8 @@ input[type="password"]:focus {
   margin-bottom: 8px;
 }
 
-.setting-row label {
+.setting-row label,
+.setting-row legend {
   margin-bottom: 4px;
 }
 

--- a/popup.html
+++ b/popup.html
@@ -13,20 +13,20 @@
 
     <section class="options">
       <h2>Options</h2>
-      <div class="setting-row">
-        <label id="opModeLabel">Operation</label>
+      <fieldset class="setting-row">
+        <legend id="opModeLabel">Operation</legend>
         <div class="segmented" id="opMode" role="group" aria-labelledby="opModeLabel">
           <button type="button" data-value="archive" class="active" aria-pressed="true">Archive Tasks</button>
           <button type="button" data-value="suggestions" aria-pressed="false">Start Suggestions</button>
         </div>
-      </div>
-      <div class="setting-row">
-        <label id="execModeLabel">Execution Mode</label>
+      </fieldset>
+      <fieldset class="setting-row">
+        <legend id="execModeLabel">Execution Mode</legend>
         <div class="radio-group" role="radiogroup" aria-labelledby="execModeLabel">
           <label><input type="radio" name="mode" value="dry" checked /> Dry Run</label>
           <label><input type="radio" name="mode" value="run" /> Run</label>
         </div>
-      </div>
+      </fieldset>
       <div class="setting-row">
         <label class="checkbox">
           <input type="checkbox" id="force" aria-describedby="forceHint" />
@@ -34,13 +34,13 @@
         </label>
         <span class="hint" id="forceHint" style="display: block; margin-left: 20px; margin-top: 2px;">Archive every task, ignoring state and matching open Pull Requests</span>
       </div>
-      <div class="setting-row">
-        <label id="scopeLabel">Scope</label>
+      <fieldset class="setting-row">
+        <legend id="scopeLabel">Scope</legend>
         <div class="radio-group" role="radiogroup" aria-labelledby="scopeLabel">
           <label><input type="radio" name="scope" value="current" /> Current tab</label>
           <label><input type="radio" name="scope" value="all" checked /> All Jules tabs</label>
         </div>
-      </div>
+      </fieldset>
     </section>
 
     <section class="settings">

--- a/popup.html
+++ b/popup.html
@@ -15,14 +15,14 @@
       <h2>Options</h2>
       <fieldset class="setting-row">
         <legend id="opModeLabel">Operation</legend>
-        <div class="segmented" id="opMode" role="group" aria-labelledby="opModeLabel">
+        <div class="segmented" id="opMode">
           <button type="button" data-value="archive" class="active" aria-pressed="true">Archive Tasks</button>
           <button type="button" data-value="suggestions" aria-pressed="false">Start Suggestions</button>
         </div>
       </fieldset>
       <fieldset class="setting-row">
         <legend id="execModeLabel">Execution Mode</legend>
-        <div class="radio-group" role="radiogroup" aria-labelledby="execModeLabel">
+        <div class="radio-group">
           <label><input type="radio" name="mode" value="dry" checked /> Dry Run</label>
           <label><input type="radio" name="mode" value="run" /> Run</label>
         </div>
@@ -36,7 +36,7 @@
       </div>
       <fieldset class="setting-row">
         <legend id="scopeLabel">Scope</legend>
-        <div class="radio-group" role="radiogroup" aria-labelledby="scopeLabel">
+        <div class="radio-group">
           <label><input type="radio" name="scope" value="current" /> Current tab</label>
           <label><input type="radio" name="scope" value="all" checked /> All Jules tabs</label>
         </div>

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -435,11 +435,11 @@ describe('popup.html accessibility', () => {
     )
   })
 
-  it('should use explicit visible labels for radio groups via aria-labelledby', () => {
+  it('should use explicit visible labels for radio groups via fieldset legends', () => {
     assert.ok(popupHtml.includes('id="execModeLabel"'), 'execModeLabel should exist')
-    assert.ok(popupHtml.includes('aria-labelledby="execModeLabel"'), 'mode radiogroup should use aria-labelledby')
+    assert.ok(popupHtml.includes('<legend id="execModeLabel">'), 'mode radiogroup should use legend')
     assert.ok(popupHtml.includes('id="scopeLabel"'), 'scopeLabel should exist')
-    assert.ok(popupHtml.includes('aria-labelledby="scopeLabel"'), 'scope radiogroup should use aria-labelledby')
+    assert.ok(popupHtml.includes('<legend id="scopeLabel">'), 'scope radiogroup should use legend')
   })
 })
 


### PR DESCRIPTION
💡 What: Replaced generic `div`s with native `fieldset`s and `legend`s for grouped radio buttons and buttons in `popup.html`.
🎯 Why: Generic containers require complex ARIA setup (which were missing or slightly incomplete) to communicate relationship state to assistive technologies. Native semantic elements establish these relationships intrinsically, ensuring screen reader compatibility.
📸 Before/After: Visual presentation is identical; the changes are strictly under-the-hood HTML semantic upgrades.
♿ Accessibility: This enhances context and grouping logic for screen readers, allowing users to understand that inputs like 'Dry Run' and 'Run' belong to 'Execution Mode'.

---
*PR created automatically by Jules for task [579775650357690644](https://jules.google.com/task/579775650357690644) started by @n24q02m*