### PR TITLE
🛡️ Sentinel: [security improvement] Replace Math.random() with crypto.getRandomValues()

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** The extension's Content Security Policy (CSP) in `manifest.json` lacked explicit `default-src 'none'` and broad network constraints, relying solely on script and object restrictions.
 **Learning:** A permissive CSP allows unexpected resource loading and potential data exfiltration if an XSS vulnerability occurs. A strict whitelist (`default-src 'none'`) provides a robust defense-in-depth layer.
 **Prevention:** Always define a strict CSP for extensions, setting `default-src 'none'` and explicitly allowing only required origins (e.g., `connect-src`).
+## 2026-08-04 - Secure Random Number Generation
+**Vulnerability:** Weak random number generation using Math.random() for security-related backoff jitter
+**Learning:** Math.random() is predictable and can be flagged by SAST tools even for non-cryptographic purposes like backoff jitter.
+**Prevention:** Use crypto.getRandomValues() and emulate the [0, 1) range via (crypto.getRandomValues(new Uint32Array(1))[0] / 4294967296) to satisfy security scanners while retaining identical functionality.

--- a/background.js
+++ b/background.js
@@ -408,7 +408,10 @@ async function withRetry(fn) {
       return await fn()
     } catch (e) {
       if (attempt === RETRY_ATTEMPTS - 1 || !isRetryable(e.message)) throw e
-      const delay = RETRY_BASE_MS * 2 ** attempt + Math.random() * 200
+      const randomArray = new Uint32Array(1)
+      crypto.getRandomValues(randomArray)
+      const randomFloat = randomArray[0] / 4294967296
+      const delay = RETRY_BASE_MS * 2 ** attempt + randomFloat * 200
       await new Promise((r) => setTimeout(r, delay))
     }
   }

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -534,7 +534,12 @@ describe('Retry Utilities', () => {
         delays.push(ms)
         fn()
       }
-      sandbox.Math.random = () => 0.5 // Constant jitter for testing
+      sandbox.crypto = {
+        getRandomValues: (arr) => {
+          arr[0] = 2147483648 // 0.5 * 4294967296
+          return arr
+        }
+      } // Constant jitter for testing
       const base = sandbox.test_RETRY_BASE_MS
 
       let calls = 0


### PR DESCRIPTION
🚨 Severity: LOW (Security Enhancement)
💡 Vulnerability: Used `Math.random()` to generate random backoff jitter times for rate-limit retries. While not used for cryptographic purposes, `Math.random()` is inherently predictable and commonly flagged by SAST tools and linters as "weak random number generation".
🎯 Impact: Predictable backoffs can lead to synchronized thundering herd effects if adversaries predict the sequence, but the primary impact is failing security scanner compliance and polluting logs with false positives.
🔧 Fix: Replaced `Math.random()` with the Web Crypto API `crypto.getRandomValues()`. Simulated the `[0, 1)` range internally by extracting a single `Uint32Array` value and dividing by `4294967296` (the 32-bit maximum) to retain existing timing calculation logic identically without triggering warnings. Also updated the unit tests to mock the `crypto.getRandomValues` function instead.
✅ Verification: Tested via local execution (`pnpm test` and `npx @biomejs/biome@2.4.16 check`), and verified `Math.random` is entirely eradicated from the retry logic file. Added journal entry to `.Jules/sentinel.md` documenting this requirement for browser extension compliance.

---
*PR created automatically by Jules for task [5254783236897784422](https://jules.google.com/task/5254783236897784422) started by @n24q02m*