### PR TITLE
🎨 Palette: Semantic Form Group Accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -31,3 +31,6 @@
 ## 2026-06-09 - Empty State Feedback
 **Learning:** When a list or process finishes with zero results, an empty summary container gives no feedback, leaving the user wondering if it actually ran or failed silently.
 **Action:** Always provide a helpful empty state message explaining why no results might have occurred, using styles consistent with other hints to offer guidance without showing as an error.
+## 2025-02-18 - Semantic Form Group Accessibility
+**Learning:** Generic `<div>` containers combined with `role="group"` or `role="radiogroup"` and `aria-labelledby` attributes are often flagged by linters (like Biome) and can be unnecessarily complex. Native semantic HTML `<fieldset>` and `<legend>` elements implicitly provide this accessibility structure without requiring explicit ARIA roles.
+**Action:** Default to using `<fieldset>` and `<legend>` when grouping related form controls (like radio buttons or segmented controls). Remember to apply a basic CSS reset (`border: none; padding: 0; margin: 0;`) to `<fieldset>` and style `<legend>` to match `<label>` to maintain the intended visual design.

--- a/popup.css
+++ b/popup.css
@@ -50,7 +50,7 @@ section {
   border-radius: 6px;
 }
 
-label {
+label, legend {
   display: block;
   font-size: 12px;
   color: #94a3b8;
@@ -259,4 +259,10 @@ button.secondary:hover {
 
 .summary .skipped {
   color: #fbbf24;
+}
+
+fieldset {
+  border: none;
+  padding: 0;
+  margin: 0;
 }

--- a/popup.css
+++ b/popup.css
@@ -50,7 +50,8 @@ section {
   border-radius: 6px;
 }
 
-label, legend {
+label,
+legend {
   display: block;
   font-size: 12px;
   color: #94a3b8;

--- a/popup.html
+++ b/popup.html
@@ -13,20 +13,20 @@
 
     <section class="options">
       <h2>Options</h2>
-      <div class="setting-row">
-        <label id="opModeLabel">Operation</label>
-        <div class="segmented" id="opMode" role="group" aria-labelledby="opModeLabel">
+      <fieldset class="setting-row">
+        <legend id="opModeLabel">Operation</legend>
+        <div class="segmented" id="opMode">
           <button type="button" data-value="archive" class="active" aria-pressed="true">Archive Tasks</button>
           <button type="button" data-value="suggestions" aria-pressed="false">Start Suggestions</button>
         </div>
-      </div>
-      <div class="setting-row">
-        <label id="execModeLabel">Execution Mode</label>
-        <div class="radio-group" role="radiogroup" aria-labelledby="execModeLabel">
+      </fieldset>
+      <fieldset class="setting-row">
+        <legend id="execModeLabel">Execution Mode</legend>
+        <div class="radio-group">
           <label><input type="radio" name="mode" value="dry" checked /> Dry Run</label>
           <label><input type="radio" name="mode" value="run" /> Run</label>
         </div>
-      </div>
+      </fieldset>
       <div class="setting-row">
         <label class="checkbox">
           <input type="checkbox" id="force" aria-describedby="forceHint" />
@@ -34,13 +34,13 @@
         </label>
         <span class="hint" id="forceHint" style="display: block; margin-left: 20px; margin-top: 2px;">Archive every task, ignoring state and matching open Pull Requests</span>
       </div>
-      <div class="setting-row">
-        <label id="scopeLabel">Scope</label>
-        <div class="radio-group" role="radiogroup" aria-labelledby="scopeLabel">
+      <fieldset class="setting-row">
+        <legend id="scopeLabel">Scope</legend>
+        <div class="radio-group">
           <label><input type="radio" name="scope" value="current" /> Current tab</label>
           <label><input type="radio" name="scope" value="all" checked /> All Jules tabs</label>
         </div>
-      </div>
+      </fieldset>
     </section>
 
     <section class="settings">

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -437,9 +437,9 @@ describe('popup.html accessibility', () => {
 
   it('should use explicit visible labels for radio groups via aria-labelledby', () => {
     assert.ok(popupHtml.includes('id="execModeLabel"'), 'execModeLabel should exist')
-    assert.ok(popupHtml.includes('aria-labelledby="execModeLabel"'), 'mode radiogroup should use aria-labelledby')
+    // // assert.ok(popupHtml.includes('aria-labelledby="execModeLabel"'), 'mode radiogroup should use aria-labelledby') // Removed as fieldset provides native grouping // Removed as fieldset provides native grouping
     assert.ok(popupHtml.includes('id="scopeLabel"'), 'scopeLabel should exist')
-    assert.ok(popupHtml.includes('aria-labelledby="scopeLabel"'), 'scope radiogroup should use aria-labelledby')
+    // // assert.ok(popupHtml.includes('aria-labelledby="scopeLabel"'), 'scope radiogroup should use aria-labelledby') // Removed as fieldset provides native grouping // Removed as fieldset provides native grouping
   })
 })
 


### PR DESCRIPTION
🎨 Palette: Semantic Form Group Accessibility

💡 What: 
- Replaced generic `<div class="setting-row">` elements functioning as logical form groups with `<fieldset class="setting-row">`.
- Replaced `<label>` elements serving as group headings with `<legend>`.
- Removed redundant ARIA attributes (`role="group"`, `role="radiogroup"`, `aria-labelledby`) as they are natively provided by the new semantic elements.
- Updated `popup.css` to reset default `<fieldset>` styling (removing borders/padding) and styled `<legend>` to visually match the previous `<label>` design.
- Cleaned up obsolete assertions in `tests/popup.test.js`.
- Logged the learning in `.Jules/palette.md`.

🎯 Why: 
Following the "First Rule of ARIA," using native HTML elements is preferable to explicitly retrofitting generic containers with ARIA roles. This simplifies the markup, clears linter warnings (e.g., from Biome), and provides a more robust structure for assistive technologies.

📸 Before/After: 
The visual layout remains pixel-perfect (verified via Playwright frontend verification).

♿ Accessibility: 
Ensures form controls like radio buttons and segmented options are grouped natively and semantically, improving screen reader compatibility without relying on manual attribute linking.

---
*PR created automatically by Jules for task [3639899706133267183](https://jules.google.com/task/3639899706133267183) started by @n24q02m*