### PR TITLE
🎨 Palette: Wrap settings in a semantic form for implicit Enter key submission

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -37,3 +37,7 @@
 ## 2024-05-15 - Fix clipped focus rings with inset box-shadow
 **Learning:** When using inset box-shadow for focus rings to avoid clipping from overflow:hidden containers, ensure the shadow color contrasts with both active and inactive states. An inset shadow matching the background color becomes invisible.
 **Action:** Use outline: 2px solid transparent to retain Windows High Contrast Mode support, and select a contrasting inset shadow color (like #0f172a) for active states.
+
+## 2023-10-25 - Implicit Form Submission and Validation
+**Learning:** Native HTML5 validation attributes (like `pattern` and `maxlength`) are bypassed if the primary submit button is not inside a semantic `<form>` element. Without a form, users also miss out on the implicit 'Enter' key submission behavior, forcing them to manually click the button.
+**Action:** Always wrap form inputs and their primary action button in a semantic `<form>` element and use `<button type="submit">` to automatically leverage native browser validation UI and keyboard accessibility.

--- a/popup.html
+++ b/popup.html
@@ -11,6 +11,7 @@
       <span class="version">v2.0</span>
     </header>
 
+    <form id="mainForm">
     <section class="options">
       <h2>Options</h2>
       <div class="setting-row">
@@ -69,7 +70,8 @@
       </label>
     </section>
 
-    <button type="button" id="startBtn" class="primary">Start Archiving</button>
+    <button type="submit" id="startBtn" class="primary">Start Archiving</button>
+    </form>
     <button type="button" id="resetBtn" class="secondary" style="display: none">Reset</button>
 
     <section id="progressSection" style="display: none">

--- a/popup.js
+++ b/popup.js
@@ -16,6 +16,7 @@ const MAX_TOKEN_LEN = 255
 const ghOwnerInput = $('#ghOwner')
 const ghTokenInput = $('#ghToken')
 const forceCheckbox = $('#force')
+const mainForm = $('#mainForm')
 const startBtn = $('#startBtn')
 const resetBtn = $('#resetBtn')
 const progressSection = $('#progressSection')
@@ -122,7 +123,8 @@ ghTokenInput.addEventListener('change', () => {
 })
 
 // --- Start operation ---
-startBtn.addEventListener('click', async () => {
+mainForm.addEventListener('submit', async (e) => {
+  e.preventDefault()
   // Save settings first, ensuring token is only in local storage
   chrome.storage.sync.set({
     ghOwner: ghOwnerInput.value.trim().slice(0, MAX_OWNER_LEN)

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -44,10 +44,18 @@ function createMockElement(tag = 'div', attrs = {}) {
     dispatchEvent: (type) => {
       if (element.listeners?.[type]) {
         element.listeners[type].forEach((cb) => {
-          cb({ target: element })
+          cb({ target: element, preventDefault: () => {}, key: element.mockKey })
         })
       }
     },
+    click: () => {
+      if (element.listeners?.click) {
+        element.listeners.click.forEach((cb) => {
+          cb({ target: element, preventDefault: () => {} })
+        })
+      }
+    },
+    reportValidity: () => true,
     style: { display: '' },
     appendChild: (child) => {
       if (!element.children) element.children = []
@@ -192,6 +200,7 @@ function setupPopupSandbox() {
   }
 
   const elements = {
+    '#mainForm': createMockElement('form'),
     '#ghOwner': createMockElement('input'),
     '#ghToken': createMockElement('input'),
     '#force': createMockElement('input', { type: 'checkbox' }),
@@ -375,7 +384,7 @@ describe('Initialization and Storage', () => {
 })
 
 describe('Button Event Handlers', () => {
-  it('should send START message when startBtn is clicked', async () => {
+  it('should send START message when mainForm is submitted', async () => {
     const { sandbox, elements } = setupPopupSandbox()
     let sentMessage = null
     sandbox.chrome.runtime.sendMessage = (msg) => {
@@ -387,7 +396,7 @@ describe('Button Event Handlers', () => {
     elements['#ghOwner'].value = 'test-owner'
     elements['#ghToken'].value = 'test-token'
 
-    await elements['#startBtn'].dispatchEvent('click')
+    await elements['#mainForm'].dispatchEvent('submit')
 
     assert.strictEqual(sentMessage.action, 'START')
     assert.strictEqual(sentMessage.options.opMode, 'archive')


### PR DESCRIPTION
💡 What: Wraps the options and settings inputs inside a semantic `<form id="mainForm">` element. Converts the primary action button to `type="submit"` and modifies the event listener in `popup.js` to trigger on form submission rather than a raw button click.

🎯 Why: Forms inherently leverage HTML5 validation attributes natively in the browser (e.g., `pattern` on the `ghOwner` field). Crucially, utilizing a form enables users to implicitly submit the settings and trigger the action by hitting the "Enter" key while focused anywhere within the options, significantly improving keyboard efficiency.

📸 Before/After: Visuals are unchanged structurally, but keyboard interactivity is enhanced.

♿ Accessibility: Greatly improves keyboard accessibility for power users by enabling implicit Enter key submission. Reduces friction compared to manually navigating to and pressing the "Start Archiving" button.

---
*PR created automatically by Jules for task [4713416746679823557](https://jules.google.com/task/4713416746679823557) started by @n24q02m*