### PR TITLE
🎨 Palette: Enable native form validation and Enter key submission

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -37,3 +37,6 @@
 ## 2024-05-15 - Fix clipped focus rings with inset box-shadow
 **Learning:** When using inset box-shadow for focus rings to avoid clipping from overflow:hidden containers, ensure the shadow color contrasts with both active and inactive states. An inset shadow matching the background color becomes invisible.
 **Action:** Use outline: 2px solid transparent to retain Windows High Contrast Mode support, and select a contrasting inset shadow color (like #0f172a) for active states.
+## 2023-11-20 - Native HTML5 Validation and Submit on Enter
+**Learning:** Native HTML5 validation attributes (`pattern`, `maxlength`) are bypassed if the primary submit button is not inside a semantic `<form>` element. Furthermore, without a form wrapping the inputs, users cannot submit using the implicit 'Enter' key.
+**Action:** Always wrap form inputs in a `<form>` element and set the primary action button to `type="submit"` to trigger native validation UI and enable implicit 'Enter' key submission. When handling the submit event via JavaScript, be sure to call `e.preventDefault()`.

--- a/popup.html
+++ b/popup.html
@@ -11,7 +11,8 @@
       <span class="version">v2.0</span>
     </header>
 
-    <section class="options">
+    <form id="mainForm">
+      <section class="options">
       <h2>Options</h2>
       <div class="setting-row">
         <fieldset style="border: none; padding: 0; margin: 0; display: contents;">
@@ -69,8 +70,9 @@
       </label>
     </section>
 
-    <button type="button" id="startBtn" class="primary">Start Archiving</button>
-    <button type="button" id="resetBtn" class="secondary" style="display: none">Reset</button>
+      <button type="submit" id="startBtn" class="primary">Start Archiving</button>
+      <button type="button" id="resetBtn" class="secondary" style="display: none">Reset</button>
+    </form>
 
     <section id="progressSection" style="display: none">
       <h2>Progress</h2>

--- a/popup.js
+++ b/popup.js
@@ -16,6 +16,7 @@ const MAX_TOKEN_LEN = 255
 const ghOwnerInput = $('#ghOwner')
 const ghTokenInput = $('#ghToken')
 const forceCheckbox = $('#force')
+const mainForm = $('#mainForm')
 const startBtn = $('#startBtn')
 const resetBtn = $('#resetBtn')
 const progressSection = $('#progressSection')
@@ -122,7 +123,8 @@ ghTokenInput.addEventListener('change', () => {
 })
 
 // --- Start operation ---
-startBtn.addEventListener('click', async () => {
+mainForm.addEventListener('submit', async (e) => {
+  e.preventDefault()
   // Save settings first, ensuring token is only in local storage
   chrome.storage.sync.set({
     ghOwner: ghOwnerInput.value.trim().slice(0, MAX_OWNER_LEN)

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -44,7 +44,7 @@ function createMockElement(tag = 'div', attrs = {}) {
     dispatchEvent: (type) => {
       if (element.listeners?.[type]) {
         element.listeners[type].forEach((cb) => {
-          cb({ target: element })
+          cb({ target: element, preventDefault: () => {} })
         })
       }
     },
@@ -195,6 +195,7 @@ function setupPopupSandbox() {
     '#ghOwner': createMockElement('input'),
     '#ghToken': createMockElement('input'),
     '#force': createMockElement('input', { type: 'checkbox' }),
+    '#mainForm': createMockElement('form'),
     '#startBtn': createMockElement('button'),
     'input[name="mode"]:checked': createMockElement('input', { value: 'dry' }),
     '#resetBtn': createMockElement('button'),
@@ -375,7 +376,7 @@ describe('Initialization and Storage', () => {
 })
 
 describe('Button Event Handlers', () => {
-  it('should send START message when startBtn is clicked', async () => {
+  it('should send START message when mainForm is submitted', async () => {
     const { sandbox, elements } = setupPopupSandbox()
     let sentMessage = null
     sandbox.chrome.runtime.sendMessage = (msg) => {
@@ -387,7 +388,7 @@ describe('Button Event Handlers', () => {
     elements['#ghOwner'].value = 'test-owner'
     elements['#ghToken'].value = 'test-token'
 
-    await elements['#startBtn'].dispatchEvent('click')
+    await elements['#mainForm'].dispatchEvent('submit')
 
     assert.strictEqual(sentMessage.action, 'START')
     assert.strictEqual(sentMessage.options.opMode, 'archive')


### PR DESCRIPTION
### 💡 What
Wrapped the inputs and primary action buttons in `popup.html` inside a semantic `<form>` element and changed the main button type to `submit`. Updated `popup.js` to listen for the `submit` event on the form.

### 🎯 Why
Without a wrapping form, native HTML5 validation constraints (like `pattern` and `maxlength`) on inputs are bypassed. Furthermore, wrapping inputs in a form enables implicit "Enter" key submission, allowing users to press Enter from anywhere within the form to submit without needing to explicitly click the button or wire up custom keydown listeners.

### 📸 Before/After
See attached videos and screenshots from frontend verification testing.

### ♿ Accessibility
Enables implicit Enter key submission for smoother keyboard navigation.

---
*PR created automatically by Jules for task [13699830965727946779](https://jules.google.com/task/13699830965727946779) started by @n24q02m*