### PR TITLE
🎨 Palette: Improve accessibility of input groups with fieldset/legend

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -31,3 +31,6 @@
 ## 2026-06-09 - Empty State Feedback
 **Learning:** When a list or process finishes with zero results, an empty summary container gives no feedback, leaving the user wondering if it actually ran or failed silently.
 **Action:** Always provide a helpful empty state message explaining why no results might have occurred, using styles consistent with other hints to offer guidance without showing as an error.
+## 2025-07-10 - Native Semantics for Grouped Inputs
+**Learning:** Using generic `div role="group"` or `div role="radiogroup"` with `aria-labelledby` creates brittle accessibility for grouped controls and often leads to linter warnings (like `noLabelWithoutControl`) because they lack native element association.
+**Action:** Always wrap related grouped inputs (like radio buttons or segmented controls) in a semantic `<fieldset>` and use a `<legend>` instead of a `<label>`. To maintain visual consistency without adding custom CSS, ensure the `<legend>` inherits the same styling as standard `<label>` elements.

--- a/popup.css
+++ b/popup.css
@@ -50,7 +50,8 @@ section {
   border-radius: 6px;
 }
 
-label {
+label,
+legend {
   display: block;
   font-size: 12px;
   color: #94a3b8;
@@ -85,7 +86,8 @@ input[type="password"]:focus {
   margin-bottom: 8px;
 }
 
-.setting-row label {
+.setting-row label,
+.setting-row legend {
   margin-bottom: 4px;
 }
 

--- a/popup.html
+++ b/popup.html
@@ -13,20 +13,20 @@
 
     <section class="options">
       <h2>Options</h2>
-      <div class="setting-row">
-        <label id="opModeLabel">Operation</label>
-        <div class="segmented" id="opMode" role="group" aria-labelledby="opModeLabel">
+      <fieldset class="setting-row" style="border: none; padding: 0; margin: 0;">
+        <legend id="opModeLabel">Operation</legend>
+        <div class="segmented" id="opMode">
           <button type="button" data-value="archive" class="active" aria-pressed="true">Archive Tasks</button>
           <button type="button" data-value="suggestions" aria-pressed="false">Start Suggestions</button>
         </div>
-      </div>
-      <div class="setting-row">
-        <label id="execModeLabel">Execution Mode</label>
-        <div class="radio-group" role="radiogroup" aria-labelledby="execModeLabel">
+      </fieldset>
+      <fieldset class="setting-row" style="border: none; padding: 0; margin: 0;">
+        <legend id="execModeLabel">Execution Mode</legend>
+        <div class="radio-group">
           <label><input type="radio" name="mode" value="dry" checked /> Dry Run</label>
           <label><input type="radio" name="mode" value="run" /> Run</label>
         </div>
-      </div>
+      </fieldset>
       <div class="setting-row">
         <label class="checkbox">
           <input type="checkbox" id="force" aria-describedby="forceHint" />
@@ -34,13 +34,13 @@
         </label>
         <span class="hint" id="forceHint" style="display: block; margin-left: 20px; margin-top: 2px;">Archive every task, ignoring state and matching open Pull Requests</span>
       </div>
-      <div class="setting-row">
-        <label id="scopeLabel">Scope</label>
-        <div class="radio-group" role="radiogroup" aria-labelledby="scopeLabel">
+      <fieldset class="setting-row" style="border: none; padding: 0; margin: 0;">
+        <legend id="scopeLabel">Scope</legend>
+        <div class="radio-group">
           <label><input type="radio" name="scope" value="current" /> Current tab</label>
           <label><input type="radio" name="scope" value="all" checked /> All Jules tabs</label>
         </div>
-      </div>
+      </fieldset>
     </section>
 
     <section class="settings">

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -435,11 +435,10 @@ describe('popup.html accessibility', () => {
     )
   })
 
-  it('should use explicit visible labels for radio groups via aria-labelledby', () => {
-    assert.ok(popupHtml.includes('id="execModeLabel"'), 'execModeLabel should exist')
-    assert.ok(popupHtml.includes('aria-labelledby="execModeLabel"'), 'mode radiogroup should use aria-labelledby')
-    assert.ok(popupHtml.includes('id="scopeLabel"'), 'scopeLabel should exist')
-    assert.ok(popupHtml.includes('aria-labelledby="scopeLabel"'), 'scope radiogroup should use aria-labelledby')
+  it('should use semantic fieldset and legend for input groups', () => {
+    assert.ok(popupHtml.includes('<fieldset class="setting-row"'), 'fieldset should be used to group inputs')
+    assert.ok(popupHtml.includes('<legend id="execModeLabel">'), 'legend should be used for execModeLabel')
+    assert.ok(popupHtml.includes('<legend id="scopeLabel">'), 'legend should be used for scopeLabel')
   })
 })
 


### PR DESCRIPTION
💡 What: Replaced generic `<div role="group">` and `<div role="radiogroup">` containers in `popup.html` with semantic HTML `<fieldset>` elements, updating pseudo-labels to `<legend>` tags.
🎯 Why: Grouped related form controls natively without relying on brittle ARIA structures like `aria-labelledby`, ensuring better robustness, mitigating `noLabelWithoutControl` issues when testing, and creating a more semantic DOM structure.
♿ Accessibility: Assistive technologies now correctly identify groups via standard HTML elements instead of injected `aria-*` parameters, reducing cognitive load and improving discoverability.
📸 Before/After: (Visual changes are identical thanks to a CSS reset on the fieldsets)

---
*PR created automatically by Jules for task [2241310738196096217](https://jules.google.com/task/2241310738196096217) started by @n24q02m*