### PR TITLE
🎨 Palette: Semantic fieldsets for form groups

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -31,3 +31,6 @@
 ## 2026-06-09 - Empty State Feedback
 **Learning:** When a list or process finishes with zero results, an empty summary container gives no feedback, leaving the user wondering if it actually ran or failed silently.
 **Action:** Always provide a helpful empty state message explaining why no results might have occurred, using styles consistent with other hints to offer guidance without showing as an error.
+## 2025-06-25 - Semantic Form Group Accessibility
+**Learning:** Using generic containers (`<div role="group">`) with pseudo-labels (`<label id="...">` and `aria-labelledby`) for grouped form controls (like segmented controls or radio groups) creates a fragile accessibility experience. While technically valid ARIA, it lacks native semantic meaning, can be parsed inconsistently by different screen readers, and requires manual ID management which is prone to copy-paste errors.
+**Action:** Always use native HTML `<fieldset>` and `<legend>` elements to group related form controls instead of generic `div`s with ARIA roles. This provides built-in semantic meaning and grouping for assistive technologies without needing manual ID associations. To maintain visual design, wrap the existing layout structures inside a visually reset `<fieldset>` and style the `<legend>` to match the previous label text.

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.1/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
@@ -33,7 +33,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "suspicious": {
         "noExplicitAny": "off",
         "noImplicitAnyLet": "off"

--- a/popup.css
+++ b/popup.css
@@ -50,7 +50,8 @@ section {
   border-radius: 6px;
 }
 
-label {
+label,
+legend {
   display: block;
   font-size: 12px;
   color: #94a3b8;

--- a/popup.html
+++ b/popup.html
@@ -14,18 +14,22 @@
     <section class="options">
       <h2>Options</h2>
       <div class="setting-row">
-        <label id="opModeLabel">Operation</label>
-        <div class="segmented" id="opMode" role="group" aria-labelledby="opModeLabel">
-          <button type="button" data-value="archive" class="active" aria-pressed="true">Archive Tasks</button>
-          <button type="button" data-value="suggestions" aria-pressed="false">Start Suggestions</button>
-        </div>
+        <fieldset style="border: none; padding: 0; margin: 0;">
+          <legend>Operation</legend>
+          <div class="segmented" id="opMode">
+            <button type="button" data-value="archive" class="active" aria-pressed="true">Archive Tasks</button>
+            <button type="button" data-value="suggestions" aria-pressed="false">Start Suggestions</button>
+          </div>
+        </fieldset>
       </div>
       <div class="setting-row">
-        <label id="execModeLabel">Execution Mode</label>
-        <div class="radio-group" role="radiogroup" aria-labelledby="execModeLabel">
-          <label><input type="radio" name="mode" value="dry" checked /> Dry Run</label>
-          <label><input type="radio" name="mode" value="run" /> Run</label>
-        </div>
+        <fieldset style="border: none; padding: 0; margin: 0;">
+          <legend>Execution Mode</legend>
+          <div class="radio-group">
+            <label><input type="radio" name="mode" value="dry" checked /> Dry Run</label>
+            <label><input type="radio" name="mode" value="run" /> Run</label>
+          </div>
+        </fieldset>
       </div>
       <div class="setting-row">
         <label class="checkbox">
@@ -35,11 +39,13 @@
         <span class="hint" id="forceHint" style="display: block; margin-left: 20px; margin-top: 2px;">Archive every task, ignoring state and matching open Pull Requests</span>
       </div>
       <div class="setting-row">
-        <label id="scopeLabel">Scope</label>
-        <div class="radio-group" role="radiogroup" aria-labelledby="scopeLabel">
-          <label><input type="radio" name="scope" value="current" /> Current tab</label>
-          <label><input type="radio" name="scope" value="all" checked /> All Jules tabs</label>
-        </div>
+        <fieldset style="border: none; padding: 0; margin: 0;">
+          <legend>Scope</legend>
+          <div class="radio-group">
+            <label><input type="radio" name="scope" value="current" /> Current tab</label>
+            <label><input type="radio" name="scope" value="all" checked /> All Jules tabs</label>
+          </div>
+        </fieldset>
       </div>
     </section>
 

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -435,11 +435,11 @@ describe('popup.html accessibility', () => {
     )
   })
 
-  it('should use explicit visible labels for radio groups via aria-labelledby', () => {
-    assert.ok(popupHtml.includes('id="execModeLabel"'), 'execModeLabel should exist')
-    assert.ok(popupHtml.includes('aria-labelledby="execModeLabel"'), 'mode radiogroup should use aria-labelledby')
-    assert.ok(popupHtml.includes('id="scopeLabel"'), 'scopeLabel should exist')
-    assert.ok(popupHtml.includes('aria-labelledby="scopeLabel"'), 'scope radiogroup should use aria-labelledby')
+  it('should use semantic fieldset and legend elements for form groups', () => {
+    assert.ok(popupHtml.includes('<fieldset'), 'fieldset element should exist')
+    assert.ok(popupHtml.includes('<legend>Operation</legend>'), 'Operation legend should exist')
+    assert.ok(popupHtml.includes('<legend>Execution Mode</legend>'), 'Execution Mode legend should exist')
+    assert.ok(popupHtml.includes('<legend>Scope</legend>'), 'Scope legend should exist')
   })
 })
 


### PR DESCRIPTION
💡 What: Replaced generic `<div role="group">` and `<div role="radiogroup">` containers (which used `aria-labelledby` pseudo-labels) with native, semantic `<fieldset>` and `<legend>` elements in `popup.html`. Updated `popup.css` to style the new `<legend>` tags identically to the previous `<label>` elements.
🎯 Why: Grouped form controls rely on programmatic association for screen readers to properly announce the context. While ARIA roles can accomplish this, using native HTML elements like `<fieldset>` is the recommended, robust standard. It prevents brittle mapping (e.g. `aria-labelledby="some-id"`), parses consistently across all screen readers, and is fundamentally better semantic code without affecting visual appearance.
♿ Accessibility: Radically improves screen reader context when tabbing into segmented controls or radio button groups by natively announcing the legend string.

Also fixed a deprecated Biome configuration (`recommended: true` -> `preset: recommended`) discovered during testing/linting.

---
*PR created automatically by Jules for task [9962073680512650719](https://jules.google.com/task/9962073680512650719) started by @n24q02m*