### PR TITLE
feat: archive tasks in batches to cut API call count

### DIFF
--- a/background.js
+++ b/background.js
@@ -22,6 +22,9 @@ const API_CONCURRENCY = 5
 // (which rate-limits with HTTP 429). Retries with backoff absorb the rest.
 const PER_ACCOUNT_CONCURRENCY = 6
 const GLOBAL_CONCURRENCY = 12
+// Tjmm5c (ArchiveTask) accepts an array of task IDs, so archive in batches to cut
+// the request count (was 1 request per task). One batch = one batchexecute call.
+const ARCHIVE_BATCH_SIZE = 50
 
 // ⚡ Bolt Optimization: After parsing the URL, use a fast regex test to extract
 // the account ID instead of allocating string arrays via `.split('/')`. This avoids
@@ -372,9 +375,9 @@ async function safeListTasks(label, config) {
   }
 }
 
-async function archiveTask(taskId, config) {
+async function archiveTasks(taskIds, config) {
   const payload = new Array(2).fill(null)
-  payload[TJMM5C.TASK_IDS] = [taskId]
+  payload[TJMM5C.TASK_IDS] = taskIds
   payload[TJMM5C.ACTION] = 1
   await callBatchExecute('Tjmm5c', payload, config)
 }
@@ -401,8 +404,8 @@ async function withRetry(fn) {
   }
 }
 
