### PR TITLE
🎨 Palette: [UX improvement] Semantic HTML for form control grouping

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -31,3 +31,6 @@
 ## 2026-06-09 - Empty State Feedback
 **Learning:** When a list or process finishes with zero results, an empty summary container gives no feedback, leaving the user wondering if it actually ran or failed silently.
 **Action:** Always provide a helpful empty state message explaining why no results might have occurred, using styles consistent with other hints to offer guidance without showing as an error.
+## 2026-10-26 - Semantic Form Control Grouping
+**Learning:** Using explicit ARIA attributes (`role="group"`, `aria-labelledby`) on generic `<div>` elements for grouping form controls introduces unnecessary complexity and potential inconsistencies for assistive technologies, especially when visual presentation doesn't naturally match standard label behavior.
+**Action:** Always prefer native semantic HTML elements (`<fieldset>` and `<legend>`) over generic `<div>` tags with ARIA roles when grouping related form controls (like radio buttons). To prevent breaking existing CSS layouts (e.g. flexbox), apply a CSS reset (`border: none; padding: 0; margin: 0;`) to the `<fieldset>` and style the `<legend>` to match `<label>` appearance.

--- a/popup.css
+++ b/popup.css
@@ -50,7 +50,14 @@ section {
   border-radius: 6px;
 }
 
-label {
+fieldset {
+  border: none;
+  padding: 0;
+  margin: 0;
+}
+
+label,
+legend {
   display: block;
   font-size: 12px;
   color: #94a3b8;
@@ -85,7 +92,8 @@ input[type="password"]:focus {
   margin-bottom: 8px;
 }
 
-.setting-row label {
+.setting-row label,
+.setting-row legend {
   margin-bottom: 4px;
 }
 

--- a/popup.html
+++ b/popup.html
@@ -13,20 +13,20 @@
 
     <section class="options">
       <h2>Options</h2>
-      <div class="setting-row">
-        <label id="opModeLabel">Operation</label>
-        <div class="segmented" id="opMode" role="group" aria-labelledby="opModeLabel">
+      <fieldset class="setting-row">
+        <legend id="opModeLabel">Operation</legend>
+        <div class="segmented" id="opMode">
           <button type="button" data-value="archive" class="active" aria-pressed="true">Archive Tasks</button>
           <button type="button" data-value="suggestions" aria-pressed="false">Start Suggestions</button>
         </div>
-      </div>
-      <div class="setting-row">
-        <label id="execModeLabel">Execution Mode</label>
-        <div class="radio-group" role="radiogroup" aria-labelledby="execModeLabel">
+      </fieldset>
+      <fieldset class="setting-row">
+        <legend id="execModeLabel">Execution Mode</legend>
+        <div class="radio-group">
           <label><input type="radio" name="mode" value="dry" checked /> Dry Run</label>
           <label><input type="radio" name="mode" value="run" /> Run</label>
         </div>
-      </div>
+      </fieldset>
       <div class="setting-row">
         <label class="checkbox">
           <input type="checkbox" id="force" aria-describedby="forceHint" />
@@ -34,13 +34,13 @@
         </label>
         <span class="hint" id="forceHint" style="display: block; margin-left: 20px; margin-top: 2px;">Archive every task, ignoring state and matching open Pull Requests</span>
       </div>
-      <div class="setting-row">
-        <label id="scopeLabel">Scope</label>
-        <div class="radio-group" role="radiogroup" aria-labelledby="scopeLabel">
+      <fieldset class="setting-row">
+        <legend id="scopeLabel">Scope</legend>
+        <div class="radio-group">
           <label><input type="radio" name="scope" value="current" /> Current tab</label>
           <label><input type="radio" name="scope" value="all" checked /> All Jules tabs</label>
         </div>
-      </div>
+      </fieldset>
     </section>
 
     <section class="settings">

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -435,11 +435,18 @@ describe('popup.html accessibility', () => {
     )
   })
 
-  it('should use explicit visible labels for radio groups via aria-labelledby', () => {
-    assert.ok(popupHtml.includes('id="execModeLabel"'), 'execModeLabel should exist')
-    assert.ok(popupHtml.includes('aria-labelledby="execModeLabel"'), 'mode radiogroup should use aria-labelledby')
-    assert.ok(popupHtml.includes('id="scopeLabel"'), 'scopeLabel should exist')
-    assert.ok(popupHtml.includes('aria-labelledby="scopeLabel"'), 'scope radiogroup should use aria-labelledby')
+  it('should use native fieldset and legend elements for grouping controls', () => {
+    assert.ok(popupHtml.includes('<fieldset class="setting-row">'), 'should use fieldset for grouping')
+    assert.ok(popupHtml.includes('<legend id="execModeLabel">'), 'execModeLabel should be a legend element')
+    assert.ok(
+      !popupHtml.includes('aria-labelledby="execModeLabel"'),
+      'should remove redundant aria-labelledby on mode radiogroup'
+    )
+    assert.ok(popupHtml.includes('<legend id="scopeLabel">'), 'scopeLabel should be a legend element')
+    assert.ok(
+      !popupHtml.includes('aria-labelledby="scopeLabel"'),
+      'should remove redundant aria-labelledby on scope radiogroup'
+    )
   })
 })
 


### PR DESCRIPTION
💡 What:
Replaced generic `<div class="setting-row">` containers that act as groups with native semantic `<fieldset>` tags. Converted their explicit heading `<label>` elements to `<legend>` tags, and removed redundant ARIA attributes (`role="radiogroup"`, `role="group"`, `aria-labelledby`) from the inner containers. Added CSS reset for `<fieldset>` to preserve layout and mapped `<label>` styling to `<legend>`.

🎯 Why:
Using native semantic elements (`<fieldset>` and `<legend>`) is a superior accessibility practice compared to relying on generic `<div>` tags paired with `role` and `aria-labelledby` attributes. It provides immediate, out-of-the-box structural meaning to screen readers and reduces markup complexity and maintenance surface area.

📸 Before/After:
(Visually identical, structural change only. See verification screenshot in PR).

♿ Accessibility:
- Replaced synthetic `role="radiogroup"` and `role="group"` with native `<fieldset>`.
- Replaced synthetic grouping labels (`aria-labelledby`) with native `<legend>` elements.
- Cleaned up redundant ARIA attributes.
- Ensured keyboard navigation and focus states remain unaffected by layout preservation.

---
*PR created automatically by Jules for task [4897535285164563902](https://jules.google.com/task/4897535285164563902) started by @n24q02m*