### PR TITLE
🎨 Palette: Fix segmented button focus rings

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -34,3 +34,6 @@
 ## 2025-06-30 - Native Semantic Elements for Groups
 **Learning:** Using `role="group"` and `role="radiogroup"` with `aria-labelledby` on `div` elements triggers `noLabelWithoutControl` a11y linter warnings, as these labels are not semantically linked to an input control via a `for` attribute in the same way native HTML works.
 **Action:** Always prefer native semantic elements like `<fieldset>` and `<legend>` for grouping related form controls. To prevent `<fieldset>` from breaking existing CSS layouts (like flexbox/grid) and injecting browser defaults, use `<fieldset style="border: none; padding: 0; margin: 0; display: contents;">`. Ensure the `<legend>` tag inherits the same styling as the generic `label` tag.
+## 2025-07-17 - Clipped Focus Rings and Contrast
+**Learning:** Using `outline` for `:focus-visible` states can result in the focus ring being visually clipped if a parent container uses `overflow: hidden` (like in rounded segmented controls). However, when replacing `outline` with an `inset box-shadow`, the shadow must not blend into the active state background color, or it will become invisible.
+**Action:** When fixing clipped focus rings using `outline: none;` and an `inset box-shadow`, always explicitly verify that the shadow color contrasts sufficiently with both the active and inactive background states of the element.

--- a/popup.css
+++ b/popup.css
@@ -147,6 +147,15 @@ input:focus-visible {
   outline-offset: 2px;
 }
 
+.segmented button:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 2px #4ade80;
+}
+
+.segmented button.active:focus-visible {
+  box-shadow: inset 0 0 0 2px #0f172a;
+}
+
 button.primary {
   display: block;
   width: 100%;


### PR DESCRIPTION
### 💡 What
Updated the `:focus-visible` styles for the `.segmented button` elements to use an `inset box-shadow` instead of an `outline`. Added specific styles for the active state to ensure the focus ring remains visible against the active green background.

### 🎯 Why
The `.segmented` container uses `overflow: hidden` to provide rounded corners to the button group. When a button received keyboard focus, the default `outline` was rendered *outside* the button's bounds, causing it to be visually clipped and entirely invisible by the parent container. This made keyboard navigation extremely difficult as users could not see which option they were currently focused on.

### 📸 Before/After
*(See attached automated verification screenshots/video)*
**Before:** Tabbing to the "Start Suggestions" button showed no visible focus indicator because the outline was clipped.
**After:** Tabbing to either button displays a clear, internal focus ring (`inset box-shadow`) that contrasts appropriately with both the dark and light (active) backgrounds.

### ♿ Accessibility
- Dramatically improves keyboard navigation by restoring a visible focus indicator for the operation mode toggle buttons.
- Ensures the focus ring contrast is sufficient against both the default (`#1a1a2e` dark) and active (`#4ade80` green) button backgrounds.

---
*PR created automatically by Jules for task [7564457922184840932](https://jules.google.com/task/7564457922184840932) started by @n24q02m*