### PR TITLE
[CLEANUP] Test helper exposure in production code

### DIFF
--- a/.jules/cleanup.md
+++ b/.jules/cleanup.md
@@ -1,0 +1,5 @@
+## 2025-05-15 - Test helper exposure removal
+
+**Learning:** Production code should not contain blocks dedicated to exposing internal state for tests (e.g., `if (TEST_MODE) { ... }`). This increases the bundle size and creates potential attack surface or confusion.
+
+**Action:** Instead of hardcoding exposure in the source, use the test runner's environment (like `node:vm`) to inject exposure logic at runtime. By calling `vm.runInContext` after the source has been loaded, you can bind internal functions and variables to the sandbox global object for assertion.

--- a/content.js
+++ b/content.js
@@ -110,17 +110,3 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
       sendResponse({ error: 'Unknown action' })
   }
 })
-
-// Exposure for testing
-if (typeof globalThis !== 'undefined' && globalThis.TEST_MODE) {
-  globalThis.test_cachedConfig = {
-    get: () => cachedConfig,
-    set: (v) => {
-      cachedConfig = v
-    }
-  }
-  globalThis.test_extractConfig = extractConfig
-  globalThis.test_getAccountNum = getAccountNum
-  globalThis.test_getAccountLabel = getAccountLabel
-  globalThis.test_injectMainWorldScript = injectMainWorldScript
-}

--- a/tests/content_account.test.js
+++ b/tests/content_account.test.js
@@ -58,6 +58,15 @@ function setupContentSandbox(initialUrl = 'https://jules.google.com/u/0/') {
   vm.createContext(sandbox)
   vm.runInContext(contentJsContent, sandbox)
 
+  // Inject test helpers
+  vm.runInContext(
+    `
+    globalThis.getAccountLabel = getAccountLabel;
+    globalThis.getAccountNum = getAccountNum;
+  `,
+    sandbox
+  )
+
   return sandbox
 }
 

--- a/tests/content_extract.test.js
+++ b/tests/content_extract.test.js
@@ -100,6 +100,20 @@ function setupEnvironment() {
   vm.createContext(sandbox)
   vm.runInContext(contentJsCode, sandbox)
 
+  // Inject test helpers
+  vm.runInContext(
+    `
+    globalThis.test_cachedConfig = {
+      get: () => cachedConfig,
+      set: (v) => { cachedConfig = v }
+    };
+    globalThis.test_extractConfig = extractConfig;
+    globalThis.test_getAccountNum = getAccountNum;
+    globalThis.test_getAccountLabel = getAccountLabel;
+  `,
+    sandbox
+  )
+
   return sandbox
 }
 

--- a/tests/content_injection.test.js
+++ b/tests/content_injection.test.js
@@ -171,6 +171,9 @@ describe('content.js script injection', () => {
     vm.createContext(sandbox)
     vm.runInContext(contentJsCode, sandbox)
 
+    // Inject test helper
+    vm.runInContext('globalThis.test_injectMainWorldScript = injectMainWorldScript;', sandbox)
+
     const initialCount = scriptCreatedCount
     assert.ok(initialCount >= 1, 'Should have injected at least once on load')
 


### PR DESCRIPTION
Removed the 'Exposure for testing' block from content.js to keep production code clean and minimize potential attack surface.

Updated the following test suites to use runtime injection via node:vm to expose internal functions and state for verification:
- tests/content_extract.test.js
- tests/content_injection.test.js
- tests/content_account.test.js

This ensures that the test suites continue to function correctly without requiring hardcoded test-only logic in the source code.

---
*PR created automatically by Jules for task [10161716017317689513](https://jules.google.com/task/10161716017317689513) started by @n24q02m*