### PR TITLE
fix: harden postMessage trust check, batchexecute parsing, and config size limit

### DIFF
--- a/background.js
+++ b/background.js
@@ -244,6 +244,7 @@ function parseResponse(text, rpcId) {
   const jsonStr = text.substring(dataStart, jsonEnd)
   const fixed = fixJsonControlChars(jsonStr)
   const outer = JSON.parse(fixed)
+  if (!Array.isArray(outer)) throw new Error('Invalid batchexecute response: expected array')
 
   // Find the entry matching our rpcId
   for (const entry of outer) {
@@ -1260,6 +1261,16 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
       return true
 
     case 'CACHE_START_CONFIG':
+      try {
+        const payload = JSON.stringify(msg.config)
+        if (payload.length > 51200) {
+          sendResponse({ error: 'Security Error: Payload exceeds size limit' })
+          break
+        }
+      } catch (_e) {
+        sendResponse({ error: 'Security Error: Invalid payload' })
+        break
+      }
       chrome.storage.session.set({ startConfig: msg.config })
       sendResponse({ ok: true })
       break

--- a/content.js
+++ b/content.js
@@ -22,7 +22,11 @@ injectMainWorldScript()
 // The MAIN world script and isolated world share the same window and origin,
 // so anything failing these checks is a cross-origin/cross-frame spoof attempt.
 function isTrustedMessage(event) {
-  return event.source === window && event.origin === window.location.origin
+  if (event.source !== window || event.origin !== window.location.origin) return false
+  const type = event.data?.type
+  if (typeof type !== 'string' || !type.startsWith('JULES_')) return false
+  if (type.endsWith('_CONFIG') && type !== 'JULES_REQUEST_CONFIG' && !event.data?.config) return false
+  return true
 }
 
 // Listen for messages from MAIN world script

--- a/tests/security.test.js
+++ b/tests/security.test.js
@@ -396,4 +396,24 @@ describe('Orchestrator Privilege Escalation Security', () => {
     assert.strictEqual(responseData?.ok, true, 'Should allow CACHE_START_CONFIG from content script')
     assert.deepStrictEqual(sessionData.startConfig, { some: 'data' })
   })
+
+  it('should reject oversized CACHE_START_CONFIG payloads (storage-quota DoS)', () => {
+    const { onMessageListeners } = setupEnvironment()
+    const listener = onMessageListeners[0]
+
+    let responseData = null
+    const sendResponse = (data) => {
+      responseData = data
+    }
+
+    const sender = { tab: { id: 1 } }
+    const largeConfig = { data: 'a'.repeat(51201) }
+    listener({ action: 'CACHE_START_CONFIG', config: largeConfig }, sender, sendResponse)
+
+    assert.strictEqual(
+      responseData?.error,
+      'Security Error: Payload exceeds size limit',
+      'Should reject CACHE_START_CONFIG payload over 50KB'
+    )
+  })
 })


### PR DESCRIPTION
Consolidates the genuinely-valuable security hardenings from the Sentinel PR backlog into one clean commit (without the bundled biome 2.5.1 config bump that conflicts with the CI pin in #548, and without the unrelated popup.html a11y churn).

## Changes
1. **content.js `isTrustedMessage`** (from #547): in addition to source/origin checks, require `event.data.type` to be a string with the `JULES_` namespace prefix, and require a `.config` payload for `*_CONFIG` messages (except `JULES_REQUEST_CONFIG`). Defends the postMessage bridge against same-context spoofed payloads.
2. **background.js `parseResponse`** (from #520): assert the outer batchexecute envelope is an array before iterating, turning a malformed response into a clean error instead of a TypeError. (Inner-array assertion from #520 dropped — too risky, could break RPCs returning non-array results.)
3. **background.js `CACHE_START_CONFIG`** (from #543 cluster): bound the stored config to 50KB via JSON.stringify length (wrapped in try/catch for non-serializable input) to prevent chrome.storage.session quota exhaustion.

## Tests
All 235 unit tests pass (added: oversized CACHE_START_CONFIG rejection). No regressions.

Supersedes Sentinel PRs #547, #543/#539/#537/#534/#531/#506/#504/#501/#497/#495 (storage DoS), #520 (type validation). Declines #484 (Math.random for retry jitter is not security-sensitive) and #529 (Enterprise-GitHub URL configurability is a feature, not a security fix).