### PR TITLE
🎨 Palette: Fix clipped focus ring on segmented buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -34,3 +34,6 @@
 ## 2025-06-30 - Native Semantic Elements for Groups
 **Learning:** Using `role="group"` and `role="radiogroup"` with `aria-labelledby` on `div` elements triggers `noLabelWithoutControl` a11y linter warnings, as these labels are not semantically linked to an input control via a `for` attribute in the same way native HTML works.
 **Action:** Always prefer native semantic elements like `<fieldset>` and `<legend>` for grouping related form controls. To prevent `<fieldset>` from breaking existing CSS layouts (like flexbox/grid) and injecting browser defaults, use `<fieldset style="border: none; padding: 0; margin: 0; display: contents;">`. Ensure the `<legend>` tag inherits the same styling as the generic `label` tag.
+## 2025-06-31 - Clipped Focus Rings in Overflow Containers
+**Learning:** When using `:focus-visible` to render an `outline` on interactive elements, parent containers with `overflow: hidden` will visually clip or completely hide the focus ring.
+**Action:** Always verify keyboard accessibility on elements within structural containers. To prevent focus ring clipping, replace the `outline` on the child element with an `inset` `box-shadow`. Ensure the shadow color contrasts sufficiently against all active and inactive backgrounds of the element (e.g. modifying the shadow color for a button's active state so the focus ring remains visible).

--- a/popup.css
+++ b/popup.css
@@ -147,6 +147,15 @@ input:focus-visible {
   outline-offset: 2px;
 }
 
+.segmented button:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 2px #4ade80;
+}
+
+.segmented button.active:focus-visible {
+  box-shadow: inset 0 0 0 2px #0f172a;
+}
+
 button.primary {
   display: block;
   width: 100%;


### PR DESCRIPTION
**💡 What**
Replaced the `outline` focus indicator with an `inset box-shadow` on the `.segmented button` interactive elements. Also specified a highly visible contrast color (`#0f172a`) for the active state of the button since the default green (`#4ade80`) would be invisible against the button's green background.

**🎯 Why**
The `.segmented` container uses `overflow: hidden`, which clipped the default `:focus-visible` `outline` focus ring on the descendant buttons during keyboard navigation. Replacing the outline with an inset box-shadow renders the focus ring completely inside the element's boundaries so it remains visible and accessible.

**📸 Before/After**
*Before:* Keyboard navigation would not show any focus indicator for the buttons inside the option selector.
*After:* Keyboard navigation clearly shows a green inner border on inactive buttons and a dark inner border on the active button.

**♿ Accessibility**
Ensured the focus states are visible for keyboard-only users, providing visual feedback on where focus currently lies. Contrast considerations were applied so the focus ring does not clash with the active state's background color.

---
*PR created automatically by Jules for task [15408329124861786073](https://jules.google.com/task/15408329124861786073) started by @n24q02m*