### PR TITLE
⚡ Bolt: Cache PR fetch promises to prevent concurrent duplicate requests

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2025-02-24 - Nested Regex vs State Machine
 **Learning:** In modern JavaScript engines, adding a redundant `regex.test()` before a `replace(regex, callback)` is a flawed optimization because V8 inherently bypasses the callback if there is no match. Furthermore, replacing complex nested regular expressions with a single-pass `for` loop state machine using `charCodeAt()` avoids large intermediate string allocations and iteration overhead, providing massive speedups for large text payloads.
 **Action:** Do not use `regex.test()` to guard a `replace()`. Instead, for critical hot paths parsing large payloads with complex constraints (like finding control characters only inside JSON strings), use a single-pass character loop state machine and `str.slice()` for unmodified chunks.
+## 2025-02-25 - Request Coalescing
+**Learning:** When fetching external data (like PRs) in parallel across multiple tabs, caching only the *resolved* result leads to thundering herd problems where multiple identical network requests are fired concurrently.
+**Action:** Cache the *Promise* of the fetch operation synchronously (request coalescing) so concurrent calls to the same resource wait on the same in-flight network request, saving API quota and time.

--- a/background.js
+++ b/background.js
@@ -817,36 +817,42 @@ async function processSuggestionsForTab(tab, options) {
 
 const prCache = new Map()
 
-async function getOpenPRs(owner, repo, token) {
+function getOpenPRs(owner, repo, token) {
   const key = `${owner}/${repo}`
   if (prCache.has(key)) return prCache.get(key)
 
-  try {
-    if (typeof owner !== 'string' || typeof repo !== 'string') {
-      throw new Error('Owner and repo must be strings')
+  // ⚡ Bolt Optimization: Cache the Promise of the fetch operation instead of the resolved data
+  // (Request Coalescing). This prevents the "thundering herd" problem where multiple parallel
+  // background tabs processing the same repo all trigger simultaneous GitHub API requests.
+  // Subsequent concurrent calls will now await this same in-flight Promise.
+  const fetchPromise = (async () => {
+    try {
+      if (typeof owner !== 'string' || typeof repo !== 'string') {
+        throw new Error('Owner and repo must be strings')
+      }
+
+      const url = new URL(`https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/pulls`)
+      url.searchParams.set('state', 'open')
+      url.searchParams.set('per_page', '100')
+
+      const res = await jFetch(url.toString(), {
+        headers: { Accept: 'application/vnd.github+json' },
+        token
+      })
+      const prs = await res.json()
+      return prs.map((pr) => ({
+        title: pr.title || '',
+        titleLower: (pr.title || '').toLowerCase(),
+        branch: pr.head?.ref || ''
+      }))
+    } catch (e) {
+      addLog(`  WARNING: Could not check PRs for ${key}: ${e.message}`)
+      return []
     }
+  })()
 
-    const url = new URL(`https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/pulls`)
-    url.searchParams.set('state', 'open')
-    url.searchParams.set('per_page', '100')
-
-    const res = await jFetch(url.toString(), {
-      headers: { Accept: 'application/vnd.github+json' },
-      token
-    })
-    const prs = await res.json()
-    const mapped = prs.map((pr) => ({
-      title: pr.title || '',
-      titleLower: (pr.title || '').toLowerCase(),
-      branch: pr.head?.ref || ''
-    }))
-    prCache.set(key, mapped)
-    return mapped
-  } catch (e) {
-    addLog(`  WARNING: Could not check PRs for ${key}: ${e.message}`)
-    prCache.set(key, [])
-    return []
-  }
+  prCache.set(key, fetchPromise)
+  return fetchPromise
 }
 
 // ⚡ Bolt Optimization: Replace `.some()` with a standard for loop to avoid

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -916,7 +916,7 @@ describe('getOpenPRs', () => {
     await sandbox.test_getOpenPRs('own', 'rep', null)
 
     assert.strictEqual(sandbox.test_prCache.has(key), true)
-    const cached = sandbox.test_prCache.get(key)
+    const cached = await sandbox.test_prCache.get(key)
     assert.strictEqual(cached.length, 1)
     assert.strictEqual(cached[0].title, 'PR')
   })


### PR DESCRIPTION
💡 What: Refactored `getOpenPRs` to cache the Promise of the fetch request instead of the resolved data array.
🎯 Why: Prevents the "thundering herd" problem where parallel tabs/tasks dispatch redundant, simultaneous GitHub API requests for the same repository before the first one completes, wasting API quota and network resources.
📊 Impact: Reduces duplicate network calls to 0 during parallel cross-tab runs. Subsequent identical requests instantly join the existing in-flight Promise queue without allocating duplicate fetch cycles.
🔬 Measurement: Verify by executing a multi-tab Archive run that hits the same `owner/repo`. Network devtools will show only 1 outgoing request for the PRs instead of 1-per-tab. Tests updated to reflect the new cached Promise return type.

---
*PR created automatically by Jules for task [2630198175665468418](https://jules.google.com/task/2630198175665468418) started by @n24q02m*