### PR TITLE
🎨 Palette: enable native form validation and implicit Enter submission

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -37,3 +37,6 @@
 ## 2024-05-15 - Fix clipped focus rings with inset box-shadow
 **Learning:** When using inset box-shadow for focus rings to avoid clipping from overflow:hidden containers, ensure the shadow color contrasts with both active and inactive states. An inset shadow matching the background color becomes invisible.
 **Action:** Use outline: 2px solid transparent to retain Windows High Contrast Mode support, and select a contrasting inset shadow color (like #0f172a) for active states.
+## 2025-06-31 - Native Form Validation
+**Learning:** Native HTML5 validation attributes (`pattern`, `maxlength`) are bypassed if the primary submit button is not inside a semantic `<form>` element.
+**Action:** Always wrap form inputs in a `<form>` to trigger native validation UI and enable implicit "Enter" key submission.

--- a/popup.html
+++ b/popup.html
@@ -11,7 +11,8 @@
       <span class="version">v2.0</span>
     </header>
 
-    <section class="options">
+    <form id="mainForm">
+      <section class="options">
       <h2>Options</h2>
       <div class="setting-row">
         <fieldset style="border: none; padding: 0; margin: 0; display: contents;">
@@ -67,9 +68,10 @@
           maxlength="255"
         />
       </label>
-    </section>
+      </section>
 
-    <button type="button" id="startBtn" class="primary">Start Archiving</button>
+      <button type="submit" id="startBtn" class="primary">Start Archiving</button>
+    </form>
     <button type="button" id="resetBtn" class="secondary" style="display: none">Reset</button>
 
     <section id="progressSection" style="display: none">

--- a/popup.js
+++ b/popup.js
@@ -122,7 +122,8 @@ ghTokenInput.addEventListener('change', () => {
 })
 
 // --- Start operation ---
-startBtn.addEventListener('click', async () => {
+$('#mainForm').addEventListener('submit', async (e) => {
+  e.preventDefault()
   // Save settings first, ensuring token is only in local storage
   chrome.storage.sync.set({
     ghOwner: ghOwnerInput.value.trim().slice(0, MAX_OWNER_LEN)

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -44,7 +44,7 @@ function createMockElement(tag = 'div', attrs = {}) {
     dispatchEvent: (type) => {
       if (element.listeners?.[type]) {
         element.listeners[type].forEach((cb) => {
-          cb({ target: element })
+          cb({ target: element, preventDefault: () => {} })
         })
       }
     },
@@ -192,6 +192,7 @@ function setupPopupSandbox() {
   }
 
   const elements = {
+    '#mainForm': createMockElement('form'),
     '#ghOwner': createMockElement('input'),
     '#ghToken': createMockElement('input'),
     '#force': createMockElement('input', { type: 'checkbox' }),
@@ -387,7 +388,7 @@ describe('Button Event Handlers', () => {
     elements['#ghOwner'].value = 'test-owner'
     elements['#ghToken'].value = 'test-token'
 
-    await elements['#startBtn'].dispatchEvent('click')
+    await elements['#mainForm'].dispatchEvent('submit')
 
     assert.strictEqual(sentMessage.action, 'START')
     assert.strictEqual(sentMessage.options.opMode, 'archive')


### PR DESCRIPTION
💡 What: Wrapped the popup configuration sections in a `<form id="mainForm">`, changed the action button to `type="submit"`, and updated `popup.js` to listen for the `submit` event instead of a `click` event.
🎯 Why: Native HTML5 validation attributes (`pattern`, `maxlength`) on the inputs were being bypassed because the inputs and submission button were not within a semantic `<form>` tag.
📸 Before/After: Visuals remain unchanged.
♿ Accessibility: Implicit "Enter" key submission is now natively supported across all inputs in the popup.

---
*PR created automatically by Jules for task [11514885822918131195](https://jules.google.com/task/11514885822918131195) started by @n24q02m*