### PR TITLE
🎨 Palette: Replace ARIA roles with semantic fieldsets

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -31,3 +31,6 @@
 ## 2026-06-09 - Empty State Feedback
 **Learning:** When a list or process finishes with zero results, an empty summary container gives no feedback, leaving the user wondering if it actually ran or failed silently.
 **Action:** Always provide a helpful empty state message explaining why no results might have occurred, using styles consistent with other hints to offer guidance without showing as an error.
+## 2026-10-26 - Semantic Fieldsets Over ARIA Groupings
+**Learning:** While \`role="group"\` or \`role="radiogroup"\` alongside \`aria-labelledby\` can group inputs for screen readers, native semantic HTML elements (\`<fieldset>\` and \`<legend>\`) provide this out-of-the-box and are universally better supported across all assistive technologies without needing explicit pseudo-label bindings.
+**Action:** Always prefer native \`<fieldset>\` and \`<legend>\` over generic \`div\` elements with ARIA roles when grouping related form controls (like radio buttons or segmented controls), ensuring to reset their default browser styling (\`border\`, \`padding\`, \`margin\`) to fit the design system.

--- a/popup.css
+++ b/popup.css
@@ -50,7 +50,8 @@ section {
   border-radius: 6px;
 }
 
-label {
+label,
+legend {
   display: block;
   font-size: 12px;
   color: #94a3b8;
@@ -85,8 +86,15 @@ input[type="password"]:focus {
   margin-bottom: 8px;
 }
 
-.setting-row label {
+.setting-row label,
+.setting-row legend {
   margin-bottom: 4px;
+}
+
+fieldset {
+  border: none;
+  padding: 0;
+  margin: 0;
 }
 
 .segmented {

--- a/popup.html
+++ b/popup.html
@@ -14,18 +14,22 @@
     <section class="options">
       <h2>Options</h2>
       <div class="setting-row">
-        <label id="opModeLabel">Operation</label>
-        <div class="segmented" id="opMode" role="group" aria-labelledby="opModeLabel">
+        <fieldset>
+          <legend>Operation</legend>
+          <div class="segmented" id="opMode">
           <button type="button" data-value="archive" class="active" aria-pressed="true">Archive Tasks</button>
           <button type="button" data-value="suggestions" aria-pressed="false">Start Suggestions</button>
-        </div>
+          </div>
+        </fieldset>
       </div>
       <div class="setting-row">
-        <label id="execModeLabel">Execution Mode</label>
-        <div class="radio-group" role="radiogroup" aria-labelledby="execModeLabel">
+        <fieldset>
+          <legend>Execution Mode</legend>
+          <div class="radio-group">
           <label><input type="radio" name="mode" value="dry" checked /> Dry Run</label>
           <label><input type="radio" name="mode" value="run" /> Run</label>
-        </div>
+          </div>
+        </fieldset>
       </div>
       <div class="setting-row">
         <label class="checkbox">
@@ -35,11 +39,13 @@
         <span class="hint" id="forceHint" style="display: block; margin-left: 20px; margin-top: 2px;">Archive every task, ignoring state and matching open Pull Requests</span>
       </div>
       <div class="setting-row">
-        <label id="scopeLabel">Scope</label>
-        <div class="radio-group" role="radiogroup" aria-labelledby="scopeLabel">
+        <fieldset>
+          <legend>Scope</legend>
+          <div class="radio-group">
           <label><input type="radio" name="scope" value="current" /> Current tab</label>
           <label><input type="radio" name="scope" value="all" checked /> All Jules tabs</label>
-        </div>
+          </div>
+        </fieldset>
       </div>
     </section>
 

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -435,11 +435,11 @@ describe('popup.html accessibility', () => {
     )
   })
 
-  it('should use explicit visible labels for radio groups via aria-labelledby', () => {
-    assert.ok(popupHtml.includes('id="execModeLabel"'), 'execModeLabel should exist')
-    assert.ok(popupHtml.includes('aria-labelledby="execModeLabel"'), 'mode radiogroup should use aria-labelledby')
-    assert.ok(popupHtml.includes('id="scopeLabel"'), 'scopeLabel should exist')
-    assert.ok(popupHtml.includes('aria-labelledby="scopeLabel"'), 'scope radiogroup should use aria-labelledby')
+  it('should use explicit native semantic fieldset and legend for grouping', () => {
+    assert.ok(popupHtml.includes('<fieldset>'), 'should use fieldset')
+    assert.ok(popupHtml.includes('<legend>Execution Mode</legend>'), 'mode radiogroup should have legend')
+    assert.ok(popupHtml.includes('<legend>Scope</legend>'), 'scope radiogroup should have legend')
+    assert.ok(popupHtml.includes('<legend>Operation</legend>'), 'opMode should have legend')
   })
 })
 


### PR DESCRIPTION
## 💡 What
This PR replaces the `div` containers that were manually grouped using `role="group"` / `role="radiogroup"` and `aria-labelledby` with native HTML `<fieldset>` and `<legend>` elements. It updates the CSS to reset default fieldset browser styling and maintain the existing visual design seamlessly. The associated tests were updated to assert on these semantic tags rather than ARIA attributes.

## 🎯 Why
Native HTML tags like `<fieldset>` and `<legend>` provide form control grouping out-of-the-box and are universally better supported by all screen readers and assistive technologies compared to applying manual ARIA bindings on non-semantic divs.

## 📸 Before/After
The visual design remains identical, as the fieldset default stylings (`border`, `padding`, `margin`) were properly stripped out.

## ♿ Accessibility
This change improves keyboard and screen-reader accessibility by utilizing semantic HTML grouping out-of-the-box instead of relying purely on explicit ARIA links.

---
*PR created automatically by Jules for task [4410483993863733008](https://jules.google.com/task/4410483993863733008) started by @n24q02m*