### PR TITLE
🎨 Palette: fix focus ring clipping on segmented buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -34,3 +34,6 @@
 ## 2025-06-30 - Native Semantic Elements for Groups
 **Learning:** Using `role="group"` and `role="radiogroup"` with `aria-labelledby` on `div` elements triggers `noLabelWithoutControl` a11y linter warnings, as these labels are not semantically linked to an input control via a `for` attribute in the same way native HTML works.
 **Action:** Always prefer native semantic elements like `<fieldset>` and `<legend>` for grouping related form controls. To prevent `<fieldset>` from breaking existing CSS layouts (like flexbox/grid) and injecting browser defaults, use `<fieldset style="border: none; padding: 0; margin: 0; display: contents;">`. Ensure the `<legend>` tag inherits the same styling as the generic `label` tag.
+## 2024-05-24 - Segmented Button Focus Ring Clipping
+**Learning:** Using `overflow: hidden` on a parent container (like `.segmented`) clips the standard `outline` focus rings (`:focus-visible`) of its child elements, making keyboard navigation inaccessible or difficult to see.
+**Action:** Replace `outline` with `inset box-shadow` for elements inside `overflow: hidden` containers to ensure the focus ring renders inside the element boundaries. Ensure the shadow color contrasts adequately against both the active and inactive backgrounds (e.g., using dark shadow on light active background, and light shadow on dark inactive background).

--- a/popup.css
+++ b/popup.css
@@ -147,6 +147,15 @@ input:focus-visible {
   outline-offset: 2px;
 }
 
+.segmented button:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 2px #4ade80;
+}
+
+.segmented button.active:focus-visible {
+  box-shadow: inset 0 0 0 2px #0f172a;
+}
+
 button.primary {
   display: block;
   width: 100%;


### PR DESCRIPTION
### 💡 What
Replaced the default `outline` with an `inset box-shadow` for the `:focus-visible` state on buttons within the `.segmented` container.

### 🎯 Why
The `.segmented` parent container has `overflow: hidden`, which was clipping the standard 2px outer focus ring (`outline`) provided by the browser. This made it impossible for keyboard users to see which button currently had focus within the segmented control. An inset box-shadow renders inside the element's boundaries and is not affected by `overflow: hidden`.

### 📸 Before/After
*(See attached screenshots from Playwright verification script.)*
Before, tabbing to the segmented buttons showed no visible change. After, a clear green or dark inset ring appears depending on the active/inactive state of the button.

### ♿ Accessibility
- Improves keyboard navigation discoverability.
- Ensures WCAG compliance for focus visibility (Criterion 2.4.7 Focus Visible).
- Added contextual colors: `#0f172a` for active buttons and `#4ade80` for inactive buttons, ensuring sufficient contrast on both backgrounds.

---
*PR created automatically by Jules for task [15611280637619310436](https://jules.google.com/task/15611280637619310436) started by @n24q02m*