### PR TITLE
[FIX] Complexity: groupTasksByRepo uses verbose map initialization

### DIFF
--- a/background.js
+++ b/background.js
@@ -319,13 +319,7 @@ function isArchivable(task) {
   return task.state == null || ARCHIVABLE_STATES.has(task.state)
 }
 function groupTasksByRepo(tasks) {
-  const map = new Map()
-  for (const t of tasks) {
-    const key = t.repo || '(no repo)'
-    if (!map.has(key)) map.set(key, [])
-    map.get(key).push(t)
-  }
-  return map
+  return Map.groupBy(tasks, (t) => t.repo || '(no repo)')
 }
 
 async function listTasks(filter, config) {


### PR DESCRIPTION
Refactored the groupTasksByRepo function in background.js to use Map.groupBy. This change replaces a verbose manual loop and map initialization with a more concise and modern native API call, reducing code complexity and improving maintainability.

---
*PR created automatically by Jules for task [3660791220850897369](https://jules.google.com/task/3660791220850897369) started by @n24q02m*