### PR TITLE
[PERF] Redundant Async Storage I/O in Tab Processing Loop

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,0 +1,5 @@
+## 2026-06-29 - Redundant Async Storage I/O in Tab Processing Loop
+
+**Learning:** [Insight] Fetching configuration from storage inside loops or frequently called per-tab functions causes unnecessary async overhead. Centralizing these reads at the start of an operation and passing them down via options improves performance and simplifies function signatures.
+
+**Action:** [How to apply next time] Always identify stable configuration values (like API tokens or user settings) that are needed across multiple network requests or tab processing steps. Fetch them once in the orchestrator's entry point (`startOperation`) and propagate them through the call stack using the `options` object.

--- a/background.js
+++ b/background.js
@@ -1083,8 +1083,7 @@ async function filterArchivableTasks(label, tasks, options) {
 
   const byRepo = groupTasksByRepo(candidates)
   addLog(`\n[${label}] Checking open PRs per task...`)
-  const { ghOwner } = await chrome.storage.sync.get(['ghOwner'])
-  const { ghToken } = await chrome.storage.local.get(['ghToken'])
+  const { ghOwner, ghToken } = options
 
   const repoEntries = [...byRepo.entries()]
   const allPRs = await runInPool(repoEntries, API_CONCURRENCY, ([_repo, repoTasks]) => {
@@ -1284,6 +1283,11 @@ async function startOperation(options) {
   const isSuggestions = initOperationState(options)
 
   try {
+    const { ghOwner } = await chrome.storage.sync.get(['ghOwner'])
+    const { ghToken } = await chrome.storage.local.get(['ghToken'])
+    options.ghOwner = ghOwner || ''
+    options.ghToken = ghToken || ''
+
     const tabs = await discoverTabs(options)
     if (!tabs) return
 


### PR DESCRIPTION
Reduced redundant asynchronous storage I/O by fetching GitHub configuration once at the start of operations and propagating them via the options object. This eliminates multiple storage reads during per-tab task filtering.

---
*PR created automatically by Jules for task [7505298216642948751](https://jules.google.com/task/7505298216642948751) started by @n24q02m*