### PR TITLE
🎨 Palette: Fix clipped focus rings in segmented control

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -34,3 +34,6 @@
 ## 2025-06-30 - Native Semantic Elements for Groups
 **Learning:** Using `role="group"` and `role="radiogroup"` with `aria-labelledby` on `div` elements triggers `noLabelWithoutControl` a11y linter warnings, as these labels are not semantically linked to an input control via a `for` attribute in the same way native HTML works.
 **Action:** Always prefer native semantic elements like `<fieldset>` and `<legend>` for grouping related form controls. To prevent `<fieldset>` from breaking existing CSS layouts (like flexbox/grid) and injecting browser defaults, use `<fieldset style="border: none; padding: 0; margin: 0; display: contents;">`. Ensure the `<legend>` tag inherits the same styling as the generic `label` tag.
+## 2026-10-25 - Clipped Focus Rings with Overflow
+**Learning:** Using `outline` for focus indicators (like `:focus-visible`) on interactive elements inside a parent container with `overflow: hidden` causes the focus ring to be visually clipped or completely hidden.
+**Action:** When a parent container requires `overflow: hidden` (like a segmented control wrapper), apply `outline: none;` to the focusable children and use an `inset` `box-shadow` instead. Always verify that the chosen `inset` shadow color contrasts sufficiently against both the inactive and active background colors of the element.

--- a/popup.css
+++ b/popup.css
@@ -147,6 +147,16 @@ input:focus-visible {
   outline-offset: 2px;
 }
 
+.segmented button:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 2px #4ade80;
+}
+
+.segmented button.active:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 2px #0f172a;
+}
+
 button.primary {
   display: block;
   width: 100%;


### PR DESCRIPTION
### 💡 What
Replaced the default `outline` with an `inset box-shadow` for the `:focus-visible` state on segmented buttons. Applied specific color matching (`#4ade80` for inactive, `#0f172a` for active) to ensure the focus ring remains visible.

### 🎯 Why
The parent `.segmented` container uses `overflow: hidden`, which caused the standard `outline` focus ring to be visually clipped entirely, rendering it invisible and breaking keyboard navigation cues for those elements. 

### 📸 Before/After
- **Before:** Navigating the segmented buttons with the keyboard showed no visible focus indicator.
- **After:** The focused button now clearly displays an inset shadow, ensuring keyboard users know which tab they are currently on.

### ♿ Accessibility
This change restores keyboard focus visibility for a primary interactive control, complying with WCAG success criteria for focus indicators without breaking the existing design constraints.

---
*PR created automatically by Jules for task [17595503205514706449](https://jules.google.com/task/17595503205514706449) started by @n24q02m*