### PR TITLE
🎨 Palette: [a11y] Replace pseudo-labels with semantic fieldset and legend

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -31,3 +31,6 @@
 ## 2026-06-09 - Empty State Feedback
 **Learning:** When a list or process finishes with zero results, an empty summary container gives no feedback, leaving the user wondering if it actually ran or failed silently.
 **Action:** Always provide a helpful empty state message explaining why no results might have occurred, using styles consistent with other hints to offer guidance without showing as an error.
+## 2026-10-25 - Native Semantic Option Groups
+**Learning:** Using `role="group"` and `role="radiogroup"` with pseudo-label `<div>` elements mapped via `aria-labelledby` triggers accessibility linting errors. Sighted and screen reader users alike benefit from native semantic groupings.
+**Action:** Always replace generic grouping wrappers and pseudo-labels for grouped controls (like segmented buttons or radio groups) with native `<fieldset>` and `<legend>` elements to ensure correct semantics without extra ARIA markup.

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.1/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
@@ -33,7 +33,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "suspicious": {
         "noExplicitAny": "off",
         "noImplicitAnyLet": "off"

--- a/popup.css
+++ b/popup.css
@@ -50,7 +50,15 @@ section {
   border-radius: 6px;
 }
 
-label {
+fieldset {
+  border: none;
+  padding: 0;
+  margin: 0;
+  min-width: 0;
+}
+
+label,
+legend {
   display: block;
   font-size: 12px;
   color: #94a3b8;
@@ -85,8 +93,10 @@ input[type="password"]:focus {
   margin-bottom: 8px;
 }
 
-.setting-row label {
+.setting-row label,
+.setting-row legend {
   margin-bottom: 4px;
+  padding: 0;
 }
 
 .segmented {

--- a/popup.html
+++ b/popup.html
@@ -13,20 +13,20 @@
 
     <section class="options">
       <h2>Options</h2>
-      <div class="setting-row">
-        <label id="opModeLabel">Operation</label>
-        <div class="segmented" id="opMode" role="group" aria-labelledby="opModeLabel">
+      <fieldset class="setting-row">
+        <legend>Operation</legend>
+        <div class="segmented" id="opMode">
           <button type="button" data-value="archive" class="active" aria-pressed="true">Archive Tasks</button>
           <button type="button" data-value="suggestions" aria-pressed="false">Start Suggestions</button>
         </div>
-      </div>
-      <div class="setting-row">
-        <label id="execModeLabel">Execution Mode</label>
-        <div class="radio-group" role="radiogroup" aria-labelledby="execModeLabel">
+      </fieldset>
+      <fieldset class="setting-row">
+        <legend>Execution Mode</legend>
+        <div class="radio-group">
           <label><input type="radio" name="mode" value="dry" checked /> Dry Run</label>
           <label><input type="radio" name="mode" value="run" /> Run</label>
         </div>
-      </div>
+      </fieldset>
       <div class="setting-row">
         <label class="checkbox">
           <input type="checkbox" id="force" aria-describedby="forceHint" />
@@ -34,13 +34,13 @@
         </label>
         <span class="hint" id="forceHint" style="display: block; margin-left: 20px; margin-top: 2px;">Archive every task, ignoring state and matching open Pull Requests</span>
       </div>
-      <div class="setting-row">
-        <label id="scopeLabel">Scope</label>
-        <div class="radio-group" role="radiogroup" aria-labelledby="scopeLabel">
+      <fieldset class="setting-row">
+        <legend>Scope</legend>
+        <div class="radio-group">
           <label><input type="radio" name="scope" value="current" /> Current tab</label>
           <label><input type="radio" name="scope" value="all" checked /> All Jules tabs</label>
         </div>
-      </div>
+      </fieldset>
     </section>
 
     <section class="settings">

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -435,11 +435,13 @@ describe('popup.html accessibility', () => {
     )
   })
 
-  it('should use explicit visible labels for radio groups via aria-labelledby', () => {
-    assert.ok(popupHtml.includes('id="execModeLabel"'), 'execModeLabel should exist')
-    assert.ok(popupHtml.includes('aria-labelledby="execModeLabel"'), 'mode radiogroup should use aria-labelledby')
-    assert.ok(popupHtml.includes('id="scopeLabel"'), 'scopeLabel should exist')
-    assert.ok(popupHtml.includes('aria-labelledby="scopeLabel"'), 'scope radiogroup should use aria-labelledby')
+  it('should use native semantic fieldset and legend for option groups', () => {
+    assert.ok(popupHtml.includes('<fieldset class="setting-row">'), 'should use fieldset elements')
+    assert.ok(popupHtml.includes('<legend>Operation</legend>'), 'Operation group should use legend')
+    assert.ok(popupHtml.includes('<legend>Execution Mode</legend>'), 'Execution Mode group should use legend')
+    assert.ok(popupHtml.includes('<legend>Scope</legend>'), 'Scope group should use legend')
+    assert.ok(!popupHtml.includes('role="group"'), 'should not use generic role="group"')
+    assert.ok(!popupHtml.includes('role="radiogroup"'), 'should not use generic role="radiogroup"')
   })
 })
 


### PR DESCRIPTION
**💡 What:** Replaced generic `<div role="group">` wrappers and pseudo-labels mapped via `aria-labelledby` with native semantic HTML `<fieldset>` and `<legend>` elements in `popup.html`. Updated `popup.css` to reset default fieldset borders and maintain visual consistency for legends.

**🎯 Why:** To resolve `lint/a11y/noLabelWithoutControl` and `lint/a11y/useSemanticElements` errors reported by Biome. Native semantic elements provide better structure and built-in accessibility for sighted and screen-reader users without relying on complex ARIA markup.

**📸 Before/After:** Visually identical. Under the hood, form options are now properly grouped and labeled.

**♿ Accessibility:**
* Fixed form labels not being associated with inputs.
* Replaced non-semantic `role="group"` and `role="radiogroup"` `div`s with native `fieldset`.
* Replaced pseudo-labels with native `legend`.

---
*PR created automatically by Jules for task [14631180878217447934](https://jules.google.com/task/14631180878217447934) started by @n24q02m*