### PR TITLE
⚡ Bolt: Optimize task PR matching performance

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -7,3 +7,7 @@
 ## 2025-02-25 - Request Coalescing
 **Learning:** When fetching external data (like PRs) in parallel across multiple tabs, caching only the *resolved* result leads to thundering herd problems where multiple identical network requests are fired concurrently.
 **Action:** Cache the *Promise* of the fetch operation synchronously (request coalescing) so concurrent calls to the same resource wait on the same in-flight network request, saving API quota and time.
+
+## 2025-02-25 - Bidirectional Substring Matching
+**Learning:** In bidirectional substring matching (e.g., `A.includes(B) || B.includes(A)`), evaluating `.includes()` in both directions is redundant because a longer string cannot be contained within a shorter one.
+**Action:** Compare string lengths (`A.length >= B.length`) before executing the `.includes()` check to prevent redundant evaluations and string searching overhead.

--- a/background.js
+++ b/background.js
@@ -857,14 +857,18 @@ function getOpenPRs(owner, repo, token) {
 
 // ⚡ Bolt Optimization: Replace `.some()` with a standard for loop to avoid
 // closure allocation overhead in this hot path called for every task.
+// Additionally, compare string lengths before bidirectional `.includes()` to
+// prevent redundant evaluation, as a longer string cannot be contained in a shorter one.
 function taskHasOpenPR(task, openPRs) {
   if (openPRs.length === 0) return false
   const taskTitle = (task.title || '').toLowerCase()
   if (!taskTitle || taskTitle === '(untitled)') return false
+  const taskLen = taskTitle.length
 
   for (let i = 0; i < openPRs.length; i++) {
     const pr = openPRs[i]
-    if (pr.titleLower.includes(taskTitle) || taskTitle.includes(pr.titleLower)) {
+    const prLen = pr.titleLower.length
+    if (prLen >= taskLen ? pr.titleLower.includes(taskTitle) : taskTitle.includes(pr.titleLower)) {
       return true
     }
   }


### PR DESCRIPTION
**💡 What:**
Optimized the bidirectional substring matching loop in `taskHasOpenPR` by comparing string lengths before performing `.includes()` checks.

**🎯 Why:**
When checking `A.includes(B) || B.includes(A)`, checking the second condition is redundant if the first fails and `A` is longer than `B`. Because a longer string cannot be contained in a shorter one, we can skip one of the `.includes()` calls depending on the relative string lengths. Since this function is called for every task against every open PR, this micro-optimization reduces string searching overhead on a hot path.

**📊 Impact:**
Reduces the number of `.includes()` evaluations by up to 50% for task title matching against PR titles, improving iteration performance for large batches of tasks.

**🔬 Measurement:**
1. Ran `pnpm test` to verify no functionality or regressions were introduced.
2. Verified that string length comparisons correctly guard the `.includes()` operations.

---
*PR created automatically by Jules for task [13932923818365640989](https://jules.google.com/task/13932923818365640989) started by @n24q02m*