### PR TITLE
[TEST] Missing test for isTrustedMessage

### DIFF
--- a/content.js
+++ b/content.js
@@ -123,4 +123,5 @@ if (typeof globalThis !== 'undefined' && globalThis.TEST_MODE) {
   globalThis.test_getAccountNum = getAccountNum
   globalThis.test_getAccountLabel = getAccountLabel
   globalThis.test_injectMainWorldScript = injectMainWorldScript
+  globalThis.test_isTrustedMessage = isTrustedMessage
 }

--- a/tests/is_trusted_message.test.js
+++ b/tests/is_trusted_message.test.js
@@ -1,0 +1,145 @@
+const { describe, it } = require('node:test')
+const assert = require('node:assert')
+const fs = require('node:fs')
+const path = require('node:path')
+const vm = require('node:vm')
+
+const contentJsPath = path.join(__dirname, '../content.js')
+const contentJsCode = fs.readFileSync(contentJsPath, 'utf8')
+
+const PAGE_ORIGIN = 'https://jules.google.com'
+
+function setupSandbox() {
+  const windowObj = {
+    location: { origin: PAGE_ORIGIN, href: `${PAGE_ORIGIN}/u/0/session` },
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    postMessage: () => {}
+  }
+  windowObj.window = windowObj
+
+  const sandbox = {
+    window: windowObj,
+    document: {
+      createElement: () => ({
+        src: '',
+        remove: () => {},
+        onload: () => {}
+      }),
+      head: { appendChild: () => {} },
+      documentElement: { appendChild: () => {} }
+    },
+    chrome: {
+      runtime: {
+        getURL: (p) => `chrome-extension://id/${p}`,
+        sendMessage: () => {},
+        onMessage: { addListener: () => {} }
+      }
+    },
+    location: windowObj.location,
+    console,
+    URL,
+    URLSearchParams,
+    Date,
+    Promise,
+    setTimeout: () => {},
+    clearTimeout: () => {},
+    TEST_MODE: true
+  }
+
+  sandbox.globalThis = sandbox
+  vm.createContext(sandbox)
+  vm.runInContext(contentJsCode, sandbox)
+  return sandbox
+}
+
+describe('content.js isTrustedMessage', () => {
+  it('should return true for valid JULES_ARCHIVER_CONFIG message', () => {
+    const sandbox = setupSandbox()
+    const event = {
+      source: sandbox.window,
+      origin: PAGE_ORIGIN,
+      data: { type: 'JULES_ARCHIVER_CONFIG', config: { some: 'data' } }
+    }
+    assert.strictEqual(sandbox.test_isTrustedMessage(event), true)
+  })
+
+  it('should return true for valid JULES_START_CONFIG message', () => {
+    const sandbox = setupSandbox()
+    const event = {
+      source: sandbox.window,
+      origin: PAGE_ORIGIN,
+      data: { type: 'JULES_START_CONFIG', config: { some: 'data' } }
+    }
+    assert.strictEqual(sandbox.test_isTrustedMessage(event), true)
+  })
+
+  it('should return true for JULES_REQUEST_CONFIG even without config payload', () => {
+    const sandbox = setupSandbox()
+    const event = {
+      source: sandbox.window,
+      origin: PAGE_ORIGIN,
+      data: { type: 'JULES_REQUEST_CONFIG' }
+    }
+    assert.strictEqual(sandbox.test_isTrustedMessage(event), true)
+  })
+
+  it('should return false if source is not window', () => {
+    const sandbox = setupSandbox()
+    const event = {
+      source: {},
+      origin: PAGE_ORIGIN,
+      data: { type: 'JULES_ARCHIVER_CONFIG', config: { some: 'data' } }
+    }
+    assert.strictEqual(sandbox.test_isTrustedMessage(event), false)
+  })
+
+  it('should return false if origin mismatch', () => {
+    const sandbox = setupSandbox()
+    const event = {
+      source: sandbox.window,
+      origin: 'https://evil.com',
+      data: { type: 'JULES_ARCHIVER_CONFIG', config: { some: 'data' } }
+    }
+    assert.strictEqual(sandbox.test_isTrustedMessage(event), false)
+  })
+
+  it('should return false if data is missing', () => {
+    const sandbox = setupSandbox()
+    const event = {
+      source: sandbox.window,
+      origin: PAGE_ORIGIN
+    }
+    assert.strictEqual(sandbox.test_isTrustedMessage(event), false)
+  })
+
+  it('should return false if type does not start with JULES_', () => {
+    const sandbox = setupSandbox()
+    const event = {
+      source: sandbox.window,
+      origin: PAGE_ORIGIN,
+      data: { type: 'NOT_JULES_CONFIG', config: { some: 'data' } }
+    }
+    assert.strictEqual(sandbox.test_isTrustedMessage(event), false)
+  })
+
+  it('should return false if _CONFIG type is missing config payload', () => {
+    const sandbox = setupSandbox()
+    const event = {
+      source: sandbox.window,
+      origin: PAGE_ORIGIN,
+      data: { type: 'JULES_ARCHIVER_CONFIG' }
+    }
+    assert.strictEqual(sandbox.test_isTrustedMessage(event), false)
+  })
+
+  it('should return false if type is not a string', () => {
+    const sandbox = setupSandbox()
+    const event = {
+      source: sandbox.window,
+      origin: PAGE_ORIGIN,
+      data: { type: 123 }
+    }
+    assert.strictEqual(sandbox.test_isTrustedMessage(event), false)
+  })
+})


### PR DESCRIPTION
This PR adds missing unit tests for the `isTrustedMessage` function in `content.js`.

Changes:
1.  **content.js**: Exposed `isTrustedMessage` for testing purposes by adding it to the `TEST_MODE` global exposure block at the end of the file.
2.  **tests/is_trusted_message.test.js**: Created a new test suite that uses a `node:vm` sandbox to thoroughly test the security validation logic of `isTrustedMessage`.

Test cases covered:
- Valid `JULES_ARCHIVER_CONFIG` messages.
- Valid `JULES_START_CONFIG` messages.
- `JULES_REQUEST_CONFIG` messages (which are allowed without a `config` payload).
- Rejection of messages from untrusted sources (not `window`).
- Rejection of messages from untrusted origins (not matching `window.location.origin`).
- Rejection of messages with missing data.
- Rejection of messages without the `JULES_` signature.
- Rejection of `_CONFIG` message types missing a `config` payload.
- Rejection of messages where the `type` is not a string.

All 250 tests in the project (including the 9 new ones) passed successfully.

---
*PR created automatically by Jules for task [18083387437323441055](https://jules.google.com/task/18083387437323441055) started by @n24q02m*