-function archiveTaskWithRetry(taskId, config) {
-  return withRetry(() => archiveTask(taskId, config))
+function archiveTasksWithRetry(taskIds, config) {
+  return withRetry(() => archiveTasks(taskIds, config))
 }
 
 // =============================================================================
@@ -1130,23 +1133,31 @@ async function executeArchive(label, toArchive, config) {
   let grandTotal = 0
   let lastUpdate = 0
 
-  await runInPool(toArchive, PER_ACCOUNT_CONCURRENCY, async (task) => {
+  const batches = []
+  for (let i = 0; i < toArchive.length; i += ARCHIVE_BATCH_SIZE) {
+    batches.push(toArchive.slice(i, i + ARCHIVE_BATCH_SIZE))
+  }
+
+  await runInPool(batches, PER_ACCOUNT_CONCURRENCY, async (batch) => {
+    const taskIds = batch.map((t) => t.id)
     const now = Date.now()
     if (now - lastUpdate > 500) {
-      updateState({ currentRepo: task.repo || '(no repo)' })
+      updateState({ currentRepo: batch[0].repo || '(no repo)' })
       lastUpdate = now
     }
     try {
-      await globalLimit(() => archiveTaskWithRetry(task.id, config))
-      grandTotal++
-      state.progress.archived += 1
+      await globalLimit(() => archiveTasksWithRetry(taskIds, config))
+      grandTotal += batch.length
+      state.progress.archived += batch.length
       if (Date.now() - lastUpdate > 500) {
         updateState({})
         lastUpdate = Date.now()
       }
-      addLog(`  Archived [${label}] [${task.id}] ${task.title}`)
+      for (const task of batch) {
+        addLog(`  Archived [${label}] [${task.id}] ${task.title}`)
+      }
     } catch (e) {
-      addLog(`  ERROR [${label}] archiving ${task.id}: ${e.message}`)
+      addLog(`  ERROR [${label}] archiving batch: ${e.message}`)
     }
   })
   return grandTotal

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -104,7 +104,7 @@ function setupEnvironment(initialStorage = {}) {
     globalThis.test_callBatchExecute = callBatchExecute;
     globalThis.test_runInPool = runInPool;
     globalThis.test_createLimiter = createLimiter;
-    globalThis.test_archiveTaskWithRetry = archiveTaskWithRetry;
+    globalThis.test_archiveTasksWithRetry = archiveTasksWithRetry;
     globalThis.test_withRetry = withRetry;
     globalThis.test_isRetryable = isRetryable;
     globalThis.test_RETRY_ATTEMPTS = RETRY_ATTEMPTS;
@@ -556,27 +556,27 @@ describe('Retry Utilities', () => {
   })
 })
 
-describe('archiveTaskWithRetry Integration', () => {
+describe('archiveTasksWithRetry Integration', () => {
   it('retries on a 429 then succeeds', async () => {
     const { sandbox } = setupEnvironment()
     let calls = 0
-    sandbox.archiveTask = async () => {
+    sandbox.archiveTasks = async () => {
       calls++
       if (calls === 1) throw new Error('batchexecute Tjmm5c failed: HTTP 429')
     }
     sandbox.setTimeout = (fn) => fn()
-    await sandbox.test_archiveTaskWithRetry('t1', {})
+    await sandbox.test_archiveTasksWithRetry(['t1'], {})
     assert.strictEqual(calls, 2)
   })
 
   it('does not retry a non-retryable error', async () => {
     const { sandbox } = setupEnvironment()
     let calls = 0
-    sandbox.archiveTask = async () => {
+    sandbox.archiveTasks = async () => {
       calls++
       throw new Error('HTTP 404')
     }
-    await assert.rejects(sandbox.test_archiveTaskWithRetry('t1', {}), { message: 'HTTP 404' })
+    await assert.rejects(sandbox.test_archiveTasksWithRetry(['t1'], {}), { message: 'HTTP 404' })
     assert.strictEqual(calls, 1)
   })
 })
@@ -712,8 +712,8 @@ describe('processTab force vs default archiving', () => {
     sandbox.listTasks = async () => tasks
     sandbox.getOpenPRs = async () => []
     const archived = []
-    sandbox.archiveTask = async (id) => {
-      archived.push(id)
+    sandbox.archiveTasks = async (ids) => {
+      archived.push(...ids)
     }
     return { sandbox, archived }
   }

--- a/tests/perf.test.js
+++ b/tests/perf.test.js
@@ -137,9 +137,11 @@ describe('Orchestrator Performance Optimization', () => {
     ]
     sandbox.getOpenPRs = async () => [] // No PRs, so they should be archived
 
-    let archiveTaskCount = 0
-    sandbox.archiveTask = async () => {
-      archiveTaskCount++
+    let archiveTasksCallCount = 0
+    let totalArchived = 0
+    sandbox.archiveTasks = async (ids) => {
+      archiveTasksCallCount++
+      totalArchived += ids.length
     }
 
     const tab = { id: 123, url: 'https://jules.google.com/u/0/' }
@@ -147,7 +149,9 @@ describe('Orchestrator Performance Optimization', () => {
 
     await sandbox.processTab(tab, options)
 
-    assert.strictEqual(archiveTaskCount, 2, 'archiveTask should be called for each task')
+    // Batching (ARCHIVE_BATCH_SIZE=50): 2 tasks fit in one batch -> one API call.
+    assert.strictEqual(archiveTasksCallCount, 1, 'archiveTasks should be called once per batch, not per task')
+    assert.strictEqual(totalArchived, 2, 'both tasks should be archived in the single batch call')
   })
 })
 


### PR DESCRIPTION
## What
Re-authors PR #522 (N+1 bulk archive) cleanly, WITHOUT the bundled biome.json 2.5.1 bump (conflicts with the pin from #548) or the popup.css/html a11y scope-creep.

The Tjmm5c (ArchiveTask) payload field is already an array (`TJMM5C.TASK_IDS` at index 0, populated as `[taskId]`). This passes the full batch of task IDs in one call instead of one call per task. `executeArchive` now chunks `toArchive` into batches of ARCHIVE_BATCH_SIZE (50) and archives each batch in a single request. Preserves the #549 hardening untouched.

## Tests
241/241 pass. Updated archiveTask->archiveTasks rename, the retry-integration tests (array args), the processTab archive integration mock, and the perf test now asserts batching (2 tasks -> 1 call, both archived).

## Verify-live note
Client-side batching is fully tested (mocked API). The one thing tests cannot prove is that the live Jules ArchiveTask RPC honors >1 id in the array — the plural `TASK_IDS` field design strongly implies it does, but a real multi-task archive run (jules Test B) should confirm before relying on it at scale.