### PR TITLE
[CLEANUP] Catching general exceptions and swallowing without context

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -1,0 +1,5 @@
+## 2026-06-29 - [CLEANUP] Catching general exceptions and swallowing without context
+
+**Vulnerability:** Silent exception swallowing in URL parsing.
+**Learning:** Swallowing exceptions without logging makes it difficult to diagnose why a fallback value (like '0' for account IDs) is being used in production.
+**Prevention:** Always log warnings with a descriptive prefix (e.g., [Jules Archiver]) when falling back due to an error, even if the fallback is safe.

--- a/background.js
+++ b/background.js
@@ -35,7 +35,9 @@ function extractAccountNum(url) {
     const pathname = new URL(url).pathname
     const match = ACCOUNT_NUM_REGEX.exec(pathname)
     return match ? match[1] : '0'
-  } catch (_e) {
+  } catch (e) {
+    // 🛡️ Sentinel: Safe fallback for malformed URLs or non-Jules origins
+    console.warn('[Jules Archiver] Error extracting account number:', e)
     return '0'
   }
 }


### PR DESCRIPTION
This PR addresses the issue of catching general exceptions and swallowing them without context in the `extractAccountNum` function in `background.js`.

### Changes:
- Updated the `catch` block in `extractAccountNum` to log the error using `console.warn` with the `[Jules Archiver]` prefix.
- Added a comment documenting why falling back to '0' is safe.
- Updated `.Jules/sentinel.md` with learnings from this task.

### Verification:
- Created a temporary test `tests/cleanup_verification.test.js` to confirm that `console.warn` is called and '0' is returned on error.
- Ran the full test suite (`node --test`), which passed (242 tests).
- Ran Biome linting (`npx @biomejs/biome check background.js`).

---
*PR created automatically by Jules for task [39052748074763315](https://jules.google.com/task/39052748074763315) started by @n24q02m*