### PR TITLE
🛡️ Sentinel: Add timeout to external API calls to mitigate resource exhaustion

### DIFF
--- a/background.js
+++ b/background.js
@@ -54,7 +54,7 @@ async function jFetch(url, options = {}) {
     throw new Error('Security Error: Disallowed fetch origin')
   }
 
-  const { token, headers = {}, ...rest } = options
+  const { token, headers = {}, timeout = 30000, ...rest } = options
 
   if (token) {
     if (origin !== 'https://api.github.com') {
@@ -65,11 +65,23 @@ async function jFetch(url, options = {}) {
     headers.Authorization = `token ${token}`
   }
 
-  const res = await fetch(url, { headers, ...rest })
-  if (!res.ok) {
-    throw new Error(`HTTP ${res.status}`)
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), timeout)
+
+  try {
+    const res = await fetch(url, { headers, signal: controller.signal, ...rest })
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status}`)
+    }
+    return res
+  } catch (e) {
+    if (e.name === 'AbortError') {
+      throw new Error('NetworkError: Request timed out')
+    }
+    throw e
+  } finally {
+    clearTimeout(timeoutId)
   }
-  return res
 }
 
 /**

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -85,7 +85,8 @@ function setupEnvironment(initialStorage = {}) {
     console,
     parseInt,
     crypto,
-    importScripts: () => {}
+    importScripts: () => {},
+    AbortController
   }
 
   vm.createContext(sandbox)

--- a/tests/perf.test.js
+++ b/tests/perf.test.js
@@ -59,7 +59,8 @@ function setupEnvironment(initialStorage = {}) {
     URL,
     Promise,
     console,
-    parseInt
+    parseInt,
+    AbortController
   }
 
   vm.createContext(sandbox)

--- a/tests/security.test.js
+++ b/tests/security.test.js
@@ -169,7 +169,9 @@ function setupEnvironment(initialTabs = {}) {
     console,
     URL,
     URLSearchParams,
-    importScripts: () => {}
+    importScripts: () => {},
+    AbortController,
+    clearTimeout
   }
 
   vm.createContext(sandbox)


### PR DESCRIPTION
## 🚨 Severity: MEDIUM

## 💡 Vulnerability:
Network requests (`jFetch`) in the background service worker lacked timeouts. Since these requests are often fired concurrently in large pools (`runInPool` + global limiters) to process hundreds of tasks, hanging requests could permanently exhaust the concurrency limit, trap background promises, and freeze the extension's execution indefinitely, leading to a resource exhaustion Denial of Service (DoS).

## 🎯 Impact:
If the external Jules API or GitHub API stalls (e.g., hanging connections that don't immediately throw `ECONNRESET`), the `fetch` promises will never resolve. This blocks the concurrency queues, preventing any further background tasks from executing until the browser forcefully terminates the service worker.

## 🔧 Fix:
Introduced a default `30000ms` (30 second) timeout to the `jFetch` utility using the standard `AbortController` API. If the timeout is reached, the controller aborts the fetch, and the resulting `AbortError` is cleanly caught and re-thrown as a `NetworkError: Request timed out`. This specific phrasing ensures the existing retry logic (`isRetryable`) properly catches and manages the failure. Also injected `AbortController` and `clearTimeout` into the Node.js `vm` sandboxes across the test suite to ensure tests continue to pass.

## ✅ Verification:
- Run `node --test` to confirm the test suite passes, meaning the newly introduced sandbox variables are correctly scoped.
- Run `npx @biomejs/biome@2.4.16 check` to ensure no linting regressions.

---
*PR created automatically by Jules for task [12229592244516728290](https://jules.google.com/task/12229592244516728290) started by @n24q02m*