### PR TITLE
🎨 Palette: Fix clipped focus ring on segmented buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -34,3 +34,6 @@
 ## 2025-06-30 - Native Semantic Elements for Groups
 **Learning:** Using `role="group"` and `role="radiogroup"` with `aria-labelledby` on `div` elements triggers `noLabelWithoutControl` a11y linter warnings, as these labels are not semantically linked to an input control via a `for` attribute in the same way native HTML works.
 **Action:** Always prefer native semantic elements like `<fieldset>` and `<legend>` for grouping related form controls. To prevent `<fieldset>` from breaking existing CSS layouts (like flexbox/grid) and injecting browser defaults, use `<fieldset style="border: none; padding: 0; margin: 0; display: contents;">`. Ensure the `<legend>` tag inherits the same styling as the generic `label` tag.
+## 2023-11-01 - Clipped Focus Rings in Overflow Containers
+**Learning:** When interactive elements are inside a container with `overflow: hidden`, their default focus outlines are clipped. Replacing the outline with an `inset box-shadow` can make the ring invisible if it matches the active background color.
+**Action:** Use `box-shadow: inset` to prevent clipping, and always replace `outline` with `outline: 2px solid transparent;` for High Contrast Mode. Ensure the shadow color contrasts with all possible element background states.

--- a/popup.css
+++ b/popup.css
@@ -147,6 +147,15 @@ input:focus-visible {
   outline-offset: 2px;
 }
 
+.segmented button:focus-visible {
+  outline: 2px solid transparent;
+  box-shadow: inset 0 0 0 2px #4ade80;
+}
+
+.segmented button.active:focus-visible {
+  box-shadow: inset 0 0 0 2px #0f172a;
+}
+
 button.primary {
   display: block;
   width: 100%;


### PR DESCRIPTION
### 💡 What
Replaced the default `outline` focus ring on `.segmented button` with an `inset box-shadow`. Specifically, added a green inner ring (`#4ade80`) for inactive buttons and a dark inner ring (`#0f172a`) for the `.active` button. I also retained `outline: 2px solid transparent;`.

### 🎯 Why
The `.segmented` container uses `overflow: hidden;` to round the corners of its child buttons. This was causing the browser's default external `outline` focus ring to be visually clipped or completely hidden when navigating the tabs via keyboard (Tab).

### 📸 Before/After
*(See Playwright verification screenshots and video attached to the pipeline)*
*   **Before:** Tabbing to the "Archive Tasks" or "Start Suggestions" button showed no visible focus indicator because it was clipped by the container bounds.
*   **After:** Tabbing to the buttons now clearly displays a clean inner ring that contrasts against both the active (green) and inactive (dark) background states.

### ♿ Accessibility
*   Restores clear visible focus indicators for keyboard navigation users.
*   Maintains Windows High Contrast Mode (WHCM) support by using `outline: 2px solid transparent;` alongside the box-shadow fix.

---
*PR created automatically by Jules for task [16282818979228167222](https://jules.google.com/task/16282818979228167222) started by @n24q02m*