### PR TITLE
fix: bring the README license badge in line with Apache-2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Chrome Extension for bulk operations on Jules tasks via batchexecute API -- archive tasks and start code suggestions at scale.**
 
 [![CI](https://github.com/n24q02m/jules-task-archiver/actions/workflows/ci.yml/badge.svg)](https://github.com/n24q02m/jules-task-archiver/actions/workflows/ci.yml)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Renovate](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://renovatebot.com)
 [![semantic-release](https://img.shields.io/badge/semantic--release-conventionalcommits-e10079?logo=semantic-release)](https://github.com/semantic-release/semantic-release)
 
@@ -162,4 +162,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 ## License
 
-[MIT](LICENSE)
+[Apache-2.0](LICENSE)


### PR DESCRIPTION
Follow-up to #648. The LICENSE became Apache-2.0 but the README still showed the MIT badge and linked its License section to MIT, so the repo contradicted itself in public.

Found while extending `scripts/repo-bootstrap/license_migrate.py` to rewrite the declarations a repo makes about its own license -- packaging metadata, release manifests, citation metadata and the README badge -- rather than the LICENSE file alone.