### PR TITLE
[TEST] Untested broadcastConfig function

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+## 2026-06-29 - Testing Main World Broadcasts
+
+**Learning:** [Insight] Testing functions in the browser's MAIN world requires a robust sandbox (vm.createContext) and explicit exposure via a test hook (globalThis.TEST_MODE) to ensure internal logic can be verified without compromising production code encapsulation.
+**Action:** [How to apply next time] Always include a TEST_MODE conditional export for critical utility functions in content or main-world scripts to allow direct unit testing of state-dependent logic.

--- a/main-world.js
+++ b/main-world.js
@@ -77,3 +77,8 @@ window.addEventListener('message', (event) => {
     broadcastConfig()
   }
 })
+
+// Exposure for testing
+if (typeof globalThis !== 'undefined' && globalThis.TEST_MODE) {
+  globalThis.test_broadcastConfig = broadcastConfig
+}

--- a/tests/main-world.test.js
+++ b/tests/main-world.test.js
@@ -45,6 +45,7 @@ function setupSandbox(initialWizData = {}) {
     window: windowMock,
     console,
     URLSearchParams: windowMock.URLSearchParams,
+    TEST_MODE: true,
     JSON,
     Date: windowMock.Date,
     String,
@@ -269,4 +270,58 @@ describe('main-world.js', () => {
     vm.runInContext(mainWorldJs, sandbox)
     assert.strictEqual(windowMock.fetch, firstFetch, 'Fetch should not be wrapped again')
   })
+})
+
+describe('broadcastConfig direct testing', () => {
+  it('should pick up updates to window.WIZ_global_data', () => {
+    const { sandbox, messages, windowMock } = setupSandbox({
+      SNlM0e: 'initial-token'
+    })
+
+    vm.runInContext(mainWorldJs, sandbox)
+    assert.strictEqual(messages.length, 1)
+    assert.strictEqual(messages[0].data.config.at, 'initial-token')
+
+    // Update global data
+    windowMock.WIZ_global_data = {
+      SNlM0e: 'updated-token'
+    }
+
+    // Call exposed broadcastConfig
+    sandbox.test_broadcastConfig()
+
+    assert.strictEqual(messages.length, 2)
+    assert.strictEqual(messages[1].data.config.at, 'updated-token')
+  })
+})
+
+it('should correctly populate the timestamp field', () => {
+  const { sandbox, messages } = setupSandbox({
+    SNlM0e: 'token'
+  })
+
+  vm.runInContext(mainWorldJs, sandbox)
+
+  // Initial broadcast
+  assert.strictEqual(messages[0].data.config.timestamp, 1234567890)
+
+  // Manual call
+  sandbox.test_broadcastConfig()
+  assert.strictEqual(messages[1].data.config.timestamp, 1234567890)
+})
+
+it('should use window.location.origin as the targetOrigin in postMessage', () => {
+  const { sandbox, messages, windowMock } = setupSandbox({
+    SNlM0e: 'token'
+  })
+
+  const customOrigin = 'https://custom.google.com'
+  windowMock.location.origin = customOrigin
+
+  vm.runInContext(mainWorldJs, sandbox)
+
+  assert.strictEqual(messages[0].targetOrigin, customOrigin)
+
+  sandbox.test_broadcastConfig()
+  assert.strictEqual(messages[1].targetOrigin, customOrigin)
 })


### PR DESCRIPTION
Added unit tests for the broadcastConfig function in main-world.js. The function is now exposed for testing via globalThis.test_broadcastConfig. Tests verify that the function correctly picks up updates to WIZ_global_data, populates the timestamp, and uses the correct targetOrigin in postMessage.

---
*PR created automatically by Jules for task [8686413228605142052](https://jules.google.com/task/8686413228605142052) started by @n24q02m*