### PR TITLE
[FIX] Complexity: groupTasksByRepo uses verbose map initialization

### DIFF
--- a/background.js
+++ b/background.js
@@ -345,13 +345,7 @@ function isArchivable(task) {
   return task.state == null || ARCHIVABLE_STATES.has(task.state)
 }
 function groupTasksByRepo(tasks) {
-  const map = new Map()
-  for (const t of tasks) {
-    const key = t.repo || '(no repo)'
-    if (!map.has(key)) map.set(key, [])
-    map.get(key).push(t)
-  }
-  return map
+  return Map.groupBy(tasks, (t) => t.repo || '(no repo)')
 }
 
 async function listTasks(filter, config) {


### PR DESCRIPTION
Refactored `groupTasksByRepo` in `background.js` to use `Map.groupBy` instead of manual loop with `Map.has` and `Map.set`. This simplifies the code and reduces verbosity while maintaining the exact same behavior, as verified by existing tests.

---
*PR created automatically by Jules for task [5177071049028738238](https://jules.google.com/task/5177071049028738238) started by @n24q02m*