### PR TITLE
🛡️ Sentinel: [MEDIUM] Replace Math.random with crypto.getRandomValues

### DIFF
--- a/background.js
+++ b/background.js
@@ -408,7 +408,9 @@ async function withRetry(fn) {
       return await fn()
     } catch (e) {
       if (attempt === RETRY_ATTEMPTS - 1 || !isRetryable(e.message)) throw e
-      const delay = RETRY_BASE_MS * 2 ** attempt + Math.random() * 200
+      const randomArray = new Uint32Array(1)
+      crypto.getRandomValues(randomArray)
+      const delay = RETRY_BASE_MS * 2 ** attempt + (randomArray[0] % 200)
       await new Promise((r) => setTimeout(r, delay))
     }
   }

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -534,7 +534,12 @@ describe('Retry Utilities', () => {
         delays.push(ms)
         fn()
       }
-      sandbox.Math.random = () => 0.5 // Constant jitter for testing
+      sandbox.crypto = {
+        getRandomValues: (arr) => {
+          arr[0] = 100 // Constant jitter for testing (100 % 200 = 100)
+          return arr
+        }
+      }
       const base = sandbox.test_RETRY_BASE_MS
 
       let calls = 0


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Used `Math.random()` for retry backoff jitter. While not used for cryptographic purposes, `Math.random()` provides weak pseudo-random number generation that is frequently flagged by SAST tools and linters as a security risk.
🎯 Impact: Non-cryptographic use cases like network retry jitter are not directly exploitable, but relying on `Math.random()` introduces predictable entropy. Fixing it clears security warnings and establishes defense-in-depth by standardizing on secure randomness APIs.
🔧 Fix: Replaced `Math.random()` with the Web Crypto API's `crypto.getRandomValues(new Uint32Array(1))` and modulo arithmetic to generate the jitter delay. Updated test mocks to support the new `crypto` implementation.
✅ Verification: Ran unit tests to confirm backoff logic behaves exactly as before.

---
*PR created automatically by Jules for task [3058356937806045898](https://jules.google.com/task/3058356937806045898) started by @n24q02m*