### PR TITLE
🎨 Palette: Enable native HTML form validation and Enter key submission

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -37,3 +37,6 @@
 ## 2024-05-15 - Fix clipped focus rings with inset box-shadow
 **Learning:** When using inset box-shadow for focus rings to avoid clipping from overflow:hidden containers, ensure the shadow color contrasts with both active and inactive states. An inset shadow matching the background color becomes invisible.
 **Action:** Use outline: 2px solid transparent to retain Windows High Contrast Mode support, and select a contrasting inset shadow color (like #0f172a) for active states.
+## 2027-10-25 - Form Submission and Native Validation
+**Learning:** Inputs (like the GitHub username) inside `popup.html` have native HTML5 validation constraints (e.g. `pattern="^[a-zA-Z0-9-]+$"`, `maxlength`). However, if the primary submit button is not wrapped inside a semantic `<form>` element, these native validation tools are completely bypassed when the button is clicked, reducing accessibility and causing silent validation failures on the frontend. Additionally, without a `<form>`, users cannot hit the "Enter" key implicitly to submit the action.
+**Action:** Always wrap form inputs in a `<form>` element. Attach a submit event listener to the form element, explicitly invoking `e.preventDefault()` inside the event handler instead of using a `click` listener directly on the primary button. Update tests to use the `submit` event to dispatch properly.

--- a/popup.html
+++ b/popup.html
@@ -11,7 +11,8 @@
       <span class="version">v2.0</span>
     </header>
 
-    <section class="options">
+    <form id="mainForm">
+      <section class="options">
       <h2>Options</h2>
       <div class="setting-row">
         <fieldset style="border: none; padding: 0; margin: 0; display: contents;">
@@ -69,8 +70,9 @@
       </label>
     </section>
 
-    <button type="button" id="startBtn" class="primary">Start Archiving</button>
+    <button type="submit" id="startBtn" class="primary">Start Archiving</button>
     <button type="button" id="resetBtn" class="secondary" style="display: none">Reset</button>
+    </form>
 
     <section id="progressSection" style="display: none">
       <h2>Progress</h2>

--- a/popup.js
+++ b/popup.js
@@ -24,6 +24,7 @@ const currentInfo = $('#currentInfo')
 const progressFill = $('#progressFill')
 const logPre = $('#log')
 const summaryDiv = $('#summary')
+const mainForm = $('#mainForm')
 
 // --- Operation mode state ---
 let opMode = 'archive'
@@ -122,7 +123,8 @@ ghTokenInput.addEventListener('change', () => {
 })
 
 // --- Start operation ---
-startBtn.addEventListener('click', async () => {
+mainForm.addEventListener('submit', async (e) => {
+  e.preventDefault()
   // Save settings first, ensuring token is only in local storage
   chrome.storage.sync.set({
     ghOwner: ghOwnerInput.value.trim().slice(0, MAX_OWNER_LEN)

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -44,7 +44,7 @@ function createMockElement(tag = 'div', attrs = {}) {
     dispatchEvent: (type) => {
       if (element.listeners?.[type]) {
         element.listeners[type].forEach((cb) => {
-          cb({ target: element })
+          cb({ target: element, preventDefault: () => {} })
         })
       }
     },
@@ -196,6 +196,7 @@ function setupPopupSandbox() {
     '#ghToken': createMockElement('input'),
     '#force': createMockElement('input', { type: 'checkbox' }),
     '#startBtn': createMockElement('button'),
+    '#mainForm': createMockElement('form'),
     'input[name="mode"]:checked': createMockElement('input', { value: 'dry' }),
     '#resetBtn': createMockElement('button'),
     '#progressSection': createMockElement('section'),
@@ -375,7 +376,7 @@ describe('Initialization and Storage', () => {
 })
 
 describe('Button Event Handlers', () => {
-  it('should send START message when startBtn is clicked', async () => {
+  it('should send START message when mainForm is submitted', async () => {
     const { sandbox, elements } = setupPopupSandbox()
     let sentMessage = null
     sandbox.chrome.runtime.sendMessage = (msg) => {
@@ -387,7 +388,7 @@ describe('Button Event Handlers', () => {
     elements['#ghOwner'].value = 'test-owner'
     elements['#ghToken'].value = 'test-token'
 
-    await elements['#startBtn'].dispatchEvent('click')
+    await elements['#mainForm'].dispatchEvent('submit')
 
     assert.strictEqual(sentMessage.action, 'START')
     assert.strictEqual(sentMessage.options.opMode, 'archive')


### PR DESCRIPTION
💡 What: Wrapped inputs and buttons in a `<form>` element and replaced the `click` listener with a `submit` listener using `e.preventDefault()`. Changed the "Start Archiving" button type to `submit`.
🎯 Why: Without a semantic `<form>`, native HTML5 validation constraints (like `pattern` and `maxlength`) on the GitHub username/token inputs were completely bypassed when clicking the primary action button. Furthermore, it prevented the user from pressing the "Enter" key to implicitly submit the form.
📸 Before/After: Verified visually via Playwright that UI behavior and layout are preserved.
♿ Accessibility: Enables native validation UI for screen readers and allows full keyboard-only form submission.

---
*PR created automatically by Jules for task [15089487762315425990](https://jules.google.com/task/15089487762315425990) started by @n24q02m*