### PR TITLE
🎨 Palette: Enable native form validation and implicit 'Enter' submission

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -37,3 +37,6 @@
 ## 2024-05-15 - Fix clipped focus rings with inset box-shadow
 **Learning:** When using inset box-shadow for focus rings to avoid clipping from overflow:hidden containers, ensure the shadow color contrasts with both active and inactive states. An inset shadow matching the background color becomes invisible.
 **Action:** Use outline: 2px solid transparent to retain Windows High Contrast Mode support, and select a contrasting inset shadow color (like #0f172a) for active states.
+## 2025-10-18 - Native Form Validation and Implicit Enter Submission
+**Learning:** Native HTML5 validation attributes (`pattern`, `maxlength`) are bypassed if the primary submit button is not inside a semantic `<form>` element. Additionally, implicit 'Enter' key submission on inputs requires a `<form>` context to trigger natively, making it a critical accessibility and UX requirement.
+**Action:** Always wrap form inputs and their corresponding action buttons in a semantic `<form>` element, and use `type="submit"` on the primary button instead of `type="button"`. Handle the form's `submit` event (and use `e.preventDefault()`) instead of the button's `click` event to capture both clicks and Enter key presses natively.

--- a/popup.html
+++ b/popup.html
@@ -11,6 +11,7 @@
       <span class="version">v2.0</span>
     </header>
 
+    <form id="mainForm">
     <section class="options">
       <h2>Options</h2>
       <div class="setting-row">
@@ -69,8 +70,9 @@
       </label>
     </section>
 
-    <button type="button" id="startBtn" class="primary">Start Archiving</button>
+    <button type="submit" id="startBtn" class="primary">Start Archiving</button>
     <button type="button" id="resetBtn" class="secondary" style="display: none">Reset</button>
+    </form>
 
     <section id="progressSection" style="display: none">
       <h2>Progress</h2>

--- a/popup.js
+++ b/popup.js
@@ -13,6 +13,7 @@ const MAX_OWNER_LEN = 39
 const MAX_TOKEN_LEN = 255
 
 // --- DOM refs ---
+const mainForm = $('#mainForm')
 const ghOwnerInput = $('#ghOwner')
 const ghTokenInput = $('#ghToken')
 const forceCheckbox = $('#force')
@@ -122,7 +123,8 @@ ghTokenInput.addEventListener('change', () => {
 })
 
 // --- Start operation ---
-startBtn.addEventListener('click', async () => {
+mainForm.addEventListener('submit', async (e) => {
+  e.preventDefault()
   // Save settings first, ensuring token is only in local storage
   chrome.storage.sync.set({
     ghOwner: ghOwnerInput.value.trim().slice(0, MAX_OWNER_LEN)

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -44,7 +44,7 @@ function createMockElement(tag = 'div', attrs = {}) {
     dispatchEvent: (type) => {
       if (element.listeners?.[type]) {
         element.listeners[type].forEach((cb) => {
-          cb({ target: element })
+          cb({ target: element, preventDefault: () => {} })
         })
       }
     },
@@ -192,6 +192,7 @@ function setupPopupSandbox() {
   }
 
   const elements = {
+    '#mainForm': createMockElement('form'),
     '#ghOwner': createMockElement('input'),
     '#ghToken': createMockElement('input'),
     '#force': createMockElement('input', { type: 'checkbox' }),
@@ -375,7 +376,7 @@ describe('Initialization and Storage', () => {
 })
 
 describe('Button Event Handlers', () => {
-  it('should send START message when startBtn is clicked', async () => {
+  it('should send START message when mainForm is submitted', async () => {
     const { sandbox, elements } = setupPopupSandbox()
     let sentMessage = null
     sandbox.chrome.runtime.sendMessage = (msg) => {
@@ -387,7 +388,7 @@ describe('Button Event Handlers', () => {
     elements['#ghOwner'].value = 'test-owner'
     elements['#ghToken'].value = 'test-token'
 
-    await elements['#startBtn'].dispatchEvent('click')
+    await elements['#mainForm'].dispatchEvent('submit')
 
     assert.strictEqual(sentMessage.action, 'START')
     assert.strictEqual(sentMessage.options.opMode, 'archive')


### PR DESCRIPTION
**💡 What:**
Wrapped the main options, settings inputs, and primary action buttons inside a semantic `<form>` element in `popup.html`, changed `startBtn` from `type="button"` to `type="submit"`, and refactored the JavaScript to handle the form's `submit` event rather than listening for the button's `click` event.

**🎯 Why:**
Previously, the form bypassed native HTML5 validation attributes (such as the `pattern` regex validation on the GitHub owner input). Crucially, users could not submit the form by pressing the 'Enter' key while focused on an input field. Wrapping these controls in a standard `<form>` allows the browser to handle both implicit form submission (via Enter) and native client-side validation natively, massively improving the keyboard navigation and form UX without additional complex JavaScript handling.

**📸 Before/After:**
*(Visuals remain structurally identical, but interaction behavior is corrected. See verified Playwright video.)*

**♿ Accessibility:**
Greatly improves keyboard accessibility for power users and assistive technologies by allowing standard implicit Enter key submission from anywhere within the form context, fulfilling standard web expectations.

---
*PR created automatically by Jules for task [12746399133710488275](https://jules.google.com/task/12746399133710488275) started by @n24q02m*