### PR TITLE
⚡ Bolt: single Map lookup for prCache

### DIFF
--- a/background.js
+++ b/background.js
@@ -819,7 +819,10 @@ const prCache = new Map()
 
 async function getOpenPRs(owner, repo, token) {
   const key = `${owner}/${repo}`
-  if (prCache.has(key)) return prCache.get(key)
+  // ⚡ Bolt Optimization: Use a single map.get() instead of .has() + .get()
+  // to avoid double hashing overhead on cache hits.
+  const cached = prCache.get(key)
+  if (cached !== undefined) return cached
 
   try {
     if (typeof owner !== 'string' || typeof repo !== 'string') {


### PR DESCRIPTION
💡 What: Replaced double Map lookup (has + get) with a single get + undefined check in getOpenPRs.
🎯 Why: Using map.has() followed by map.get() requires computing the hash and traversing the Map's internal structures twice. A single map.get() call reduces this overhead.
📊 Impact: Eliminates redundant hashing operations on cache hits for PR data, slightly reducing execution time in the PR check phase.
🔬 Measurement: Run the test suite to verify no regressions in cache behavior.

---
*PR created automatically by Jules for task [4415780096091333616](https://jules.google.com/task/4415780096091333616) started by @n24q02m*