### PR TITLE
🎨 Palette: Fix clipped focus outline on segmented buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -34,3 +34,6 @@
 ## 2025-06-30 - Native Semantic Elements for Groups
 **Learning:** Using `role="group"` and `role="radiogroup"` with `aria-labelledby` on `div` elements triggers `noLabelWithoutControl` a11y linter warnings, as these labels are not semantically linked to an input control via a `for` attribute in the same way native HTML works.
 **Action:** Always prefer native semantic elements like `<fieldset>` and `<legend>` for grouping related form controls. To prevent `<fieldset>` from breaking existing CSS layouts (like flexbox/grid) and injecting browser defaults, use `<fieldset style="border: none; padding: 0; margin: 0; display: contents;">`. Ensure the `<legend>` tag inherits the same styling as the generic `label` tag.
+## 2025-10-26 - Focus Visibility in Overflow Hidden Containers
+**Learning:** Using `overflow: hidden` on a container (like `.segmented`) visually clips the standard `outline` focus rings of its child interactive elements (like buttons).
+**Action:** Replace `outline` with an `inset box-shadow` on the child elements to ensure the focus ring remains fully visible. Ensure the `box-shadow` color provides sufficient contrast against both the active and inactive background states, and use `outline: 2px solid transparent;` to maintain Windows High Contrast Mode compatibility.

--- a/patch_css.py
+++ b/patch_css.py
@@ -1,0 +1,24 @@
+import re
+
+with open('popup.css', 'r') as f:
+    content = f.read()
+
+# Remove the general focus styles
+content = content.replace('''button:focus-visible,
+input:focus-visible {
+  outline: 2px solid #4ade80;
+  outline-offset: 2px;
+}''', '')
+
+# Insert them earlier in the file (e.g. before .segmented rules)
+insert_point = content.find('.hint {')
+new_content = content[:insert_point] + '''button:focus-visible,
+input:focus-visible {
+  outline: 2px solid #4ade80;
+  outline-offset: 2px;
+}
+
+''' + content[insert_point:]
+
+with open('popup.css', 'w') as f:
+    f.write(new_content)

--- a/popup.css
+++ b/popup.css
@@ -77,6 +77,12 @@ input[type="password"]:focus {
   border-color: #4ade80;
 }
 
+button:focus-visible,
+input:focus-visible {
+  outline: 2px solid #4ade80;
+  outline-offset: 2px;
+}
+
 .hint {
   color: #94a3b8;
   font-size: 11px;
@@ -114,10 +120,19 @@ input[type="password"]:focus {
   background: #1e293b;
 }
 
+.segmented button:focus-visible {
+  outline: 2px solid transparent;
+  box-shadow: inset 0 0 0 2px #4ade80;
+}
+
 .segmented button.active {
   background: #4ade80;
   color: #0f172a;
   font-weight: 600;
+}
+
+.segmented button.active:focus-visible {
+  box-shadow: inset 0 0 0 2px #0f172a;
 }
 
 .radio-group {
@@ -139,12 +154,6 @@ input[type="password"]:focus {
 input[type="radio"],
 input[type="checkbox"] {
   accent-color: #4ade80;
-}
-
-button:focus-visible,
-input:focus-visible {
-  outline: 2px solid #4ade80;
-  outline-offset: 2px;
 }
 
 button.primary {


### PR DESCRIPTION
### 💡 What
Replaced the default `outline` with an `inset box-shadow` for `:focus-visible` state on `.segmented button`s in `popup.css`.

### 🎯 Why
The `.segmented` container uses `overflow: hidden`, which visually clips the standard 2px `outline` of its child buttons when they are focused via keyboard navigation. Using an `inset` box shadow ensures the focus ring is drawn *inside* the button boundaries and won't be clipped.

### 📸 Before/After
*(See attached Frontend Verification screenshots)*

### ♿ Accessibility
Improves keyboard navigation accessibility by ensuring focus rings are clearly visible on the operation mode toggle buttons. Uses `outline: 2px solid transparent;` to maintain compatibility with Windows High Contrast Mode while hiding the native outline. Also ensures the focus ring color contrasts sufficiently against both the active (`#4ade80` against `#1e293b`) and inactive (`#0f172a` against `#4ade80`) background states.

---
*PR created automatically by Jules for task [10477105193769525641](https://jules.google.com/task/10477105193769525641) started by @n24q02m*