### PR TITLE
🎨 Palette: Add form wrapping for native validation and Enter-to-submit accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -37,3 +37,6 @@
 ## 2024-05-15 - Fix clipped focus rings with inset box-shadow
 **Learning:** When using inset box-shadow for focus rings to avoid clipping from overflow:hidden containers, ensure the shadow color contrasts with both active and inactive states. An inset shadow matching the background color becomes invisible.
 **Action:** Use outline: 2px solid transparent to retain Windows High Contrast Mode support, and select a contrasting inset shadow color (like #0f172a) for active states.
+## 2026-10-25 - Form Native Submit Accessibility
+**Learning:** Attaching primary actions to a `button click` event rather than a `form submit` event breaks native HTML validation and makes it impossible for keyboard users to submit simply by pressing "Enter" within input fields.
+**Action:** Always wrap form inputs and their primary submit button in a `<form>` element, and listen to the `submit` event rather than the button `click`. This enables Enter-to-submit by default and allows using native attributes like `maxlength` or `pattern` robustly. Additionally, wrap fields in a `<fieldset>` to easily disable all inputs at once during processing states.

--- a/popup.html
+++ b/popup.html
@@ -11,6 +11,8 @@
       <span class="version">v2.0</span>
     </header>
 
+    <form id="mainForm">
+      <fieldset id="formControls" style="border: none; padding: 0; margin: 0; min-width: 0;">
     <section class="options">
       <h2>Options</h2>
       <div class="setting-row">
@@ -68,9 +70,11 @@
         />
       </label>
     </section>
+      </fieldset>
 
-    <button type="button" id="startBtn" class="primary">Start Archiving</button>
-    <button type="button" id="resetBtn" class="secondary" style="display: none">Reset</button>
+      <button type="submit" id="startBtn" class="primary">Start Archiving</button>
+      <button type="button" id="resetBtn" class="secondary" style="display: none">Reset</button>
+    </form>
 
     <section id="progressSection" style="display: none">
       <h2>Progress</h2>

--- a/popup.js
+++ b/popup.js
@@ -18,6 +18,8 @@ const ghTokenInput = $('#ghToken')
 const forceCheckbox = $('#force')
 const startBtn = $('#startBtn')
 const resetBtn = $('#resetBtn')
+const mainForm = $('#mainForm')
+const formControls = $('#formControls')
 const progressSection = $('#progressSection')
 const summarySection = $('#summarySection')
 const currentInfo = $('#currentInfo')
@@ -122,7 +124,9 @@ ghTokenInput.addEventListener('change', () => {
 })
 
 // --- Start operation ---
-startBtn.addEventListener('click', async () => {
+mainForm.addEventListener('submit', async (e) => {
+  e.preventDefault()
+
   // Save settings first, ensuring token is only in local storage
   chrome.storage.sync.set({
     ghOwner: ghOwnerInput.value.trim().slice(0, MAX_OWNER_LEN)
@@ -156,6 +160,7 @@ startBtn.addEventListener('click', async () => {
   // Reset UI
   startBtn.disabled = true
   startBtn.setAttribute('aria-busy', 'true')
+  formControls.disabled = true
   startBtn.textContent = getRunningText()
   resetBtn.style.display = 'none'
   progressSection.style.display = 'block'
@@ -172,6 +177,7 @@ startBtn.addEventListener('click', async () => {
 resetBtn.addEventListener('click', () => {
   chrome.runtime.sendMessage({ action: 'RESET' })
   startBtn.disabled = false
+  formControls.disabled = false
   startBtn.removeAttribute('aria-busy')
   updateOpModeUI(opMode)
   resetBtn.style.display = 'none'
@@ -217,6 +223,7 @@ function renderState(state) {
   // Done or error
   if (state.status === 'done' || state.status === 'error') {
     startBtn.disabled = false
+    formControls.disabled = false
     startBtn.removeAttribute('aria-busy')
     updateOpModeUI(opMode)
     resetBtn.style.display = 'block'
@@ -283,6 +290,7 @@ chrome.runtime.sendMessage({ action: 'GET_STATE' }, (state) => {
     renderState(state)
     if (state.status === 'running') {
       startBtn.disabled = true
+      formControls.disabled = true
       startBtn.setAttribute('aria-busy', 'true')
       startBtn.textContent = getRunningText()
     } else {

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -41,11 +41,11 @@ function createMockElement(tag = 'div', attrs = {}) {
       if (!element.listeners[type]) element.listeners[type] = []
       element.listeners[type].push(cb)
     },
-    dispatchEvent: (type) => {
+    dispatchEvent: async (type, eventArg = {}) => {
       if (element.listeners?.[type]) {
-        element.listeners[type].forEach((cb) => {
-          cb({ target: element })
-        })
+        for (const cb of element.listeners[type]) {
+          await cb({ target: element, preventDefault: () => {}, ...eventArg })
+        }
       }
     },
     style: { display: '' },
@@ -197,6 +197,8 @@ function setupPopupSandbox() {
     '#force': createMockElement('input', { type: 'checkbox' }),
     '#startBtn': createMockElement('button'),
     'input[name="mode"]:checked': createMockElement('input', { value: 'dry' }),
+    '#mainForm': createMockElement('form'),
+    '#formControls': createMockElement('fieldset'),
     '#resetBtn': createMockElement('button'),
     '#progressSection': createMockElement('section'),
     '#summarySection': createMockElement('section'),
@@ -299,6 +301,7 @@ describe('renderState', () => {
 
     assert.strictEqual(elements['#progressFill'].style.width, '100%')
     assert.strictEqual(elements['#startBtn'].disabled, false)
+    assert.strictEqual(elements['#formControls'].disabled, false)
     assert.strictEqual(elements['#resetBtn'].style.display, 'block')
     assert.strictEqual(elements['#summarySection'].style.display, 'block')
     assert.strictEqual(elements['#progressFill'].parentElement.getAttribute('aria-valuenow'), '100')
@@ -375,7 +378,7 @@ describe('Initialization and Storage', () => {
 })
 
 describe('Button Event Handlers', () => {
-  it('should send START message when startBtn is clicked', async () => {
+  it('should send START message when mainForm is submitted', async () => {
     const { sandbox, elements } = setupPopupSandbox()
     let sentMessage = null
     sandbox.chrome.runtime.sendMessage = (msg) => {
@@ -387,10 +390,13 @@ describe('Button Event Handlers', () => {
     elements['#ghOwner'].value = 'test-owner'
     elements['#ghToken'].value = 'test-token'
 
-    await elements['#startBtn'].dispatchEvent('click')
+    await elements['#mainForm'].dispatchEvent('submit', {
+      preventDefault: () => {}
+    })
 
     assert.strictEqual(sentMessage.action, 'START')
     assert.strictEqual(sentMessage.options.opMode, 'archive')
+    assert.strictEqual(elements['#formControls'].disabled, true)
     assert.strictEqual(elements['#startBtn'].disabled, true)
     assert.strictEqual(elements['#startBtn'].textContent, '⏳ Dry Running Archive...')
   })
@@ -408,6 +414,7 @@ describe('Button Event Handlers', () => {
 
     assert.strictEqual(sentMessage.action, 'RESET')
     assert.strictEqual(elements['#startBtn'].disabled, false)
+    assert.strictEqual(elements['#formControls'].disabled, false)
     assert.strictEqual(elements['#startBtn'].textContent, 'Dry Run Archive')
     assert.strictEqual(elements['#resetBtn'].style.display, 'none')
   })


### PR DESCRIPTION
💡 What: Wrapped inputs in a `<form>` and `<fieldset>` and listened to `submit` instead of `click`.
🎯 Why: Using a primary action button purely with JS `click` events breaks HTML validation (like `pattern` and `maxlength`) and prevents keyboard users from easily pressing Enter to submit.
📸 Before/After: Visual changes are transparent, but keyboard operation and native validation now function correctly.
♿ Accessibility: Enabling Enter-to-submit creates a more standard, expected interaction model for screen reader and keyboard-only users.

---
*PR created automatically by Jules for task [9644307086767574390](https://jules.google.com/task/9644307086767574390) started by @n24q02m*