### PR TITLE
🎨 Palette: Use semantic fieldsets for grouping form controls

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -31,3 +31,6 @@
 ## 2026-06-09 - Empty State Feedback
 **Learning:** When a list or process finishes with zero results, an empty summary container gives no feedback, leaving the user wondering if it actually ran or failed silently.
 **Action:** Always provide a helpful empty state message explaining why no results might have occurred, using styles consistent with other hints to offer guidance without showing as an error.
+## 2024-05-24 - Replace implicit ARIA groups with semantic HTML fieldsets
+**Learning:** Using `div` tags with `role="group"` or `role="radiogroup"` combined with `aria-labelledby` works for screen readers, but the W3C standard and most robust method for grouping related form controls (like radio buttons) is to use native semantic HTML `<fieldset>` and `<legend>` tags.
+**Action:** When grouping form controls, default to `<fieldset>` and `<legend>` instead of generic containers with ARIA roles. Remember to strip out the browser's default `<fieldset>` styling (border, padding, margin) to preserve the existing design system.

--- a/popup.css
+++ b/popup.css
@@ -50,7 +50,8 @@ section {
   border-radius: 6px;
 }
 
-label {
+label,
+legend {
   display: block;
   font-size: 12px;
   color: #94a3b8;
@@ -259,4 +260,10 @@ button.secondary:hover {
 
 .summary .skipped {
   color: #fbbf24;
+}
+
+fieldset {
+  border: none;
+  padding: 0;
+  margin: 0;
 }

--- a/popup.html
+++ b/popup.html
@@ -13,20 +13,20 @@
 
     <section class="options">
       <h2>Options</h2>
-      <div class="setting-row">
-        <label id="opModeLabel">Operation</label>
-        <div class="segmented" id="opMode" role="group" aria-labelledby="opModeLabel">
+      <fieldset class="setting-row">
+        <legend id="opModeLabel">Operation</legend>
+        <div class="segmented" id="opMode">
           <button type="button" data-value="archive" class="active" aria-pressed="true">Archive Tasks</button>
           <button type="button" data-value="suggestions" aria-pressed="false">Start Suggestions</button>
         </div>
-      </div>
-      <div class="setting-row">
-        <label id="execModeLabel">Execution Mode</label>
-        <div class="radio-group" role="radiogroup" aria-labelledby="execModeLabel">
+      </fieldset>
+      <fieldset class="setting-row">
+        <legend id="execModeLabel">Execution Mode</legend>
+        <div class="radio-group">
           <label><input type="radio" name="mode" value="dry" checked /> Dry Run</label>
           <label><input type="radio" name="mode" value="run" /> Run</label>
         </div>
-      </div>
+      </fieldset>
       <div class="setting-row">
         <label class="checkbox">
           <input type="checkbox" id="force" aria-describedby="forceHint" />
@@ -34,13 +34,13 @@
         </label>
         <span class="hint" id="forceHint" style="display: block; margin-left: 20px; margin-top: 2px;">Archive every task, ignoring state and matching open Pull Requests</span>
       </div>
-      <div class="setting-row">
-        <label id="scopeLabel">Scope</label>
-        <div class="radio-group" role="radiogroup" aria-labelledby="scopeLabel">
+      <fieldset class="setting-row">
+        <legend id="scopeLabel">Scope</legend>
+        <div class="radio-group">
           <label><input type="radio" name="scope" value="current" /> Current tab</label>
           <label><input type="radio" name="scope" value="all" checked /> All Jules tabs</label>
         </div>
-      </div>
+      </fieldset>
     </section>
 
     <section class="settings">

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -435,11 +435,12 @@ describe('popup.html accessibility', () => {
     )
   })
 
-  it('should use explicit visible labels for radio groups via aria-labelledby', () => {
-    assert.ok(popupHtml.includes('id="execModeLabel"'), 'execModeLabel should exist')
-    assert.ok(popupHtml.includes('aria-labelledby="execModeLabel"'), 'mode radiogroup should use aria-labelledby')
-    assert.ok(popupHtml.includes('id="scopeLabel"'), 'scopeLabel should exist')
-    assert.ok(popupHtml.includes('aria-labelledby="scopeLabel"'), 'scope radiogroup should use aria-labelledby')
+  it('should use semantic fieldset and legend for grouping form controls', () => {
+    assert.ok(popupHtml.includes('<fieldset class="setting-row">'), 'should use fieldset for setting rows')
+    assert.ok(popupHtml.includes('<legend id="execModeLabel">Execution Mode</legend>'), 'execMode should use legend')
+    assert.ok(popupHtml.includes('<legend id="scopeLabel">Scope</legend>'), 'scope should use legend')
+    assert.ok(!popupHtml.includes('role="radiogroup"'), 'should not use explicit radiogroup role')
+    assert.ok(!popupHtml.includes('role="group"'), 'should not use explicit group role')
   })
 })
 


### PR DESCRIPTION
💡 What: Replaced generic `<div>` tags that used explicit `role="group"` / `role="radiogroup"` and `aria-labelledby` attributes with native semantic HTML `<fieldset>` and `<legend>` tags in the popup.
🎯 Why: To improve the underlying markup and adhere to the W3C recommended standard for grouping related form controls (like radio buttons). This improves the experience for screen reader users natively.
📸 Before/After: Visuals are exactly the same, as the browser default styling for `<fieldset>` was reset.
♿ Accessibility: Uses the native semantic `<fieldset>` and `<legend>` elements rather than explicit ARIA attributes, providing a more robust accessible experience out of the box.

---
*PR created automatically by Jules for task [8600619215105986868](https://jules.google.com/task/8600619215105986868) started by @n24q02m*