### PR TITLE
⚡ Bolt: Optimize PR cache map lookups

### DIFF
--- a/background.js
+++ b/background.js
@@ -819,7 +819,10 @@ const prCache = new Map()
 
 async function getOpenPRs(owner, repo, token) {
   const key = `${owner}/${repo}`
-  if (prCache.has(key)) return prCache.get(key)
+  // ⚡ Bolt Optimization: Use a single map.get(key) lookup instead of
+  // map.has(key) followed by map.get(key) to reduce hashing operations.
+  const cached = prCache.get(key)
+  if (cached !== undefined) return cached
 
   try {
     if (typeof owner !== 'string' || typeof repo !== 'string') {


### PR DESCRIPTION
💡 What: Replaced the double Map lookup (`prCache.has()` followed by `prCache.get()`) in `getOpenPRs` with a single `prCache.get()` call and an `!== undefined` check.

🎯 Why: In high-frequency paths, querying a Map twice for the same key requires redundant hashing operations. Since `prCache` stores arrays (which are truthy/defined), a single `.get()` safely handles both the existence check and value retrieval.

📊 Impact: Reduces hashing operations for PR cache hits by 50% per repository processed, slightly lowering CPU overhead during the PR checking phase without sacrificing code readability.

🔬 Measurement: Run the test suite (`pnpm test`); all task filtering and GitHub API mocking tests pass as expected. Verify by inspecting `getOpenPRs` in `background.js`.

---
*PR created automatically by Jules for task [17236038664897309527](https://jules.google.com/task/17236038664897309527) started by @n24q02m*