### PR TITLE
🎨 Palette: Add Enter key submission for form controls

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
+## 2025-06-30 - Form Controls Enter Key Submission
+**Learning:** Native HTML5 validation attributes (pattern, maxlength) are bypassed if the primary submit button is not inside a semantic <form> element. Users also expect to submit forms by pressing Enter in input fields. Wrapping inputs in a form can break existing styling, so manually invoking .reportValidity() on inputs during click handlers and adding explicit keydown listeners for the Enter key is a clean alternative.
+**Action:** Always wrap form inputs in a <form> element or explicitly handle Enter key events and native validation manually via .reportValidity() to ensure inputs are verified and users can submit forms naturally using the keyboard.
 ## 2025-04-03 - Progressive Disclosure for Multi-Mode UIs
 **Learning:** In a multi-mode UI (like Archive vs Suggestions), showing all settings at once creates cognitive overload, especially when settings like GitHub tokens are only relevant to one mode.
 **Action:** Use progressive disclosure in `popup.js` to hide mode-specific settings (like the `.settings` section and `force` checkbox) when they are not relevant to the currently selected mode, keeping the UI clean and focused.

--- a/popup.js
+++ b/popup.js
@@ -121,8 +121,20 @@ ghTokenInput.addEventListener('change', () => {
   chrome.storage.local.set({ ghToken: ghTokenInput.value.trim().slice(0, MAX_TOKEN_LEN) })
 })
 
+// --- Support Enter key submission ---
+;[ghOwnerInput, ghTokenInput].forEach((input) => {
+  input.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' && !startBtn.disabled) {
+      e.preventDefault()
+      startBtn.click()
+    }
+  })
+})
+
 // --- Start operation ---
 startBtn.addEventListener('click', async () => {
+  if (!ghOwnerInput.reportValidity() || !ghTokenInput.reportValidity()) return
+
   // Save settings first, ensuring token is only in local storage
   chrome.storage.sync.set({
     ghOwner: ghOwnerInput.value.trim().slice(0, MAX_OWNER_LEN)

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -73,6 +73,7 @@ function createMockElement(tag = 'div', attrs = {}) {
     focus: () => {
       element.focused = true
     },
+    reportValidity: () => true,
     textContent: '',
     value: '',
     checked: false,


### PR DESCRIPTION
💡 What: Added an event listener to the GitHub Owner and Token input fields to trigger form submission when the 'Enter' key is pressed, while preserving native HTML5 validation UI by calling `.reportValidity()`.
🎯 Why: Native HTML5 validation attributes (`maxlength`, `pattern`) are bypassed when not enclosed in a semantic `<form>` element with a submit button. Users naturally expect to be able to submit forms by pressing Enter. Adding form wrappers can sometimes break existing visual layouts, so manually handling the Enter key and invoking validation provides a robust alternative.
📸 Before/After: Verified that functionality is identical visually, but hitting Enter now correctly executes validation before proceeding, rather than doing nothing.
♿ Accessibility: Improved keyboard navigability by ensuring users do not have to manually focus and click the primary action button.

---
*PR created automatically by Jules for task [4001878928028547582](https://jules.google.com/task/4001878928028547582) started by @n24q02m*