### PR TITLE
🎨 Palette: Fix clipped focus rings on segmented buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -34,3 +34,6 @@
 ## 2025-06-30 - Native Semantic Elements for Groups
 **Learning:** Using `role="group"` and `role="radiogroup"` with `aria-labelledby` on `div` elements triggers `noLabelWithoutControl` a11y linter warnings, as these labels are not semantically linked to an input control via a `for` attribute in the same way native HTML works.
 **Action:** Always prefer native semantic elements like `<fieldset>` and `<legend>` for grouping related form controls. To prevent `<fieldset>` from breaking existing CSS layouts (like flexbox/grid) and injecting browser defaults, use `<fieldset style="border: none; padding: 0; margin: 0; display: contents;">`. Ensure the `<legend>` tag inherits the same styling as the generic `label` tag.
+## 2025-07-04 - Clipped Focus Rings in Overflow Containers
+**Learning:** Using `outline` for `:focus-visible` on interactive elements inside a container with `overflow: hidden` causes the focus ring to be visually clipped, creating an accessibility issue.
+**Action:** Override the focus style on the interactive element with `outline: none;` and use an `inset` `box-shadow` (e.g., `box-shadow: inset 0 0 0 2px <color>;`) to render the focus indicator completely inside its boundaries.

--- a/popup.css
+++ b/popup.css
@@ -147,6 +147,11 @@ input:focus-visible {
   outline-offset: 2px;
 }
 
+.segmented button:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 2px #4ade80;
+}
+
 button.primary {
   display: block;
   width: 100%;


### PR DESCRIPTION
💡 What: Replaced outline with inset box-shadow for focused buttons in .segmented containers.\n🎯 Why: The previous outline was visually clipped by the parent's overflow: hidden, harming accessibility.\n♿ Accessibility: Restores a fully visible focus ring for keyboard users.

---
*PR created automatically by Jules for task [11548205746763738113](https://jules.google.com/task/11548205746763738113) started by @n24q02m*