### PR TITLE
[FIX] Address the original bug with legacy state codes

### DIFF
--- a/background.js
+++ b/background.js
@@ -355,7 +355,7 @@ function groupTasksByRepo(tasks) {
 }
 
 async function listTasks(filter, config) {
-  const payload = [filter, 4]
+  const payload = [filter, null]
   const result = await callBatchExecute('p1Takd', payload, config)
   if (!result?.[0]) return []
   return result[0].map(parseTask)


### PR DESCRIPTION
Address the original bug with legacy state codes.

Updated \`listTasks\` in \`background.js\` to fetch all tasks from the Jules API by using a \`null\` state filter instead of the hardcoded \`4\` in the \`p1Takd\` RPC payload.

This ensures that:
- **Force mode** can correctly see and archive non-terminal tasks (e.g. states 7, 99).
- **Default mode** correctly sees all terminal-state tasks (2, 4, 12, null), not just those in state 4.

This change aligns the network fetch layer with the extension's local filtering logic, fixing a regression where the API filter was too restrictive for the "Force" operation to succeed.

---
*PR created automatically by Jules for task [9179246085449083855](https://jules.google.com/task/9179246085449083855) started by @n24q02m*