### PR TITLE
⚡ Bolt: Batch trimLog array slicing to eliminate O(N²) bottleneck

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -7,3 +7,6 @@
 ## 2025-02-25 - Request Coalescing
 **Learning:** When fetching external data (like PRs) in parallel across multiple tabs, caching only the *resolved* result leads to thundering herd problems where multiple identical network requests are fired concurrently.
 **Action:** Cache the *Promise* of the fetch operation synchronously (request coalescing) so concurrent calls to the same resource wait on the same in-flight network request, saving API quota and time.
+## 2025-02-25 - High-Water Mark Buffers for Array Max Lengths
+**Learning:** Frequent `.splice(0, n)` calls on large arrays to enforce a maximum length on every insert cause severe O(N^2) performance degradation due to constant element shifting.
+**Action:** Implement a high-water mark buffer (e.g., `if (arr.length > MAX + BUFFER) arr.splice(0, arr.length - MAX)`) to batch cleanup operations and significantly reduce CPU overhead in high-frequency paths.

--- a/background.js
+++ b/background.js
@@ -902,12 +902,13 @@ const DEFAULT_STATE = {
 // stays bounded — otherwise the array grows without limit and every write
 // re-serializes the whole thing.
 const MAX_LOG_LINES = 2000
+const LOG_BUFFER = 500
 
 let state = { ...DEFAULT_STATE }
 let pendingFlush = null
 
 function trimLog() {
-  if (state.log.length > MAX_LOG_LINES) {
+  if (state.log.length > MAX_LOG_LINES + LOG_BUFFER) {
     state.log.splice(0, state.log.length - MAX_LOG_LINES)
   }
 }

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -101,6 +101,7 @@ function setupEnvironment(initialStorage = {}) {
     globalThis.test_addLog = addLog;
     globalThis.test_trimLog = trimLog;
     globalThis.test_MAX_LOG_LINES = MAX_LOG_LINES;
+    globalThis.test_LOG_BUFFER = LOG_BUFFER;
     globalThis.test_buildBatchRequest = buildBatchRequest;
     globalThis.test_callBatchExecute = callBatchExecute;
     globalThis.test_runInPool = runInPool;
@@ -1348,11 +1349,15 @@ describe('state management', () => {
 
   it('caps the retained log at MAX_LOG_LINES, dropping the oldest lines', () => {
     const { sandbox } = setupEnvironment({})
-    for (let i = 0; i < 2500; i++) sandbox.test_addLog(`line ${i}`)
+    const max = sandbox.test_MAX_LOG_LINES
+    const buffer = sandbox.test_LOG_BUFFER
+    for (let i = 0; i < max + buffer + 10; i++) sandbox.test_addLog(`line ${i}`)
     const log = sandbox.test_state().log
-    assert.strictEqual(log.length, 2000)
-    assert.strictEqual(log[log.length - 1], 'line 2499')
-    assert.strictEqual(log[0], 'line 500') // oldest 500 lines dropped
+    // At exactly max + buffer + 1, it trims down to max (2000).
+    // It then adds 9 more lines, ending up with 2009.
+    assert.strictEqual(log.length, max + 9)
+    assert.strictEqual(log[log.length - 1], `line ${max + buffer + 9}`)
+    assert.strictEqual(log[0], `line ${buffer + 1}`) // oldest entries dropped
   })
 
   it('coalesces a storm of log writes into a single storage write', async () => {
@@ -2033,32 +2038,34 @@ describe('safeListSources', () => {
 })
 
 describe('trimLog Internal', () => {
-  it('should not trim if log length is equal to MAX_LOG_LINES', () => {
+  it('should not trim if log length is equal to MAX_LOG_LINES + LOG_BUFFER', () => {
     const { sandbox } = setupEnvironment()
     const max = sandbox.test_MAX_LOG_LINES
+    const buffer = sandbox.test_LOG_BUFFER
     const state = sandbox.test_state()
-    state.log = Array.from({ length: max }, (_, i) => `line ${i}`)
+    state.log = Array.from({ length: max + buffer }, (_, i) => `line ${i}`)
 
     sandbox.test_trimLog()
 
-    assert.strictEqual(state.log.length, max)
+    assert.strictEqual(state.log.length, max + buffer)
     assert.strictEqual(state.log[0], 'line 0')
-    assert.strictEqual(state.log[max - 1], `line ${max - 1}`)
+    assert.strictEqual(state.log[max + buffer - 1], `line ${max + buffer - 1}`)
   })
 
-  it('should trim oldest entries if log length exceeds MAX_LOG_LINES', () => {
+  it('should trim oldest entries if log length exceeds MAX_LOG_LINES + LOG_BUFFER', () => {
     const { sandbox } = setupEnvironment()
     const max = sandbox.test_MAX_LOG_LINES
+    const buffer = sandbox.test_LOG_BUFFER
     const state = sandbox.test_state()
-    // Create max + 10 entries
-    state.log = Array.from({ length: max + 10 }, (_, i) => `line ${i}`)
+    // Create max + buffer + 10 entries
+    state.log = Array.from({ length: max + buffer + 10 }, (_, i) => `line ${i}`)
 
     sandbox.test_trimLog()
 
     assert.strictEqual(state.log.length, max)
-    // Should have removed the first 10 entries
-    assert.strictEqual(state.log[0], 'line 10')
-    assert.strictEqual(state.log[max - 1], `line ${max + 9}`)
+    // Should have removed the first buffer + 10 entries
+    assert.strictEqual(state.log[0], `line ${buffer + 10}`)
+    assert.strictEqual(state.log[max - 1], `line ${max + buffer + 9}`)
   })
 })
 


### PR DESCRIPTION
💡 What: Implemented a high-water mark buffer for the `trimLog` array truncation function in `background.js`. The log array now grows up to 2500 (`MAX_LOG_LINES + LOG_BUFFER`) before being batched-sliced back down to 2000, instead of strictly enforcing a 2000 limit on every insert.

🎯 Why: During bulk archiving jobs, thousands of logs are rapidly generated. Because `splice(0, n)` is an O(N) operation (shifting all elements), calling it sequentially for every single log line beyond 2000 effectively resulted in an O(N²) time complexity bottleneck that froze the orchestrator loop. By deferring the cleanup operation until the buffer is full, array shifting overhead is drastically reduced.

📊 Impact: Reduces amortized O(N) element shifting cost to O(1) per insert on high-frequency log paths, eliminating service worker freezing during bulk runs.

🔬 Measurement: Ensure `node --test` runs completely and that `trimLog Internal` suite checks exact boundaries at 2500, not 2000.

---
*PR created automatically by Jules for task [11783915149566029250](https://jules.google.com/task/11783915149566029250) started by @n24q02m*