### PR TITLE
🛡️ Sentinel: [security improvement] Enhance Content Security Policy

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-07-18 - Restrict Content Security Policy
+**Vulnerability:** The extension's Content Security Policy (CSP) in `manifest.json` lacked explicit `default-src 'none'` and broad network constraints, relying solely on script and object restrictions.
+**Learning:** A permissive CSP allows unexpected resource loading and potential data exfiltration if an XSS vulnerability occurs. A strict whitelist (`default-src 'none'`) provides a robust defense-in-depth layer.
+**Prevention:** Always define a strict CSP for extensions, setting `default-src 'none'` and explicitly allowing only required origins (e.g., `connect-src`).

--- a/manifest.json
+++ b/manifest.json
@@ -22,7 +22,7 @@
     }
   ],
   "content_security_policy": {
-    "extension_pages": "script-src 'self'; object-src 'none';"
+    "extension_pages": "default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src https://jules.google.com https://api.github.com; img-src 'self' data:; object-src 'none';"
   },
   "action": {
     "default_popup": "popup.html",


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The extension's Content Security Policy (CSP) in `manifest.json` lacked explicit `default-src 'none'` and broad network constraints.
🎯 Impact: A permissive CSP allows unexpected resource loading and potential data exfiltration if an XSS vulnerability occurs elsewhere.
🔧 Fix: Implemented a strict CSP by adding `default-src 'none'`, and whitelisting only necessary domains for `connect-src` (`https://jules.google.com`, `https://api.github.com`).
✅ Verification: Ensure the extension loads and communicates with GitHub and Jules correctly without throwing CSP errors. Tested via full suite (`pnpm test`) and code review.

---
*PR created automatically by Jules for task [5403182265793907782](https://jules.google.com/task/5403182265793907782) started by @n24q02m*