### PR TITLE
⚡ Bolt: High-water mark buffer for log trimming

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -7,3 +7,7 @@
 ## 2025-02-25 - Request Coalescing
 **Learning:** When fetching external data (like PRs) in parallel across multiple tabs, caching only the *resolved* result leads to thundering herd problems where multiple identical network requests are fired concurrently.
 **Action:** Cache the *Promise* of the fetch operation synchronously (request coalescing) so concurrent calls to the same resource wait on the same in-flight network request, saving API quota and time.
+
+## 2024-08-13 - High-water Mark Buffer for High-Frequency Splices
+**Learning:** Frequent `.splice(0, n)` calls on large arrays (like retaining logs) enforce a maximum length but cause severe O(N^2) performance degradation due to constant element shifting on every insert.
+**Action:** Implement a high-water mark buffer (e.g., waiting for `MAX + BUFFER` before slicing elements) to batch cleanup operations and significantly reduce CPU overhead in high-frequency paths. Update tests to assert on the buffer threshold rather than the strict `MAX` limit.

--- a/background.js
+++ b/background.js
@@ -902,12 +902,16 @@ const DEFAULT_STATE = {
 // stays bounded — otherwise the array grows without limit and every write
 // re-serializes the whole thing.
 const MAX_LOG_LINES = 2000
+const LOG_BUFFER = 200
 
 let state = { ...DEFAULT_STATE }
 let pendingFlush = null
 
 function trimLog() {
-  if (state.log.length > MAX_LOG_LINES) {
+  // ⚡ Bolt Optimization: Implement a high-water mark buffer to batch array shifts.
+  // Instead of splicing on every single insert over MAX_LOG_LINES, we wait until
+  // the array exceeds MAX + BUFFER, reducing O(N^2) shifting overhead.
+  if (state.log.length > MAX_LOG_LINES + LOG_BUFFER) {
     state.log.splice(0, state.log.length - MAX_LOG_LINES)
   }
 }

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -101,6 +101,7 @@ function setupEnvironment(initialStorage = {}) {
     globalThis.test_addLog = addLog;
     globalThis.test_trimLog = trimLog;
     globalThis.test_MAX_LOG_LINES = MAX_LOG_LINES;
+    globalThis.test_LOG_BUFFER = LOG_BUFFER;
     globalThis.test_buildBatchRequest = buildBatchRequest;
     globalThis.test_callBatchExecute = callBatchExecute;
     globalThis.test_runInPool = runInPool;
@@ -1350,9 +1351,18 @@ describe('state management', () => {
     const { sandbox } = setupEnvironment({})
     for (let i = 0; i < 2500; i++) sandbox.test_addLog(`line ${i}`)
     const log = sandbox.test_state().log
-    assert.strictEqual(log.length, 2000)
+    assert.strictEqual(log.length, 2098)
     assert.strictEqual(log[log.length - 1], 'line 2499')
-    assert.strictEqual(log[0], 'line 500') // oldest 500 lines dropped
+    assert.strictEqual(log[0], 'line 402')
+  })
+
+  it('does not trim if log length is under MAX_LOG_LINES + LOG_BUFFER', () => {
+    const { sandbox } = setupEnvironment({})
+    const max = sandbox.test_MAX_LOG_LINES
+    const buffer = sandbox.test_LOG_BUFFER
+    for (let i = 0; i < max + buffer; i++) sandbox.test_addLog(`line ${i}`)
+    const log = sandbox.test_state().log
+    assert.strictEqual(log.length, max + buffer)
   })
 
   it('coalesces a storm of log writes into a single storage write', async () => {
@@ -2033,32 +2043,34 @@ describe('safeListSources', () => {
 })
 
 describe('trimLog Internal', () => {
-  it('should not trim if log length is equal to MAX_LOG_LINES', () => {
+  it('should not trim if log length is equal to MAX_LOG_LINES + LOG_BUFFER', () => {
     const { sandbox } = setupEnvironment()
     const max = sandbox.test_MAX_LOG_LINES
+    const buffer = sandbox.test_LOG_BUFFER
     const state = sandbox.test_state()
-    state.log = Array.from({ length: max }, (_, i) => `line ${i}`)
+    state.log = Array.from({ length: max + buffer }, (_, i) => `line ${i}`)
 
     sandbox.test_trimLog()
 
-    assert.strictEqual(state.log.length, max)
+    assert.strictEqual(state.log.length, max + buffer)
     assert.strictEqual(state.log[0], 'line 0')
-    assert.strictEqual(state.log[max - 1], `line ${max - 1}`)
+    assert.strictEqual(state.log[max + buffer - 1], `line ${max + buffer - 1}`)
   })
 
-  it('should trim oldest entries if log length exceeds MAX_LOG_LINES', () => {
+  it('should trim oldest entries if log length exceeds MAX_LOG_LINES + LOG_BUFFER', () => {
     const { sandbox } = setupEnvironment()
     const max = sandbox.test_MAX_LOG_LINES
+    const buffer = sandbox.test_LOG_BUFFER
     const state = sandbox.test_state()
-    // Create max + 10 entries
-    state.log = Array.from({ length: max + 10 }, (_, i) => `line ${i}`)
+    // Create max + buffer + 10 entries
+    state.log = Array.from({ length: max + buffer + 10 }, (_, i) => `line ${i}`)
 
     sandbox.test_trimLog()
 
     assert.strictEqual(state.log.length, max)
-    // Should have removed the first 10 entries
-    assert.strictEqual(state.log[0], 'line 10')
-    assert.strictEqual(state.log[max - 1], `line ${max + 9}`)
+    // Should have removed the first buffer + 10 entries
+    assert.strictEqual(state.log[0], `line ${buffer + 10}`)
+    assert.strictEqual(state.log[max - 1], `line ${max + buffer + 9}`)
   })
 })
 


### PR DESCRIPTION
💡 What: Replaced direct `splice` calls in `trimLog()` on every log insertion exceeding `MAX_LOG_LINES` with a high-water mark buffer approach, waiting until log length exceeds `MAX_LOG_LINES + LOG_BUFFER` before performing the `splice`.
🎯 Why: Frequent `.splice(0, n)` calls on large arrays cause O(N^2) performance degradation due to constant element shifting. 
📊 Impact: Significantly reduces CPU overhead during high-volume operations (e.g. bulk running) by batching cleanup operations and drastically reducing array shifts. 
🔬 Measurement: Verify by executing unit tests and checking for absence of UI lag in the extension popup during rapid task archiving or suggestions processing.

---
*PR created automatically by Jules for task [12759654333985893460](https://jules.google.com/task/12759654333985893460) started by @n24q02m*