### PR TITLE
🎨 Palette: Wrap inputs in semantic form

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -37,3 +37,7 @@
 ## 2024-05-15 - Fix clipped focus rings with inset box-shadow
 **Learning:** When using inset box-shadow for focus rings to avoid clipping from overflow:hidden containers, ensure the shadow color contrasts with both active and inactive states. An inset shadow matching the background color becomes invisible.
 **Action:** Use outline: 2px solid transparent to retain Windows High Contrast Mode support, and select a contrasting inset shadow color (like #0f172a) for active states.
+
+## 2026-07-30 - Wrap form inputs in a semantic <form> tag
+**Learning:** Native HTML5 validation attributes (`pattern`, `maxlength`) are bypassed if the primary submit button is not inside a semantic `<form>` element. To trigger native validation UI and enable implicit 'Enter' key submission, always wrap form inputs in a `<form>`.
+**Action:** Use native semantic `<form>` element and handle the `submit` event rather than relying entirely on button clicks.

--- a/popup.html
+++ b/popup.html
@@ -11,6 +11,7 @@
       <span class="version">v2.0</span>
     </header>
 
+    <form id="mainForm">
     <section class="options">
       <h2>Options</h2>
       <div class="setting-row">
@@ -69,7 +70,8 @@
       </label>
     </section>
 
-    <button type="button" id="startBtn" class="primary">Start Archiving</button>
+    <button type="submit" id="startBtn" class="primary">Start Archiving</button>
+    </form>
     <button type="button" id="resetBtn" class="secondary" style="display: none">Reset</button>
 
     <section id="progressSection" style="display: none">

--- a/popup.js
+++ b/popup.js
@@ -13,6 +13,7 @@ const MAX_OWNER_LEN = 39
 const MAX_TOKEN_LEN = 255
 
 // --- DOM refs ---
+const mainForm = $('#mainForm')
 const ghOwnerInput = $('#ghOwner')
 const ghTokenInput = $('#ghToken')
 const forceCheckbox = $('#force')
@@ -122,7 +123,9 @@ ghTokenInput.addEventListener('change', () => {
 })
 
 // --- Start operation ---
-startBtn.addEventListener('click', async () => {
+mainForm.addEventListener('submit', async (e) => {
+  e.preventDefault()
+
   // Save settings first, ensuring token is only in local storage
   chrome.storage.sync.set({
     ghOwner: ghOwnerInput.value.trim().slice(0, MAX_OWNER_LEN)

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -44,7 +44,7 @@ function createMockElement(tag = 'div', attrs = {}) {
     dispatchEvent: (type) => {
       if (element.listeners?.[type]) {
         element.listeners[type].forEach((cb) => {
-          cb({ target: element })
+          cb({ target: element, preventDefault: () => {} })
         })
       }
     },
@@ -192,6 +192,7 @@ function setupPopupSandbox() {
   }
 
   const elements = {
+    '#mainForm': createMockElement('form'),
     '#ghOwner': createMockElement('input'),
     '#ghToken': createMockElement('input'),
     '#force': createMockElement('input', { type: 'checkbox' }),
@@ -387,7 +388,7 @@ describe('Button Event Handlers', () => {
     elements['#ghOwner'].value = 'test-owner'
     elements['#ghToken'].value = 'test-token'
 
-    await elements['#startBtn'].dispatchEvent('click')
+    await elements['#mainForm'].dispatchEvent('submit')
 
     assert.strictEqual(sentMessage.action, 'START')
     assert.strictEqual(sentMessage.options.opMode, 'archive')


### PR DESCRIPTION
### 💡 What
Wrapped the inputs and submit button in a semantic `<form>` element in `popup.html`, changed the start button to `type="submit"`, and modified `popup.js` to listen for the `submit` event instead of the `click` event.

### 🎯 Why
Native HTML5 validation attributes (`pattern`, `maxlength`) are bypassed if the primary submit button is not inside a semantic `<form>` element. By wrapping the inputs in a `<form>`, we trigger native validation UI and enable implicit 'Enter' key submission without needing manual `keydown` event listeners.

### 📸 Before/After
*(Visual verification completed with Playwright to ensure layout remains unchanged and form submission is triggered correctly by pressing "Enter")*

### ♿ Accessibility
Improves keyboard accessibility by allowing users to submit the form directly via the 'Enter' key while focused on any input field, and relies on native browser validation UI which is generally more robust for screen readers.

---
*PR created automatically by Jules for task [14336106897077764375](https://jules.google.com/task/14336106897077764375) started by @n24q02m*