### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix weak random number generation

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** The extension's Content Security Policy (CSP) in `manifest.json` lacked explicit `default-src 'none'` and broad network constraints, relying solely on script and object restrictions.
 **Learning:** A permissive CSP allows unexpected resource loading and potential data exfiltration if an XSS vulnerability occurs. A strict whitelist (`default-src 'none'`) provides a robust defense-in-depth layer.
 **Prevention:** Always define a strict CSP for extensions, setting `default-src 'none'` and explicitly allowing only required origins (e.g., `connect-src`).
+## 2026-06-05 - Weak random number generation in background.js
+**Vulnerability:** Used `Math.random()` to generate jitter delay during backoff retry loops. This is a weak PRNG which is generally discouraged by static analysis tools for security contexts, even when used merely for jitter.
+**Learning:** Browser extension linting and security scanning tools often strictly flag any usage of `Math.random()` in background scripts as a potential weakness.
+**Prevention:** Always use `crypto.getRandomValues()` for generating random numbers in browser extensions, regardless of the cryptographical necessity of the randomness. Convert the `Uint32Array` output to a float by dividing by 4294967296.

--- a/background.js
+++ b/background.js
@@ -408,7 +408,10 @@ async function withRetry(fn) {
       return await fn()
     } catch (e) {
       if (attempt === RETRY_ATTEMPTS - 1 || !isRetryable(e.message)) throw e
-      const delay = RETRY_BASE_MS * 2 ** attempt + Math.random() * 200
+      const randomArray = new Uint32Array(1)
+      crypto.getRandomValues(randomArray)
+      const randomFloat = randomArray[0] / 4294967296
+      const delay = RETRY_BASE_MS * 2 ** attempt + randomFloat * 200
       await new Promise((r) => setTimeout(r, delay))
     }
   }

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -534,7 +534,12 @@ describe('Retry Utilities', () => {
         delays.push(ms)
         fn()
       }
-      sandbox.Math.random = () => 0.5 // Constant jitter for testing
+      sandbox.crypto = {
+        getRandomValues: (arr) => {
+          arr[0] = 2147483648
+          return arr
+        }
+      } // Constant jitter for testing
       const base = sandbox.test_RETRY_BASE_MS
 
       let calls = 0


### PR DESCRIPTION
Replaces `Math.random()` with `crypto.getRandomValues()` for backoff jitter to satisfy SAST tooling and security linters.

---
*PR created automatically by Jules for task [12741488681565989989](https://jules.google.com/task/12741488681565989989) started by @n24q02m*