### PR TITLE
🛡️ Sentinel: [MEDIUM] Replace weak Math.random() with crypto.getRandomValues()

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** The extension's Content Security Policy (CSP) in `manifest.json` lacked explicit `default-src 'none'` and broad network constraints, relying solely on script and object restrictions.
 **Learning:** A permissive CSP allows unexpected resource loading and potential data exfiltration if an XSS vulnerability occurs. A strict whitelist (`default-src 'none'`) provides a robust defense-in-depth layer.
 **Prevention:** Always define a strict CSP for extensions, setting `default-src 'none'` and explicitly allowing only required origins (e.g., `connect-src`).
+## 2024-07-25 - Prevent Weak Randomness Warnings
+**Vulnerability:** Weak random number generation warning from security scanners due to using `Math.random()` for backoff jitter.
+**Learning:** Even for non-cryptographic purposes like backoff jitter, `Math.random()` is often flagged by SAST tools in browser extensions. Replacing it prevents false positives and ensures a baseline level of cryptographic safety.
+**Prevention:** Prefer `crypto.getRandomValues()` over `Math.random()` in browser extensions, using `crypto.getRandomValues(new Uint32Array(1))[0] / 4294967296` for an equivalent `[0, 1)` range.

--- a/background.js
+++ b/background.js
@@ -408,7 +408,8 @@ async function withRetry(fn) {
       return await fn()
     } catch (e) {
       if (attempt === RETRY_ATTEMPTS - 1 || !isRetryable(e.message)) throw e
-      const delay = RETRY_BASE_MS * 2 ** attempt + Math.random() * 200
+      // Use crypto.getRandomValues instead of Math.random() to prevent SAST tool weak random number generation warnings
+      const delay = RETRY_BASE_MS * 2 ** attempt + (crypto.getRandomValues(new Uint32Array(1))[0] / 4294967296) * 200
       await new Promise((r) => setTimeout(r, delay))
     }
   }

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -534,7 +534,12 @@ describe('Retry Utilities', () => {
         delays.push(ms)
         fn()
       }
-      sandbox.Math.random = () => 0.5 // Constant jitter for testing
+      sandbox.crypto = {
+        getRandomValues: (arr) => {
+          arr[0] = 2147483648
+          return arr
+        }
+      }
       const base = sandbox.test_RETRY_BASE_MS
 
       let calls = 0


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The backoff retry logic was using `Math.random()` to generate jitter delays. While not strictly used in a cryptographic context, `Math.random()` triggers weak random number generation warnings from security scanners (SAST tools).
🎯 Impact: Using `Math.random()` creates false positives in security pipelines, reducing confidence in security checks and establishing a precedent for non-secure RNG usage within the extension background worker.
🔧 Fix: Replaced `Math.random()` with `(crypto.getRandomValues(new Uint32Array(1))[0] / 4294967296)` to utilize a cryptographically secure pseudo-random number generator (CSPRNG), matching the `[0, 1)` range and silencing warnings while preserving existing behavior. Added a descriptive comment explaining the change.
✅ Verification: Ran `node --test` (the retry delay test behavior was maintained via mocking `sandbox.crypto`) and `npx @biomejs/biome check` locally; verified backoff timing works equivalently.

---
*PR created automatically by Jules for task [16417978001809741182](https://jules.google.com/task/16417978001809741182) started by @n24q02m*