### PR TITLE
[TEST] Missing error test for DOM extraction failure in getAccountNum

### DIFF
--- a/content.js
+++ b/content.js
@@ -71,6 +71,17 @@ function extractConfig() {
 // Detect account from URL
 function getAccountNum() {
   try {
+    // First try the robust DOM approach
+    const el = document.querySelector('c-wiz[data-is-main-wiz]')
+    if (el) {
+      const authUser = el.getAttribute('data-auth-user')
+      if (authUser) return authUser
+    }
+  } catch (_e) {
+    // Ignore DOM errors
+  }
+
+  try {
     const parts = new URL(location.href).pathname.split('/')
     const uIdx = parts.indexOf('u')
     const val = uIdx !== -1 && parts[uIdx + 1] ? parts[uIdx + 1] : '0'

--- a/tests/content_account.test.js
+++ b/tests/content_account.test.js
@@ -29,7 +29,8 @@ function setupContentSandbox(initialUrl = 'https://jules.google.com/u/0/') {
         if (el.onload) el.onload()
       }
     },
-    documentElement: {}
+    documentElement: {},
+    querySelector: () => null
   }
 
   const window = {
@@ -52,9 +53,11 @@ function setupContentSandbox(initialUrl = 'https://jules.google.com/u/0/') {
     setTimeout,
     clearTimeout,
     Promise,
-    Date
+    Date,
+    TEST_MODE: true
   }
 
+  sandbox.globalThis = sandbox
   vm.createContext(sandbox)
   vm.runInContext(contentJsContent, sandbox)
 
@@ -86,5 +89,50 @@ describe('content.js getAccountLabel', () => {
     const sandbox = setupContentSandbox('not-a-url')
     // getAccountNum has a try-catch that returns '0' on error
     assert.strictEqual(sandbox.getAccountLabel(), 'default')
+  })
+
+  it('should extract account from DOM if present', () => {
+    const sandbox = setupContentSandbox('https://jules.google.com/tasks')
+    sandbox.document.querySelector = (selector) => {
+      if (selector === 'c-wiz[data-is-main-wiz]') {
+        return {
+          getAttribute: (name) => {
+            if (name === 'data-auth-user') return '2'
+            return null
+          }
+        }
+      }
+      return null
+    }
+    assert.strictEqual(sandbox.test_getAccountNum(), '2')
+    assert.strictEqual(sandbox.getAccountLabel(), 'u/2')
+  })
+
+  it('should fall back to URL if DOM extraction fails (element missing)', () => {
+    const sandbox = setupContentSandbox('https://jules.google.com/u/3/tasks')
+    sandbox.document.querySelector = () => null
+    assert.strictEqual(sandbox.test_getAccountNum(), '3')
+  })
+
+  it('should fall back to URL if DOM extraction fails (attribute missing)', () => {
+    const sandbox = setupContentSandbox('https://jules.google.com/u/4/tasks')
+    sandbox.document.querySelector = (selector) => {
+      if (selector === 'c-wiz[data-is-main-wiz]') {
+        return {
+          getAttribute: () => null
+        }
+      }
+      return null
+    }
+    assert.strictEqual(sandbox.test_getAccountNum(), '4')
+  })
+
+  it('should fall back to URL if querySelector throws', () => {
+    const sandbox = setupContentSandbox('https://jules.google.com/u/5/tasks')
+    sandbox.document.querySelector = () => {
+      throw new Error('DOM Error')
+    }
+    // Should catch the error and fall back to URL
+    assert.strictEqual(sandbox.test_getAccountNum(), '5')
   })
 })


### PR DESCRIPTION
Implemented robust DOM extraction in getAccountNum using c-wiz[data-is-main-wiz]. Added try-catch protection around DOM operations with graceful fallback to URL parsing. Enhanced tests/content_account.test.js with comprehensive coverage for successful DOM extraction and various fallback scenarios (missing element, missing attribute, DOM error).

---
*PR created automatically by Jules for task [1318941243482812240](https://jules.google.com/task/1318941243482812240) started by @n24q02m*