### PR TITLE
🎨 Palette: Fix clipped focus ring on segmented buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -34,3 +34,6 @@
 ## 2025-06-30 - Native Semantic Elements for Groups
 **Learning:** Using `role="group"` and `role="radiogroup"` with `aria-labelledby` on `div` elements triggers `noLabelWithoutControl` a11y linter warnings, as these labels are not semantically linked to an input control via a `for` attribute in the same way native HTML works.
 **Action:** Always prefer native semantic elements like `<fieldset>` and `<legend>` for grouping related form controls. To prevent `<fieldset>` from breaking existing CSS layouts (like flexbox/grid) and injecting browser defaults, use `<fieldset style="border: none; padding: 0; margin: 0; display: contents;">`. Ensure the `<legend>` tag inherits the same styling as the generic `label` tag.
+## 2024-05-15 - Fix clipped focus rings with inset box-shadow
+**Learning:** When using inset box-shadow for focus rings to avoid clipping from overflow:hidden containers, ensure the shadow color contrasts with both active and inactive states. An inset shadow matching the background color becomes invisible.
+**Action:** Use outline: 2px solid transparent to retain Windows High Contrast Mode support, and select a contrasting inset shadow color (like #0f172a) for active states.

--- a/popup.css
+++ b/popup.css
@@ -147,6 +147,15 @@ input:focus-visible {
   outline-offset: 2px;
 }
 
+.segmented button:focus-visible {
+  outline: 2px solid transparent;
+  box-shadow: inset 0 0 0 2px #4ade80;
+}
+
+.segmented button.active:focus-visible {
+  box-shadow: inset 0 0 0 2px #0f172a;
+}
+
 button.primary {
   display: block;
   width: 100%;


### PR DESCRIPTION
💡 What: Replaced the default outline focus ring with an inset box-shadow for segmented buttons.
🎯 Why: The previous outline focus ring was clipped due to the parent container's `overflow: hidden` property.
📸 Before/After: Visual focus ring is now fully visible and correctly adapts color contrast for active states.
♿ Accessibility: Retained Windows High Contrast Mode support by using `outline: 2px solid transparent` and ensuring the focus ring contrasts well against both active and inactive states.

---
*PR created automatically by Jules for task [11392374648371808857](https://jules.google.com/task/11392374648371808857) started by @n24q02m*