### PR TITLE
🎨 Palette: Fix clipped focus ring on segmented buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -34,3 +34,6 @@
 ## 2025-06-30 - Native Semantic Elements for Groups
 **Learning:** Using `role="group"` and `role="radiogroup"` with `aria-labelledby` on `div` elements triggers `noLabelWithoutControl` a11y linter warnings, as these labels are not semantically linked to an input control via a `for` attribute in the same way native HTML works.
 **Action:** Always prefer native semantic elements like `<fieldset>` and `<legend>` for grouping related form controls. To prevent `<fieldset>` from breaking existing CSS layouts (like flexbox/grid) and injecting browser defaults, use `<fieldset style="border: none; padding: 0; margin: 0; display: contents;">`. Ensure the `<legend>` tag inherits the same styling as the generic `label` tag.
+## 2024-07-14 - Fix clipped focus ring on segmented buttons
+**Learning:** When interactive elements (like buttons) are placed inside a container with `overflow: hidden` (like a segmented control to round the corners), the default browser `outline` focus ring is often visually clipped or completely hidden.
+**Action:** Replace the default `outline` with an `inset box-shadow` to ensure the focus indicator is rendered completely inside the element's boundaries. When doing so, ensure the shadow color contrasts sufficiently against all potential element background states (e.g., active vs. inactive).

--- a/popup.css
+++ b/popup.css
@@ -147,6 +147,15 @@ input:focus-visible {
   outline-offset: 2px;
 }
 
+.segmented button:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 2px #4ade80;
+}
+
+.segmented button.active:focus-visible {
+  box-shadow: inset 0 0 0 2px #0f172a;
+}
+
 button.primary {
   display: block;
   width: 100%;


### PR DESCRIPTION
💡 **What**: Added `inset box-shadow` focus styles for the buttons within the segmented control.
🎯 **Why**: The parent `.segmented` container uses `overflow: hidden` to create rounded corners, which was clipping the default browser `outline` focus ring on the buttons, making it invisible when navigating via keyboard.
📸 **Before/After**: See visual verification step (focus rings are now correctly rendered inside the buttons and are visible during keyboard navigation).
♿ **Accessibility**: Restores visible focus states (`:focus-visible`) for keyboard users navigating the Operation mode buttons, ensuring they know which mode is currently focused. Added contrasting shadow colors for active (`#0f172a`) and inactive (`#4ade80`) states.

---
*PR created automatically by Jules for task [16833232093502693709](https://jules.google.com/task/16833232093502693709) started by @n24q02m*