### PR TITLE
🎨 Palette: Wrap form inputs in a semantic <form>

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -37,3 +37,6 @@
 ## 2024-05-15 - Fix clipped focus rings with inset box-shadow
 **Learning:** When using inset box-shadow for focus rings to avoid clipping from overflow:hidden containers, ensure the shadow color contrasts with both active and inactive states. An inset shadow matching the background color becomes invisible.
 **Action:** Use outline: 2px solid transparent to retain Windows High Contrast Mode support, and select a contrasting inset shadow color (like #0f172a) for active states.
+## 2025-05-24 - Form Context and Implicit Submission
+**Learning:** Native HTML5 validation attributes (`pattern`, `maxlength`) are bypassed if the primary submit button is not inside a semantic `<form>` element. Furthermore, without a `<form>`, users cannot press 'Enter' to submit implicitly.
+**Action:** Always wrap form inputs and their primary action button in a `<form>` element, and use `type="submit"` for the primary button to trigger native validation UI and enable implicit 'Enter' key submission.

--- a/popup.html
+++ b/popup.html
@@ -11,6 +11,7 @@
       <span class="version">v2.0</span>
     </header>
 
+    <form id="mainForm">
     <section class="options">
       <h2>Options</h2>
       <div class="setting-row">
@@ -69,8 +70,9 @@
       </label>
     </section>
 
-    <button type="button" id="startBtn" class="primary">Start Archiving</button>
+    <button type="submit" id="startBtn" class="primary">Start Archiving</button>
     <button type="button" id="resetBtn" class="secondary" style="display: none">Reset</button>
+    </form>
 
     <section id="progressSection" style="display: none">
       <h2>Progress</h2>

--- a/popup.js
+++ b/popup.js
@@ -24,6 +24,7 @@ const currentInfo = $('#currentInfo')
 const progressFill = $('#progressFill')
 const logPre = $('#log')
 const summaryDiv = $('#summary')
+const mainForm = $('#mainForm')
 
 // --- Operation mode state ---
 let opMode = 'archive'
@@ -122,7 +123,8 @@ ghTokenInput.addEventListener('change', () => {
 })
 
 // --- Start operation ---
-startBtn.addEventListener('click', async () => {
+mainForm.addEventListener('submit', async (e) => {
+  e.preventDefault()
   // Save settings first, ensuring token is only in local storage
   chrome.storage.sync.set({
     ghOwner: ghOwnerInput.value.trim().slice(0, MAX_OWNER_LEN)

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -44,7 +44,7 @@ function createMockElement(tag = 'div', attrs = {}) {
     dispatchEvent: (type) => {
       if (element.listeners?.[type]) {
         element.listeners[type].forEach((cb) => {
-          cb({ target: element })
+          cb({ target: element, preventDefault: () => {} })
         })
       }
     },
@@ -205,7 +205,8 @@ function setupPopupSandbox() {
     '#log': createMockElement('pre'),
     '#summary': createMockElement('div'),
     '.settings': createMockElement('section'),
-    '.setting-row': createMockElement('div')
+    '.setting-row': createMockElement('div'),
+    '#mainForm': createMockElement('form')
   }
 
   // Parent element for elements that use .parentElement in popup.js
@@ -375,7 +376,7 @@ describe('Initialization and Storage', () => {
 })
 
 describe('Button Event Handlers', () => {
-  it('should send START message when startBtn is clicked', async () => {
+  it('should send START message when mainForm is submitted', async () => {
     const { sandbox, elements } = setupPopupSandbox()
     let sentMessage = null
     sandbox.chrome.runtime.sendMessage = (msg) => {
@@ -387,7 +388,7 @@ describe('Button Event Handlers', () => {
     elements['#ghOwner'].value = 'test-owner'
     elements['#ghToken'].value = 'test-token'
 
-    await elements['#startBtn'].dispatchEvent('click')
+    await elements['#mainForm'].dispatchEvent('submit')
 
     assert.strictEqual(sentMessage.action, 'START')
     assert.strictEqual(sentMessage.options.opMode, 'archive')


### PR DESCRIPTION
### 💡 What
Wrapped the inputs and primary action buttons within the Chrome Extension popup in a semantic `<form id="mainForm">` element. Converted the primary `#startBtn` button to `type="submit"` and updated the event listener in `popup.js` from `'click'` to `'submit'` (with `e.preventDefault()`). Updated corresponding tests in `tests/popup.test.js` to dispatch 'submit' instead of 'click'.

### 🎯 Why
Native HTML5 input validation attributes like `pattern` and `maxlength` (used on `#ghOwner` and `#ghToken`) are effectively bypassed in the UI unless their associated submit button sits inside a semantic `<form>` element. In the original implementation, invalid input would not trigger native browser tooltips explaining the error. Furthermore, without a `<form>`, users cannot implicitly submit their settings by simply pressing the "Enter" key while focused on a text field, forcing them to manually tab to (or click) the submit button. This change fixes both issues, drastically improving the accessibility and fluid usability of the extension interface.

### 📸 Before/After
*(Visuals remain structurally identical, but native validation UI tooltips now trigger on invalid input, and implicit 'Enter' key submission now functions correctly).*

### ♿ Accessibility
- Enables implicit form submission via the 'Enter' key, significantly improving the experience for keyboard-only users and screen reader navigation.
- Restores native browser validation UI (e.g., "Please match the requested format" for `pattern` mismatches), which provides immediate, accessible, and localized feedback to the user on validation failures.

---
*PR created automatically by Jules for task [16416490945351644301](https://jules.google.com/task/16416490945351644301) started by @n24q02m*