### PR TITLE
[SECURITY] Missing Type Validation in JSON Parser

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -1,0 +1,7 @@
+## 2026-06-29 - Missing Type Validation in JSON Parser
+
+**Vulnerability:** Missing type validation on deeply nested JSON payloads from `batchexecute` RPC responses. While the top-level response was checked for array type, the inner payload (`entry[2]`) and its parsed result were not, potentially leading to runtime exceptions or unexpected behavior if the API returns non-array structures.
+
+**Learning:** When parsing multi-layered JSON (especially from internal/undocumented RPCs like `batchexecute`), every layer of deserialization must be accompanied by explicit type validation. Assuming the structure based on successful cases is insufficient for security-critical paths.
+
+**Prevention:** Always validate that the input to `JSON.parse` is of the expected type (e.g., `string`) and that the output matches the expected schema (e.g., `Array.isArray`) before proceeding with iteration or property access.

--- a/background.js
+++ b/background.js
@@ -252,9 +252,11 @@ function parseResponse(text, rpcId) {
   // Find the entry matching our rpcId
   for (const entry of outer) {
     if (!Array.isArray(entry) || entry[1] !== rpcId) continue
-    if (!entry[2]) return null
+    if (typeof entry[2] !== 'string') return null
     const innerFixed = fixJsonControlChars(entry[2])
-    return JSON.parse(innerFixed)
+    const inner = JSON.parse(innerFixed)
+    if (!Array.isArray(inner)) throw new Error('Invalid batchexecute response: expected inner array')
+    return inner
   }
 
   return null

--- a/tests/security_json.test.js
+++ b/tests/security_json.test.js
@@ -46,7 +46,7 @@ describe('parseResponse Type Validation Security', () => {
   it('should throw if outer is not an array', () => {
     const sandbox = setup()
     // Valid XSS prefix + newline + byte count + non-array JSON object
-    const text = ")]}'\n\n10\n{\"not\": \"an array\"}"
+    const text = ')]}\'\n\n10\n{"not": "an array"}'
     assert.throws(() => sandbox.parseResponse(text, 'rpcId'), {
       message: 'Invalid batchexecute response: expected array'
     })
@@ -57,7 +57,7 @@ describe('parseResponse Type Validation Security', () => {
     // outer is [[null, "rpcId", "{\"not\": \"an array\"}"]]
     const innerPayload = JSON.stringify({ not: 'an array' })
     const outer = [[null, 'rpcId', innerPayload]]
-    const text = ")]}'\n\n100\n" + JSON.stringify(outer)
+    const text = `)]}'\n\n100\n${JSON.stringify(outer)}`
 
     assert.throws(() => sandbox.parseResponse(text, 'rpcId'), {
       message: 'Invalid batchexecute response: expected inner array'
@@ -68,7 +68,7 @@ describe('parseResponse Type Validation Security', () => {
     const sandbox = setup()
     // entry[2] is a number instead of a string
     const outer = [[null, 'rpcId', 12345]]
-    const text = ")]}'\n\n100\n" + JSON.stringify(outer)
+    const text = `)]}'\n\n100\n${JSON.stringify(outer)}`
 
     const result = sandbox.parseResponse(text, 'rpcId')
     assert.strictEqual(result, null)
@@ -77,7 +77,7 @@ describe('parseResponse Type Validation Security', () => {
   it('should return null if rpcId is not found', () => {
     const sandbox = setup()
     const outer = [[null, 'otherRpc', '[]']]
-    const text = ")]}'\n\n100\n" + JSON.stringify(outer)
+    const text = `)]}'\n\n100\n${JSON.stringify(outer)}`
 
     const result = sandbox.parseResponse(text, 'rpcId')
     assert.strictEqual(result, null)
@@ -87,7 +87,7 @@ describe('parseResponse Type Validation Security', () => {
     const sandbox = setup()
     const innerData = ['task1', 'Title']
     const outer = [[null, 'rpcId', JSON.stringify(innerData)]]
-    const text = ")]}'\n\n100\n" + JSON.stringify(outer)
+    const text = `)]}'\n\n100\n${JSON.stringify(outer)}`
 
     const result = sandbox.parseResponse(text, 'rpcId')
     assert.deepStrictEqual(result, innerData)

--- a/tests/security_json.test.js
+++ b/tests/security_json.test.js
@@ -1,0 +1,95 @@
+const { describe, it } = require('node:test')
+const assert = require('node:assert')
+const fs = require('node:fs')
+const vm = require('node:vm')
+const path = require('node:path')
+
+const bgScriptPath = path.join(__dirname, '..', 'background.js')
+const utilsScriptPath = path.join(__dirname, '..', 'utils.js')
+const bgScriptContent = fs.readFileSync(bgScriptPath, 'utf8')
+const utilsScriptContent = fs.readFileSync(utilsScriptPath, 'utf8')
+
+function setup() {
+  const sandbox = {
+    chrome: {
+      storage: {
+        session: { get: async () => ({}), set: async () => {} },
+        sync: { get: async () => ({}) },
+        local: { get: async () => ({}) }
+      },
+      runtime: { onMessage: { addListener: () => {} } }
+    },
+    setTimeout,
+    setInterval: () => {},
+    console,
+    Error,
+    JSON,
+    Array,
+    String,
+    Math,
+    Object,
+    Promise,
+    parseInt,
+    crypto: { getRandomValues: (arr) => arr },
+    importScripts: () => {},
+    globalThis: {}
+  }
+  vm.createContext(sandbox)
+  sandbox.globalThis = sandbox
+  vm.runInContext(utilsScriptContent + bgScriptContent, sandbox)
+  // Expose parseResponse if not already global
+  vm.runInContext('globalThis.parseResponse = parseResponse', sandbox)
+  return sandbox
+}
+
+describe('parseResponse Type Validation Security', () => {
+  it('should throw if outer is not an array', () => {
+    const sandbox = setup()
+    // Valid XSS prefix + newline + byte count + non-array JSON object
+    const text = ")]}'\n\n10\n{\"not\": \"an array\"}"
+    assert.throws(() => sandbox.parseResponse(text, 'rpcId'), {
+      message: 'Invalid batchexecute response: expected array'
+    })
+  })
+
+  it('should throw if inner result is not an array', () => {
+    const sandbox = setup()
+    // outer is [[null, "rpcId", "{\"not\": \"an array\"}"]]
+    const innerPayload = JSON.stringify({ not: 'an array' })
+    const outer = [[null, 'rpcId', innerPayload]]
+    const text = ")]}'\n\n100\n" + JSON.stringify(outer)
+
+    assert.throws(() => sandbox.parseResponse(text, 'rpcId'), {
+      message: 'Invalid batchexecute response: expected inner array'
+    })
+  })
+
+  it('should return null if entry[2] is not a string', () => {
+    const sandbox = setup()
+    // entry[2] is a number instead of a string
+    const outer = [[null, 'rpcId', 12345]]
+    const text = ")]}'\n\n100\n" + JSON.stringify(outer)
+
+    const result = sandbox.parseResponse(text, 'rpcId')
+    assert.strictEqual(result, null)
+  })
+
+  it('should return null if rpcId is not found', () => {
+    const sandbox = setup()
+    const outer = [[null, 'otherRpc', '[]']]
+    const text = ")]}'\n\n100\n" + JSON.stringify(outer)
+
+    const result = sandbox.parseResponse(text, 'rpcId')
+    assert.strictEqual(result, null)
+  })
+
+  it('should parse valid response', () => {
+    const sandbox = setup()
+    const innerData = ['task1', 'Title']
+    const outer = [[null, 'rpcId', JSON.stringify(innerData)]]
+    const text = ")]}'\n\n100\n" + JSON.stringify(outer)
+
+    const result = sandbox.parseResponse(text, 'rpcId')
+    assert.deepStrictEqual(result, innerData)
+  })
+})


### PR DESCRIPTION
This PR addresses a security vulnerability where the JSON parser in background.js was missing type validation for deeply nested payloads in batchexecute RPC responses. We added explicit checks to ensure that the inner payload is a string and that the resulting parsed object is an array, preventing potential runtime exceptions and improving robustness.

---
*PR created automatically by Jules for task [13532362698538628129](https://jules.google.com/task/13532362698538628129) started by @n24q02m*