### PR TITLE
🎨 Palette: Improve accessible form grouping

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -31,3 +31,6 @@
 ## 2026-06-09 - Empty State Feedback
 **Learning:** When a list or process finishes with zero results, an empty summary container gives no feedback, leaving the user wondering if it actually ran or failed silently.
 **Action:** Always provide a helpful empty state message explaining why no results might have occurred, using styles consistent with other hints to offer guidance without showing as an error.
+## 2025-07-28 - Semantic Grouping with Native Fieldsets
+**Learning:** Using generic `<div>` wrappers with `role="group"` or `role="radiogroup"` combined with `aria-labelledby` creates accessibility warnings and relies on ARIA bridging rather than semantic HTML. Sighted users see a group, but assistive technologies prefer native structural elements.
+**Action:** Always prefer native HTML `<fieldset>` and `<legend>` for grouping related form controls. To avoid breaking existing CSS flex/grid layouts when retrofitting generic `<div>` containers, wrap the container in a `<fieldset style="border: none; padding: 0; margin: 0; display: contents;">` and convert the pseudo-label into a `<legend>`. Update CSS selectors (like `label, legend`) to ensure visual consistency without introducing custom class bloat.

--- a/popup.css
+++ b/popup.css
@@ -50,7 +50,8 @@ section {
   border-radius: 6px;
 }
 
-label {
+label,
+legend {
   display: block;
   font-size: 12px;
   color: #94a3b8;
@@ -85,7 +86,8 @@ input[type="password"]:focus {
   margin-bottom: 8px;
 }
 
-.setting-row label {
+.setting-row label,
+.setting-row legend {
   margin-bottom: 4px;
 }
 

--- a/popup.html
+++ b/popup.html
@@ -14,18 +14,22 @@
     <section class="options">
       <h2>Options</h2>
       <div class="setting-row">
-        <label id="opModeLabel">Operation</label>
-        <div class="segmented" id="opMode" role="group" aria-labelledby="opModeLabel">
-          <button type="button" data-value="archive" class="active" aria-pressed="true">Archive Tasks</button>
-          <button type="button" data-value="suggestions" aria-pressed="false">Start Suggestions</button>
-        </div>
+        <fieldset style="border: none; padding: 0; margin: 0; display: contents;">
+          <legend id="opModeLabel">Operation</legend>
+          <div class="segmented" id="opMode">
+            <button type="button" data-value="archive" class="active" aria-pressed="true">Archive Tasks</button>
+            <button type="button" data-value="suggestions" aria-pressed="false">Start Suggestions</button>
+          </div>
+        </fieldset>
       </div>
       <div class="setting-row">
-        <label id="execModeLabel">Execution Mode</label>
-        <div class="radio-group" role="radiogroup" aria-labelledby="execModeLabel">
-          <label><input type="radio" name="mode" value="dry" checked /> Dry Run</label>
-          <label><input type="radio" name="mode" value="run" /> Run</label>
-        </div>
+        <fieldset style="border: none; padding: 0; margin: 0; display: contents;">
+          <legend id="execModeLabel">Execution Mode</legend>
+          <div class="radio-group">
+            <label><input type="radio" name="mode" value="dry" checked /> Dry Run</label>
+            <label><input type="radio" name="mode" value="run" /> Run</label>
+          </div>
+        </fieldset>
       </div>
       <div class="setting-row">
         <label class="checkbox">
@@ -35,11 +39,13 @@
         <span class="hint" id="forceHint" style="display: block; margin-left: 20px; margin-top: 2px;">Archive every task, ignoring state and matching open Pull Requests</span>
       </div>
       <div class="setting-row">
-        <label id="scopeLabel">Scope</label>
-        <div class="radio-group" role="radiogroup" aria-labelledby="scopeLabel">
-          <label><input type="radio" name="scope" value="current" /> Current tab</label>
-          <label><input type="radio" name="scope" value="all" checked /> All Jules tabs</label>
-        </div>
+        <fieldset style="border: none; padding: 0; margin: 0; display: contents;">
+          <legend id="scopeLabel">Scope</legend>
+          <div class="radio-group">
+            <label><input type="radio" name="scope" value="current" /> Current tab</label>
+            <label><input type="radio" name="scope" value="all" checked /> All Jules tabs</label>
+          </div>
+        </fieldset>
       </div>
     </section>
 

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -435,11 +435,10 @@ describe('popup.html accessibility', () => {
     )
   })
 
-  it('should use explicit visible labels for radio groups via aria-labelledby', () => {
-    assert.ok(popupHtml.includes('id="execModeLabel"'), 'execModeLabel should exist')
-    assert.ok(popupHtml.includes('aria-labelledby="execModeLabel"'), 'mode radiogroup should use aria-labelledby')
-    assert.ok(popupHtml.includes('id="scopeLabel"'), 'scopeLabel should exist')
-    assert.ok(popupHtml.includes('aria-labelledby="scopeLabel"'), 'scope radiogroup should use aria-labelledby')
+  it('should use explicit visible legends for form groups', () => {
+    assert.ok(popupHtml.includes('<legend id="execModeLabel">'), 'execModeLabel legend should exist')
+    assert.ok(popupHtml.includes('<legend id="scopeLabel">'), 'scopeLabel legend should exist')
+    assert.ok(popupHtml.includes('<fieldset'), 'fieldset should exist')
   })
 })
 


### PR DESCRIPTION
Replaced non-semantic `<div>` containers using `role="group"` and `aria-labelledby` with native HTML `<fieldset>` and `<legend>` elements to resolve Biome linting errors and improve accessibility. Used `display: contents` and updated CSS selectors to preserve existing layouts perfectly without adding custom CSS.

Updated `.Jules/palette.md` with UX learning.

---
*PR created automatically by Jules for task [1069206648755882833](https://jules.google.com/task/1069206648755882833) started by @n24q02m*