### PR TITLE
⚡ Bolt: [PERF] Redundant Session Storage Read in Tab Processing Loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-06-29 - Redundant Session Storage Read Optimization
+**Learning:** Repetitive asynchronous reads from `chrome.storage.session` in a processing loop (like tab processing) can be a bottleneck. Caching the value in a local variable for the duration of the operation significantly reduces overhead.
+**Action:** Always implement a local cache for storage-backed configurations that are stable during a batch operation, and ensure proper invalidation on configuration updates or operation resets.

--- a/background.js
+++ b/background.js
@@ -687,8 +687,10 @@ async function startSuggestion(suggestion, repo, config, startConfig) {
 }
 
 async function getStartConfig() {
+  if (cachedStartConfig) return cachedStartConfig
   const { startConfig } = await chrome.storage.session.get('startConfig')
-  return startConfig || null
+  cachedStartConfig = startConfig || null
+  return cachedStartConfig
 }
 
 // =============================================================================
@@ -867,6 +869,7 @@ const DEFAULT_STATE = {
 const MAX_LOG_LINES = 2000
 
 let state = { ...DEFAULT_STATE }
+let cachedStartConfig = null
 let pendingFlush = null
 
 function trimLog() {
@@ -1203,6 +1206,7 @@ async function processTab(tab, options) {
 }
 
 function initOperationState(options) {
+  cachedStartConfig = null
   prCache.clear()
   const randomArray = new Uint32Array(1)
   crypto.getRandomValues(randomArray)
@@ -1330,11 +1334,13 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
         sendResponse({ error: 'Security Error: Invalid payload' })
         break
       }
+      cachedStartConfig = msg.config
       chrome.storage.session.set({ startConfig: msg.config })
       sendResponse({ ok: true })
       break
 
     case 'RESET':
+      cachedStartConfig = null
       if (_sender.tab) {
         sendResponse({ error: 'Security Error: Unauthorized action from content script' })
         break


### PR DESCRIPTION
💡 What:
Implemented a local cache (`cachedStartConfig`) for the `startConfig` retrieved from `chrome.storage.session`. Updated `getStartConfig()` to return the cached value if available, and ensured the cache is invalidated when the configuration changes or the operation is reset/initialized.

🎯 Why:
`getStartConfig()` was being called repeatedly in the tab processing loop. Since `chrome.storage.session.get` is asynchronous and involves serialization/deserialization, calling it frequently during a batch operation adds unnecessary overhead and latency.

📊 Impact:
Eliminates redundant async storage reads during suggestion processing. For a tab with many repositories, this significantly reduces the number of IPC calls and improves the overall responsiveness of the start suggestion operation.

🧪 Measurement:
Verified via unit tests and a targeted performance verification script that storage is now only accessed once per operation run instead of once per repository/suggestion.

---
*PR created automatically by Jules for task [9652997382732557957](https://jules.google.com/task/9652997382732557957) started by @n24q02m*