### PR TITLE
🎨 Palette: Improve accessibility with semantic fieldsets

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -31,3 +31,7 @@
 ## 2026-06-09 - Empty State Feedback
 **Learning:** When a list or process finishes with zero results, an empty summary container gives no feedback, leaving the user wondering if it actually ran or failed silently.
 **Action:** Always provide a helpful empty state message explaining why no results might have occurred, using styles consistent with other hints to offer guidance without showing as an error.
+
+## 2024-06-20 - Use Native Fieldsets Over ARIA Groups
+**Learning:** Replacing generic containers (<div>) with semantic HTML elements (<fieldset> and <legend>) provides better native accessibility and grouping for screen readers than relying solely on ARIA roles and labels, while preserving existing visual design via CSS resets.
+**Action:** When creating form control groups (radio buttons, segmented controls), use native <fieldset> and <legend> elements instead of <div> wrappers with role='group' and aria-labelledby.

--- a/popup.css
+++ b/popup.css
@@ -50,7 +50,14 @@ section {
   border-radius: 6px;
 }
 
-label {
+fieldset {
+  border: none;
+  padding: 0;
+  margin: 0;
+}
+
+label,
+legend {
   display: block;
   font-size: 12px;
   color: #94a3b8;

--- a/popup.html
+++ b/popup.html
@@ -13,20 +13,20 @@
 
     <section class="options">
       <h2>Options</h2>
-      <div class="setting-row">
-        <label id="opModeLabel">Operation</label>
-        <div class="segmented" id="opMode" role="group" aria-labelledby="opModeLabel">
+      <fieldset class="setting-row">
+        <legend>Operation</legend>
+        <div class="segmented" id="opMode">
           <button type="button" data-value="archive" class="active" aria-pressed="true">Archive Tasks</button>
           <button type="button" data-value="suggestions" aria-pressed="false">Start Suggestions</button>
         </div>
-      </div>
-      <div class="setting-row">
-        <label id="execModeLabel">Execution Mode</label>
-        <div class="radio-group" role="radiogroup" aria-labelledby="execModeLabel">
+      </fieldset>
+      <fieldset class="setting-row">
+        <legend>Execution Mode</legend>
+        <div class="radio-group">
           <label><input type="radio" name="mode" value="dry" checked /> Dry Run</label>
           <label><input type="radio" name="mode" value="run" /> Run</label>
         </div>
-      </div>
+      </fieldset>
       <div class="setting-row">
         <label class="checkbox">
           <input type="checkbox" id="force" aria-describedby="forceHint" />
@@ -34,13 +34,13 @@
         </label>
         <span class="hint" id="forceHint" style="display: block; margin-left: 20px; margin-top: 2px;">Archive every task, ignoring state and matching open Pull Requests</span>
       </div>
-      <div class="setting-row">
-        <label id="scopeLabel">Scope</label>
-        <div class="radio-group" role="radiogroup" aria-labelledby="scopeLabel">
+      <fieldset class="setting-row">
+        <legend>Scope</legend>
+        <div class="radio-group">
           <label><input type="radio" name="scope" value="current" /> Current tab</label>
           <label><input type="radio" name="scope" value="all" checked /> All Jules tabs</label>
         </div>
-      </div>
+      </fieldset>
     </section>
 
     <section class="settings">

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -435,11 +435,13 @@ describe('popup.html accessibility', () => {
     )
   })
 
-  it('should use explicit visible labels for radio groups via aria-labelledby', () => {
-    assert.ok(popupHtml.includes('id="execModeLabel"'), 'execModeLabel should exist')
-    assert.ok(popupHtml.includes('aria-labelledby="execModeLabel"'), 'mode radiogroup should use aria-labelledby')
-    assert.ok(popupHtml.includes('id="scopeLabel"'), 'scopeLabel should exist')
-    assert.ok(popupHtml.includes('aria-labelledby="scopeLabel"'), 'scope radiogroup should use aria-labelledby')
+  it('should use native fieldset and legend for grouped controls', () => {
+    assert.ok(popupHtml.includes('<fieldset class="setting-row">'), 'should use fieldset for setting rows')
+    assert.ok(popupHtml.includes('<legend>Execution Mode</legend>'), 'should use native legend for execution mode')
+    assert.ok(popupHtml.includes('<legend>Scope</legend>'), 'should use native legend for scope')
+    assert.ok(popupHtml.includes('<legend>Operation</legend>'), 'should use native legend for operation')
+    assert.ok(!popupHtml.includes('role="radiogroup"'), 'should not use explicit radiogroup role on div')
+    assert.ok(!popupHtml.includes('role="group"'), 'should not use explicit group role on div')
   })
 })
 


### PR DESCRIPTION
💡 **What:** Replaced `div` elements that use ARIA `role="group"` and `role="radiogroup"` with native HTML `<fieldset>` and `<legend>` elements.
🎯 **Why:** To improve native screen-reader support and semantic structure, aligning with web accessibility best practices (preferring native HTML over ARIA attributes).
📸 **Before/After:** The visual design remains identical due to CSS resets applied to the new semantic elements. (Verified via local testing).
♿ **Accessibility:** Replaces invisible ARIA attributes and roles with native, semantic HTML elements (`<fieldset>` and `<legend>`) which provide better default behavior and parsing by assistive technologies.

---
*PR created automatically by Jules for task [11156367287283793560](https://jules.google.com/task/11156367287283793560) started by @n24q02m*