### PR TITLE
fix: emit conventional commit titles for renovate dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -54,5 +54,11 @@
       "matchPackageNames": ["node"],
       "allowedVersions": ">=24.0.0 <25.0.0"
     }
-  ]
+  ],
+  "semanticCommits": "enabled",
+  "commitMessagePrefix": "fix(deps):",
+  "commitMessageAction": "update",
+  "commitMessageTopic": "{{depName}}",
+  "semanticCommitType": "fix",
+  "semanticCommitScope": "deps"
 }


### PR DESCRIPTION
## Why

`renovate.json` here lists `":semanticCommits"` in `extends`, which is **not** sufficient on its own — Renovate still falls back to `chore(deps):` for github-actions and major bumps. Two consequences:

- `chore:` is not an allowed commit prefix in this org (only `fix:` / `feat:`).
- python-semantic-release does not count a `chore` commit, so a dependency bump lands on `main` and is never released — a silent no-op release.

Observed live: this repos Renovate Dependency Dashboard queues the better-semantic-release bump as `chore(deps): update ... to v1.2.2`, while repos carrying the explicit block queue it as `fix(deps): ...`.

## What

Adds the identical six-key block that `mcp-core` and `web-core` already carry:

```json
"semanticCommits": "enabled",
"commitMessagePrefix": "fix(deps):",
"commitMessageAction": "update",
"commitMessageTopic": "{{depName}}",
"semanticCommitType": "fix",
"semanticCommitScope": "deps"
```

Config only — no source change. The edit was applied by script and asserted to leave every pre-existing key byte-identical (parse before, parse after, diff the dicts).

Found by an audit across all 37 non-archived repos in the Productions + Scripts lists: 21 cut releases, all standardized on `n24q02m/better-semantic-release`, and 6 of them were missing this block.