### PR TITLE
🎨 Palette: Fix focus ring clipping in segmented buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -34,3 +34,7 @@
 ## 2025-06-30 - Native Semantic Elements for Groups
 **Learning:** Using `role="group"` and `role="radiogroup"` with `aria-labelledby` on `div` elements triggers `noLabelWithoutControl` a11y linter warnings, as these labels are not semantically linked to an input control via a `for` attribute in the same way native HTML works.
 **Action:** Always prefer native semantic elements like `<fieldset>` and `<legend>` for grouping related form controls. To prevent `<fieldset>` from breaking existing CSS layouts (like flexbox/grid) and injecting browser defaults, use `<fieldset style="border: none; padding: 0; margin: 0; display: contents;">`. Ensure the `<legend>` tag inherits the same styling as the generic `label` tag.
+
+## 2026-07-02 - Focus Ring Clipping in Overflow Hidden Containers
+**Learning:** The standard `:focus-visible` outline is visually clipped when applied to interactive elements inside parent containers with `overflow: hidden`, breaking keyboard navigation visibility.
+**Action:** Override the focus style on the interactive element with `outline: none;` and use an `inset` `box-shadow` to render the focus indicator completely inside its boundaries, ensuring the focus state is always fully visible.

--- a/popup.css
+++ b/popup.css
@@ -147,6 +147,11 @@ input:focus-visible {
   outline-offset: 2px;
 }
 
+.segmented button:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 2px #4ade80;
+}
+
 button.primary {
   display: block;
   width: 100%;


### PR DESCRIPTION
💡 **What:** Replaced the external `outline` for `:focus-visible` on `.segmented` buttons with an `inset box-shadow`.
🎯 **Why:** The `.segmented` container uses `overflow: hidden` along with `border-radius`. This combination caused the standard focus ring (which draws outside the element boundaries) to be visually clipped on the edges, making keyboard navigation less visible and harder for users to track.
📸 **Before/After:** The focus indicator is now cleanly drawn completely inside the bounds of the segmented buttons.
♿ **Accessibility:** This directly improves visibility and navigation cues for keyboard users by ensuring the focus state is always identifiable and unclipped.

*(Also added a new critical learning entry to `.Jules/palette.md` noting the implications of `overflow: hidden` on focus outlines).*

---
*PR created automatically by Jules for task [4336679773602913202](https://jules.google.com/task/4336679773602913202) started by @n24q02m*