### PR TITLE
🎨 Palette: Fix clipped focus rings on segmented buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -34,3 +34,6 @@
 ## 2025-06-30 - Native Semantic Elements for Groups
 **Learning:** Using `role="group"` and `role="radiogroup"` with `aria-labelledby` on `div` elements triggers `noLabelWithoutControl` a11y linter warnings, as these labels are not semantically linked to an input control via a `for` attribute in the same way native HTML works.
 **Action:** Always prefer native semantic elements like `<fieldset>` and `<legend>` for grouping related form controls. To prevent `<fieldset>` from breaking existing CSS layouts (like flexbox/grid) and injecting browser defaults, use `<fieldset style="border: none; padding: 0; margin: 0; display: contents;">`. Ensure the `<legend>` tag inherits the same styling as the generic `label` tag.
+## 2026-11-20 - Clipped Focus Rings in Overflow Hidden Containers
+**Learning:** When using `overflow: hidden` on a parent container, default `outline-offset` focus rings on its interactive children get visually clipped or completely hidden, severely degrading the experience for keyboard navigation users.
+**Action:** Always override the default `outline` with an `inset` `box-shadow` for interactive elements inside `overflow: hidden` containers. Ensure the chosen inset shadow color contrasts sufficiently against all potential element background states (e.g., using a darker shadow on a brightly colored active button).

--- a/popup.css
+++ b/popup.css
@@ -147,6 +147,15 @@ input:focus-visible {
   outline-offset: 2px;
 }
 
+.segmented button:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 2px #4ade80;
+}
+
+.segmented button.active:focus-visible {
+  box-shadow: inset 0 0 0 2px #0f172a;
+}
+
 button.primary {
   display: block;
   width: 100%;


### PR DESCRIPTION
## 💡 What
Replaced the default `outline` focus ring on the segmented operation mode buttons with an `inset box-shadow`. 

## 🎯 Why
The parent container `.segmented` uses `overflow: hidden` to create its rounded pill shape. This clipping property was cutting off the default `outline-offset` focus ring, making keyboard navigation highly confusing and inaccessible for those buttons.

## 📸 Before/After
(See attached screenshot from frontend verification where the focus ring is now clearly visible completely inside the button's boundaries).

## ♿ Accessibility
- Dramatically improves keyboard navigation visibility for the primary mode selector.
- Ensures adaptive contrast compliance by applying a dark inset shadow (`#0f172a`) when the button is in its active (green `#4ade80`) state, and a bright green shadow when inactive.

---
*PR created automatically by Jules for task [9975540139797241446](https://jules.google.com/task/9975540139797241446) started by @n24q02m*