### PR TITLE
🎨 Palette: Fix clipped focus rings in segmented control

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -34,3 +34,6 @@
 ## 2025-06-30 - Native Semantic Elements for Groups
 **Learning:** Using `role="group"` and `role="radiogroup"` with `aria-labelledby` on `div` elements triggers `noLabelWithoutControl` a11y linter warnings, as these labels are not semantically linked to an input control via a `for` attribute in the same way native HTML works.
 **Action:** Always prefer native semantic elements like `<fieldset>` and `<legend>` for grouping related form controls. To prevent `<fieldset>` from breaking existing CSS layouts (like flexbox/grid) and injecting browser defaults, use `<fieldset style="border: none; padding: 0; margin: 0; display: contents;">`. Ensure the `<legend>` tag inherits the same styling as the generic `label` tag.
+## 2025-07-02 - Clipped Focus Rings in Overflow Containers
+**Learning:** When using standard `outline` and `outline-offset` for `:focus-visible` styles, the focus ring will be visually clipped if the interactive element is inside a parent container with `overflow: hidden` (like a segmented control wrapper).
+**Action:** Always replace the default focus `outline` with an `inset box-shadow` on interactive elements contained within `overflow: hidden` boundaries, ensuring the focus indicator renders completely inside the element. Additionally, ensure the inset shadow color has sufficient contrast against the active/selected state background.

--- a/popup.css
+++ b/popup.css
@@ -147,6 +147,15 @@ input:focus-visible {
   outline-offset: 2px;
 }
 
+.segmented button:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 2px #4ade80;
+}
+
+.segmented button.active:focus-visible {
+  box-shadow: inset 0 0 0 2px #0f172a;
+}
+
 button.primary {
   display: block;
   width: 100%;


### PR DESCRIPTION
💡 **What**: Added an `inset box-shadow` to `:focus-visible` states on segmented control buttons in `popup.css`, instead of relying on the default `outline`.
🎯 **Why**: The default `outline` with `outline-offset` gets visually clipped by the parent `.segmented` container's `overflow: hidden` property.
📸 **Before/After**: The focus ring is now fully visible and contained within the button boundaries, rather than being cut off on the outer edges.
♿ **Accessibility**: Improves keyboard navigation clarity by ensuring focus indicators are fully visible and not clipped. A contrasting color (`#0f172a`) is used for the active state to ensure the focus ring remains visible against the active background (`#4ade80`).

---
*PR created automatically by Jules for task [7720750459936847812](https://jules.google.com/task/7720750459936847812) started by @n24q02m*