### PR TITLE
🛡️ Sentinel: [MEDIUM] Add input validation on user form

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The extension's Content Security Policy (CSP) in `manifest.json` lacked explicit `default-src 'none'` and broad network constraints, relying solely on script and object restrictions.
 **Learning:** A permissive CSP allows unexpected resource loading and potential data exfiltration if an XSS vulnerability occurs. A strict whitelist (`default-src 'none'`) provides a robust defense-in-depth layer.
 **Prevention:** Always define a strict CSP for extensions, setting `default-src 'none'` and explicitly allowing only required origins (e.g., `connect-src`).
+
+## 2024-07-25 - Add Input Validation and Enter Key Submission to Popup
+**Vulnerability:** The popup form inputs bypassed native HTML5 validation constraints (`pattern`, `maxlength`) because the primary submit button was not inside a semantic `<form>`, allowing potentially invalid strings to be processed.
+**Learning:** When form elements cannot be wrapped in a `<form>` to avoid layout breakage, native validation must be enforced manually via `.reportValidity()` during the click handler, and implicit 'Enter' key submission restored via a `keydown` listener, to prevent invalid user data injection.
+**Prevention:** Always ensure input validation is triggered, either implicitly via `<form>` wrapping or explicitly via JavaScript `.reportValidity()`, before processing user inputs.

--- a/popup.js
+++ b/popup.js
@@ -123,6 +123,8 @@ ghTokenInput.addEventListener('change', () => {
 
 // --- Start operation ---
 startBtn.addEventListener('click', async () => {
+  if (!ghOwnerInput.reportValidity() || !ghTokenInput.reportValidity()) return
+
   // Save settings first, ensuring token is only in local storage
   chrome.storage.sync.set({
     ghOwner: ghOwnerInput.value.trim().slice(0, MAX_OWNER_LEN)
@@ -287,6 +289,16 @@ chrome.runtime.sendMessage({ action: 'GET_STATE' }, (state) => {
       startBtn.textContent = getRunningText()
     } else {
       resetBtn.style.display = 'block'
+    }
+  }
+})
+
+// --- Keyboard support ---
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter') {
+    if (!startBtn.disabled && startBtn.style.display !== 'none' && !startBtn.hasAttribute('aria-busy')) {
+      e.preventDefault()
+      startBtn.click()
     }
   }
 })

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -73,6 +73,7 @@ function createMockElement(tag = 'div', attrs = {}) {
     focus: () => {
       element.focused = true
     },
+    reportValidity: () => true,
     textContent: '',
     value: '',
     checked: false,
@@ -177,7 +178,8 @@ function createMockDocument(elements, opModeButtons, radioStates) {
       const frag = createMockElement('documentfragment')
       frag.nodeType = 11
       return frag
-    }
+    },
+    addEventListener: () => {}
   }
 }
 

--- a/tests/security.test.js
+++ b/tests/security.test.js
@@ -80,7 +80,8 @@ describe('Security: ghToken Storage Cleanup', () => {
       }),
       createElement: () => ({
         appendChild: () => {}
-      })
+      }),
+      addEventListener: () => {}
     }
 
     const sandbox = { chrome, document, console, setTimeout, setInterval, clearInterval }


### PR DESCRIPTION
- Enforce `.reportValidity()` on inputs in popup.js `startBtn` click handler to prevent invalid user data injection.
- Add `keydown` event listener in `popup.js` to restore implicit 'Enter' key submission capability that was missing since inputs were not enclosed in a semantic `<form>`.
- Add Sentinel journal learning explaining the vulnerability and the fix.
- Ensure the `tests/security.test.js` and `tests/popup.test.js` test files correctly mock the newly added DOM methods to keep tests green.

---
*PR created automatically by Jules for task [9126727745556208856](https://jules.google.com/task/9126727745556208856) started by @n24q02m*