### PR TITLE
🎨 Palette: Fix invisible focus rings on segmented tabs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -34,3 +34,6 @@
 ## 2025-06-30 - Native Semantic Elements for Groups
 **Learning:** Using `role="group"` and `role="radiogroup"` with `aria-labelledby` on `div` elements triggers `noLabelWithoutControl` a11y linter warnings, as these labels are not semantically linked to an input control via a `for` attribute in the same way native HTML works.
 **Action:** Always prefer native semantic elements like `<fieldset>` and `<legend>` for grouping related form controls. To prevent `<fieldset>` from breaking existing CSS layouts (like flexbox/grid) and injecting browser defaults, use `<fieldset style="border: none; padding: 0; margin: 0; display: contents;">`. Ensure the `<legend>` tag inherits the same styling as the generic `label` tag.
+## 2026-07-04 - Focus Visibility on Segmented Controls
+**Learning:** Using `outline` for focus indicators on inner elements within an `overflow: hidden` parent (like a segmented control) causes the outline to be visually clipped, rendering the focus state invisible to keyboard users. Furthermore, active states often need inverse focus colors for sufficient contrast.
+**Action:** Replace `outline` with `box-shadow: inset` for focus rings inside clipped containers. Always verify that the inset shadow color has sufficient contrast against both the default and the active background colors of the element.

--- a/popup.css
+++ b/popup.css
@@ -147,6 +147,16 @@ input:focus-visible {
   outline-offset: 2px;
 }
 
+.segmented button:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 2px #4ade80;
+}
+
+.segmented button.active:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 2px #0f172a;
+}
+
 button.primary {
   display: block;
   width: 100%;


### PR DESCRIPTION
💡 **What**: Replaced the clipped `outline` focus indicator with an `inset box-shadow` on segmented buttons (`.segmented button:focus-visible`). Added specific, high-contrast box shadow for `.active` elements.
🎯 **Why**: When navigating the UI via keyboard, the default focus outlines on the primary "Operation" segmented tabs were clipped and completely invisible due to the parent container's `overflow: hidden`, causing a major accessibility barrier.
📸 **Before/After**: See the attached screenshots/videos in the Playwright verification directory for the visible focus rings.
♿ **Accessibility**: Keyboard navigation is now visibly supported on segmented controls, with sufficient contrast ratios across both selected and unselected states.

---
*PR created automatically by Jules for task [2765548314936142663](https://jules.google.com/task/2765548314936142663) started by @n24q02m*