### PR TITLE
🎨 Palette: Native form validation and Enter key submission

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -37,3 +37,6 @@
 ## 2024-05-15 - Fix clipped focus rings with inset box-shadow
 **Learning:** When using inset box-shadow for focus rings to avoid clipping from overflow:hidden containers, ensure the shadow color contrasts with both active and inactive states. An inset shadow matching the background color becomes invisible.
 **Action:** Use outline: 2px solid transparent to retain Windows High Contrast Mode support, and select a contrasting inset shadow color (like #0f172a) for active states.
+## 2024-05-20 - Native Form Validation and Submission
+**Learning:** Native HTML5 validation attributes (`pattern`, `maxlength`) and implicit "Enter" key submission are completely bypassed if input fields and their primary action button are not wrapped in a semantic `<form>` element.
+**Action:** Always wrap form inputs and primary action buttons in a semantic `<form>`, use `type="submit"` for the primary button, and handle the `submit` event (with `e.preventDefault()`) instead of listening to button clicks. This ensures native validation and keyboard accessibility (like submitting via Enter) work out-of-the-box.

--- a/popup.html
+++ b/popup.html
@@ -11,6 +11,7 @@
       <span class="version">v2.0</span>
     </header>
 
+    <form id="mainForm">
     <section class="options">
       <h2>Options</h2>
       <div class="setting-row">
@@ -69,8 +70,9 @@
       </label>
     </section>
 
-    <button type="button" id="startBtn" class="primary">Start Archiving</button>
+    <button type="submit" id="startBtn" class="primary">Start Archiving</button>
     <button type="button" id="resetBtn" class="secondary" style="display: none">Reset</button>
+    </form>
 
     <section id="progressSection" style="display: none">
       <h2>Progress</h2>

--- a/popup.js
+++ b/popup.js
@@ -13,6 +13,7 @@ const MAX_OWNER_LEN = 39
 const MAX_TOKEN_LEN = 255
 
 // --- DOM refs ---
+const mainForm = $('#mainForm')
 const ghOwnerInput = $('#ghOwner')
 const ghTokenInput = $('#ghToken')
 const forceCheckbox = $('#force')
@@ -122,7 +123,8 @@ ghTokenInput.addEventListener('change', () => {
 })
 
 // --- Start operation ---
-startBtn.addEventListener('click', async () => {
+mainForm.addEventListener('submit', async (e) => {
+  e.preventDefault()
   // Save settings first, ensuring token is only in local storage
   chrome.storage.sync.set({
     ghOwner: ghOwnerInput.value.trim().slice(0, MAX_OWNER_LEN)

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -41,10 +41,10 @@ function createMockElement(tag = 'div', attrs = {}) {
       if (!element.listeners[type]) element.listeners[type] = []
       element.listeners[type].push(cb)
     },
-    dispatchEvent: (type) => {
+    dispatchEvent: (type, payload = {}) => {
       if (element.listeners?.[type]) {
         element.listeners[type].forEach((cb) => {
-          cb({ target: element })
+          cb({ target: element, preventDefault: () => {}, ...payload })
         })
       }
     },
@@ -192,6 +192,7 @@ function setupPopupSandbox() {
   }
 
   const elements = {
+    '#mainForm': createMockElement('form'),
     '#ghOwner': createMockElement('input'),
     '#ghToken': createMockElement('input'),
     '#force': createMockElement('input', { type: 'checkbox' }),
@@ -387,7 +388,7 @@ describe('Button Event Handlers', () => {
     elements['#ghOwner'].value = 'test-owner'
     elements['#ghToken'].value = 'test-token'
 
-    await elements['#startBtn'].dispatchEvent('click')
+    await elements['#mainForm'].dispatchEvent('submit')
 
     assert.strictEqual(sentMessage.action, 'START')
     assert.strictEqual(sentMessage.options.opMode, 'archive')


### PR DESCRIPTION
🎨 Palette: Native Form Validation and Submission

Implemented native HTML5 form validation and Enter-key submission by wrapping inputs in a semantic `<form>` element.

💡 What: Wrapped `popup.html` inputs in `<form id="mainForm">`, changed the `#startBtn` to `type="submit"`, and bound to the form's `submit` event rather than the button's `click`.
🎯 Why: Native HTML5 validation (`pattern`, `maxlength`) was bypassed because fields were not in a `<form>`. Additionally, users couldn't submit via Enter key.
📸 Before/After: Visuals remained identical. See UI validation steps.
♿ Accessibility: Enables submitting the form via the Enter key while focusing input fields, aligning with expected keyboard interaction.


---
*PR created automatically by Jules for task [6106513573855273875](https://jules.google.com/task/6106513573855273875) started by @n24q02m*