### PR TITLE
🎨 Palette: Fix clipped focus rings on segmented buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -34,3 +34,6 @@
 ## 2025-06-30 - Native Semantic Elements for Groups
 **Learning:** Using `role="group"` and `role="radiogroup"` with `aria-labelledby` on `div` elements triggers `noLabelWithoutControl` a11y linter warnings, as these labels are not semantically linked to an input control via a `for` attribute in the same way native HTML works.
 **Action:** Always prefer native semantic elements like `<fieldset>` and `<legend>` for grouping related form controls. To prevent `<fieldset>` from breaking existing CSS layouts (like flexbox/grid) and injecting browser defaults, use `<fieldset style="border: none; padding: 0; margin: 0; display: contents;">`. Ensure the `<legend>` tag inherits the same styling as the generic `label` tag.
+## 2026-11-10 - Clipped Focus Rings & Inset Shadow Contrast
+**Learning:** When using `overflow: hidden` on a container (like `.segmented`), native focus rings (`outline`) on child elements are visually clipped, breaking accessibility visibility. Replacing them with `inset box-shadow` fixes the clipping but introduces a contrast risk: if the inset shadow color matches the element's active background color, the focus ring becomes invisible.
+**Action:** Always override clipped focus rings with `inset box-shadow`, but ensure you explicitly set a contrasting shadow color for all element states (e.g., active vs. inactive backgrounds).

--- a/popup.css
+++ b/popup.css
@@ -147,6 +147,15 @@ input:focus-visible {
   outline-offset: 2px;
 }
 
+.segmented button:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 2px #4ade80;
+}
+
+.segmented button.active:focus-visible {
+  box-shadow: inset 0 0 0 2px #0f172a;
+}
+
 button.primary {
   display: block;
   width: 100%;


### PR DESCRIPTION
💡 **What:** Replaced the native `outline` focus ring with an `inset box-shadow` for the segmented operation mode buttons in `popup.css`. Added specific shadow colors for both the inactive and active states of the buttons. Added a journal entry to `.Jules/palette.md` detailing this learning.

🎯 **Why:** The `.segmented` container uses `overflow: hidden` to create its rounded pill shape. This unintentionally clips the standard 2px `outline` applied to its child buttons on `:focus-visible`, rendering the focus ring invisible. The inset shadow fixes the clipping, but requires manual color management to ensure it's visible against both dark and active (green) backgrounds.

📸 **Before/After:** The focus ring is now clearly visible and rendered entirely inside the button boundaries, rather than being cut off by the parent container.

♿ **Accessibility:** Restores crucial visual feedback for keyboard navigation (Tab), ensuring that screen reader and keyboard-only users can easily identify which operation mode is currently focused.

---
*PR created automatically by Jules for task [3956295685164046753](https://jules.google.com/task/3956295685164046753) started by @n24q02m*