### PR TITLE
🎨 Palette: Improve accessibility of form groups

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -31,3 +31,6 @@
 ## 2026-06-09 - Empty State Feedback
 **Learning:** When a list or process finishes with zero results, an empty summary container gives no feedback, leaving the user wondering if it actually ran or failed silently.
 **Action:** Always provide a helpful empty state message explaining why no results might have occurred, using styles consistent with other hints to offer guidance without showing as an error.
+## 2025-06-25 - Semantic Grouping for Form Controls
+**Learning:** Using a generic `div role="group"` with a pseudo-label (e.g. `<label id="...">` and `aria-labelledby`) for logical form groups (like operation selection or execution mode) triggers accessibility warnings (`noLabelWithoutControl`) because `<label>` elements are intended exclusively for interactive form controls like inputs, not container elements. Furthermore, structural wrappers are less semantically robust than native grouping elements.
+**Action:** Always replace logical form groupings with native `<fieldset>` and `<legend>` elements to provide semantically correct and universally supported accessibility. When migrating existing visual designs, wrap the layout in a reset `<fieldset>` (`border: none; padding: 0; margin: 0;`) and style the `<legend>` to match the previous pseudo-label, avoiding the need for complex custom CSS classes or new design tokens.

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.1/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
@@ -33,7 +33,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "suspicious": {
         "noExplicitAny": "off",
         "noImplicitAnyLet": "off"

--- a/popup.css
+++ b/popup.css
@@ -50,7 +50,14 @@ section {
   border-radius: 6px;
 }
 
-label {
+fieldset {
+  border: none;
+  padding: 0;
+  margin: 0;
+}
+
+label,
+legend {
   display: block;
   font-size: 12px;
   color: #94a3b8;

--- a/popup.html
+++ b/popup.html
@@ -14,18 +14,22 @@
     <section class="options">
       <h2>Options</h2>
       <div class="setting-row">
-        <label id="opModeLabel">Operation</label>
-        <div class="segmented" id="opMode" role="group" aria-labelledby="opModeLabel">
-          <button type="button" data-value="archive" class="active" aria-pressed="true">Archive Tasks</button>
-          <button type="button" data-value="suggestions" aria-pressed="false">Start Suggestions</button>
-        </div>
+        <fieldset>
+          <legend>Operation</legend>
+          <div class="segmented" id="opMode">
+            <button type="button" data-value="archive" class="active" aria-pressed="true">Archive Tasks</button>
+            <button type="button" data-value="suggestions" aria-pressed="false">Start Suggestions</button>
+          </div>
+        </fieldset>
       </div>
       <div class="setting-row">
-        <label id="execModeLabel">Execution Mode</label>
-        <div class="radio-group" role="radiogroup" aria-labelledby="execModeLabel">
-          <label><input type="radio" name="mode" value="dry" checked /> Dry Run</label>
-          <label><input type="radio" name="mode" value="run" /> Run</label>
-        </div>
+        <fieldset>
+          <legend>Execution Mode</legend>
+          <div class="radio-group">
+            <label><input type="radio" name="mode" value="dry" checked /> Dry Run</label>
+            <label><input type="radio" name="mode" value="run" /> Run</label>
+          </div>
+        </fieldset>
       </div>
       <div class="setting-row">
         <label class="checkbox">
@@ -35,11 +39,13 @@
         <span class="hint" id="forceHint" style="display: block; margin-left: 20px; margin-top: 2px;">Archive every task, ignoring state and matching open Pull Requests</span>
       </div>
       <div class="setting-row">
-        <label id="scopeLabel">Scope</label>
-        <div class="radio-group" role="radiogroup" aria-labelledby="scopeLabel">
-          <label><input type="radio" name="scope" value="current" /> Current tab</label>
-          <label><input type="radio" name="scope" value="all" checked /> All Jules tabs</label>
-        </div>
+        <fieldset>
+          <legend>Scope</legend>
+          <div class="radio-group">
+            <label><input type="radio" name="scope" value="current" /> Current tab</label>
+            <label><input type="radio" name="scope" value="all" checked /> All Jules tabs</label>
+          </div>
+        </fieldset>
       </div>
     </section>
 

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -435,11 +435,10 @@ describe('popup.html accessibility', () => {
     )
   })
 
-  it('should use explicit visible labels for radio groups via aria-labelledby', () => {
-    assert.ok(popupHtml.includes('id="execModeLabel"'), 'execModeLabel should exist')
-    assert.ok(popupHtml.includes('aria-labelledby="execModeLabel"'), 'mode radiogroup should use aria-labelledby')
-    assert.ok(popupHtml.includes('id="scopeLabel"'), 'scopeLabel should exist')
-    assert.ok(popupHtml.includes('aria-labelledby="scopeLabel"'), 'scope radiogroup should use aria-labelledby')
+  it('should use explicit semantic fieldset and legend for radio groups', () => {
+    assert.ok(popupHtml.includes('<fieldset>'), 'fieldset should exist')
+    assert.ok(popupHtml.includes('<legend>Execution Mode</legend>'), 'mode fieldset should use legend')
+    assert.ok(popupHtml.includes('<legend>Scope</legend>'), 'scope fieldset should use legend')
   })
 })
 


### PR DESCRIPTION
💡 **What:** Replaced generic `div` elements acting as form groups with semantic `<fieldset>` and `<legend>` elements.
🎯 **Why:** To improve accessibility for screen readers and resolve Biome lint warnings (`noLabelWithoutControl`). Using semantic HTML for form groupings is preferred over generic elements with ARIA roles.
📸 **Before/After:** Visually identical, but the DOM structure is now semantically correct.
♿ **Accessibility:** Form groups (Operation, Execution Mode, Scope) are now properly grouped using `fieldset` and labeled with `legend`, improving compatibility with assistive technologies.
🔧 **Other:** Also fixed a deprecation warning in `biome.json` by running `biome migrate`.

---
*PR created automatically by Jules for task [6668865122188099209](https://jules.google.com/task/6668865122188099209) started by @n24q02m*