### PR TITLE
🎨 Palette: [UX improvement] Fix segmented button focus ring clipping

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -34,3 +34,7 @@
 ## 2025-06-30 - Native Semantic Elements for Groups
 **Learning:** Using `role="group"` and `role="radiogroup"` with `aria-labelledby` on `div` elements triggers `noLabelWithoutControl` a11y linter warnings, as these labels are not semantically linked to an input control via a `for` attribute in the same way native HTML works.
 **Action:** Always prefer native semantic elements like `<fieldset>` and `<legend>` for grouping related form controls. To prevent `<fieldset>` from breaking existing CSS layouts (like flexbox/grid) and injecting browser defaults, use `<fieldset style="border: none; padding: 0; margin: 0; display: contents;">`. Ensure the `<legend>` tag inherits the same styling as the generic `label` tag.
+
+## 2026-07-15 - Fix focus ring clipping in overflow-hidden containers
+**Learning:** When applying an `outline` for `:focus-visible` on elements inside a container with `overflow: hidden`, the focus ring will often be clipped and invisible. Furthermore, when using an `inset box-shadow` to replace the outline, the chosen color must maintain adequate contrast against all possible backgrounds (e.g. active vs inactive button states).
+**Action:** Use `outline: none` combined with an `inset box-shadow` to ensure the focus indicator renders completely inside the element's boundaries. Verify contrast against different state backgrounds and adjust the shadow color if necessary (e.g. using a dark shadow on a light active background and a light shadow on a dark inactive background).

--- a/popup.css
+++ b/popup.css
@@ -147,6 +147,16 @@ input:focus-visible {
   outline-offset: 2px;
 }
 
+.segmented button:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 2px #4ade80;
+}
+
+.segmented button.active:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 2px #0f172a;
+}
+
 button.primary {
   display: block;
   width: 100%;


### PR DESCRIPTION
### 💡 What
Updated the `:focus-visible` styling for the `.segmented button` controls in the popup extension. Replaced the default `outline` with an `inset box-shadow`, applying distinct shadow colors for the inactive state (`#4ade80`, light green) and the active state (`#0f172a`, dark slate). 

### 🎯 Why
The parent container (`.segmented`) uses `overflow: hidden`, which was clipping the native `outline` focus ring, rendering it completely invisible to keyboard navigators on the left/right/top edges of the buttons. Furthermore, the active button uses a bright green background, while the inactive buttons use a dark background. Using an inset shadow ensures the focus ring is not clipped, and applying state-specific colors ensures the focus ring maintains high contrast regardless of which button is focused.

### 📸 Before/After
*(See Playwright verified screenshots for the visual result showing clear, inset focus rings on both active and inactive buttons)*

### ♿ Accessibility
- Radically improves keyboard navigation for the main Operations selector by ensuring the focus indicator is actually visible.
- Maintains high color contrast for the focus ring across both button states (dark ring on bright green background, bright green ring on dark background).

---
*PR created automatically by Jules for task [13239778560903988449](https://jules.google.com/task/13239778560903988449) started by @n24q02m*