### PR TITLE
🎨 Palette: Add semantic form wrapping to popup ui

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -37,3 +37,6 @@
 ## 2024-05-15 - Fix clipped focus rings with inset box-shadow
 **Learning:** When using inset box-shadow for focus rings to avoid clipping from overflow:hidden containers, ensure the shadow color contrasts with both active and inactive states. An inset shadow matching the background color becomes invisible.
 **Action:** Use outline: 2px solid transparent to retain Windows High Contrast Mode support, and select a contrasting inset shadow color (like #0f172a) for active states.
+## 2025-06-30 - Semantic Forms for HTML5 Validation
+**Learning:** Native HTML5 validation attributes (`pattern`, `maxlength`) and implicit 'Enter' key submission are bypassed if the primary action button is not inside a semantic `<form>` element.
+**Action:** Always wrap form inputs and their corresponding action buttons in a semantic `<form>`, change the primary button to `type="submit"`, and handle the form's `submit` event (using `e.preventDefault()`) rather than listening to the button's `click` event.

--- a/patch_form.sh
+++ b/patch_form.sh
@@ -1,0 +1,10 @@
+sed -i 's/<section class="options">/<form id="mainForm">\n    <section class="options">/g' popup.html
+sed -i 's/<button type="button" id="startBtn" class="primary">Start Archiving<\/button>/<button type="submit" id="startBtn" class="primary">Start Archiving<\/button>/g' popup.html
+sed -i 's/<button type="button" id="resetBtn" class="secondary" style="display: none">Reset<\/button>/<button type="button" id="resetBtn" class="secondary" style="display: none">Reset<\/button>\n    <\/form>/g' popup.html
+
+sed -i "s/const resetBtn = \$('#resetBtn')/const resetBtn = \$('#resetBtn')\nconst mainForm = \$('#mainForm')/g" popup.js
+sed -i "s/startBtn.addEventListener('click', async () => {/mainForm.addEventListener('submit', async (e) => {\n  e.preventDefault()/g" popup.js
+
+sed -i "s/cb({ target: element })/cb({ target: element, preventDefault: () => {} })/g" tests/popup.test.js
+sed -i "s/'#ghOwner': createMockElement('input'),/'#mainForm': createMockElement('form'),\n    '#ghOwner': createMockElement('input'),/g" tests/popup.test.js
+sed -i "s/await elements\['#startBtn'\].dispatchEvent('click')/await elements\['#mainForm'\].dispatchEvent('submit')/g" tests/popup.test.js

--- a/popup.html
+++ b/popup.html
@@ -11,6 +11,7 @@
       <span class="version">v2.0</span>
     </header>
 
+    <form id="mainForm">
     <section class="options">
       <h2>Options</h2>
       <div class="setting-row">
@@ -69,8 +70,9 @@
       </label>
     </section>
 
-    <button type="button" id="startBtn" class="primary">Start Archiving</button>
+    <button type="submit" id="startBtn" class="primary">Start Archiving</button>
     <button type="button" id="resetBtn" class="secondary" style="display: none">Reset</button>
+    </form>
 
     <section id="progressSection" style="display: none">
       <h2>Progress</h2>

--- a/popup.js
+++ b/popup.js
@@ -18,6 +18,7 @@ const ghTokenInput = $('#ghToken')
 const forceCheckbox = $('#force')
 const startBtn = $('#startBtn')
 const resetBtn = $('#resetBtn')
+const mainForm = $('#mainForm')
 const progressSection = $('#progressSection')
 const summarySection = $('#summarySection')
 const currentInfo = $('#currentInfo')
@@ -122,7 +123,8 @@ ghTokenInput.addEventListener('change', () => {
 })
 
 // --- Start operation ---
-startBtn.addEventListener('click', async () => {
+mainForm.addEventListener('submit', async (e) => {
+  e.preventDefault()
   // Save settings first, ensuring token is only in local storage
   chrome.storage.sync.set({
     ghOwner: ghOwnerInput.value.trim().slice(0, MAX_OWNER_LEN)

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -45,7 +45,7 @@ function createMockElement(tag = 'div', attrs = {}) {
     dispatchEvent: (type) => {
       if (element.listeners?.[type]) {
         element.listeners[type].forEach((cb) => {
-          cb({ target: element })
+          cb({ target: element, preventDefault: () => {} })
         })
       }
     },
@@ -193,6 +193,7 @@ function setupPopupSandbox() {
   }
 
   const elements = {
+    '#mainForm': createMockElement('form'),
     '#ghOwner': createMockElement('input'),
     '#ghToken': createMockElement('input'),
     '#force': createMockElement('input', { type: 'checkbox' }),
@@ -388,7 +389,7 @@ describe('Button Event Handlers', () => {
     elements['#ghOwner'].value = 'test-owner'
     elements['#ghToken'].value = 'test-token'
 
-    await elements['#startBtn'].dispatchEvent('click')
+    await elements['#mainForm'].dispatchEvent('submit')
 
     assert.strictEqual(sentMessage.action, 'START')
     assert.strictEqual(sentMessage.options.opMode, 'archive')


### PR DESCRIPTION
Wrapped popup UI elements inside a `<form id="mainForm">`, changed primary action to `type="submit"`, and updated `popup.js` to listen for the `submit` event (using `e.preventDefault()`). Updated corresponding tests.

---
*PR created automatically by Jules for task [1630106507377002691](https://jules.google.com/task/1630106507377002691) started by @n24q02m*