### PR TITLE
[CLEANUP] Silent Error Swallowing in Fetch Interceptor

### DIFF
--- a/main-world.js
+++ b/main-world.js
@@ -56,8 +56,8 @@ if (!window.__julesArchiver) {
           },
           window.location.origin
         )
-      } catch (_e) {
-        /* ignore parse errors */
+      } catch (e) {
+        console.warn('[Jules Archiver] Failed to parse StartSuggestion (Rja83d) payload:', e)
       }
     }
     return resp


### PR DESCRIPTION
Replaced the silent catch block in the `main-world.js` fetch interceptor with a descriptive `console.warn` using the `[Jules Archiver]` prefix. This improves maintainability and auditing of parsing failures for StartSuggestion (Rja83d) payloads.

- Replaced empty catch block with `console.warn`
- Renamed `_e` to `e` as it is now used for logging
- Verified with linting and unit tests

---
*PR created automatically by Jules for task [8815371297082432816](https://jules.google.com/task/8815371297082432816) started by @n24q02m*