### PR TITLE
fix: pin biome to 2.4.16 in CI to match biome.json schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,10 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Run Biome check
-        run: npx @biomejs/biome check .
+        # Pin to the version declared in biome.json $schema. Unpinned `npx @biomejs/biome`
+        # pulls latest, which auto-upgraded past 2.4.16 and broke CI with new lint rules
+        # and deprecated config keys despite no source changes.
+        run: npx @biomejs/biome@2.4.16 check .
 
       - name: Validate manifest.json
         run: |


### PR DESCRIPTION
## Problem
CI "Lint & Format" has been red on main since ~2026-06-12. Root cause: the lint job runs `npx @biomejs/biome check .` without a pinned version, so it pulls the latest Biome. Biome auto-upgraded past 2.4.16 (the version declared in `biome.json` $schema), introducing new lint rules (a11y: noLabelWithoutControl, useSemanticElements) and a deprecated-config warning. No source changed — only the tool.

## Verification
Checked out the repo with true LF line endings (Linux-equivalent) and ran `npx @biomejs/biome@2.4.16 check .` -> exit 0, zero errors. The committed blobs are already correctly formatted for 2.4.16; the only issue is the unpinned tool.

## Fix
Pin the Biome version in CI to 2.4.16 to match `biome.json` $schema. No code changes.