### PR TITLE
🎨 Palette: Wrap inputs in native form for implicit submission

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -37,3 +37,6 @@
 ## 2024-05-15 - Fix clipped focus rings with inset box-shadow
 **Learning:** When using inset box-shadow for focus rings to avoid clipping from overflow:hidden containers, ensure the shadow color contrasts with both active and inactive states. An inset shadow matching the background color becomes invisible.
 **Action:** Use outline: 2px solid transparent to retain Windows High Contrast Mode support, and select a contrasting inset shadow color (like #0f172a) for active states.
+## 2026-08-14 - Native Form Wrapping for Implicit Submission
+**Learning:** Native HTML5 validation attributes (`pattern`, `maxlength`) and implicit 'Enter' key submission are bypassed if the primary action button is not inside a semantic `<form>` element.
+**Action:** Always wrap form inputs and their corresponding action buttons in a semantic `<form>`, change the primary button to `type="submit"`, and handle the form's `submit` event (using `e.preventDefault()`) rather than listening to the button's `click` event.

--- a/popup.html
+++ b/popup.html
@@ -11,6 +11,7 @@
       <span class="version">v2.0</span>
     </header>
 
+    <form id="mainForm">
     <section class="options">
       <h2>Options</h2>
       <div class="setting-row">
@@ -69,8 +70,9 @@
       </label>
     </section>
 
-    <button type="button" id="startBtn" class="primary">Start Archiving</button>
+    <button type="submit" id="startBtn" class="primary">Start Archiving</button>
     <button type="button" id="resetBtn" class="secondary" style="display: none">Reset</button>
+    </form>
 
     <section id="progressSection" style="display: none">
       <h2>Progress</h2>

--- a/popup.js
+++ b/popup.js
@@ -16,6 +16,7 @@ const MAX_TOKEN_LEN = 255
 const ghOwnerInput = $('#ghOwner')
 const ghTokenInput = $('#ghToken')
 const forceCheckbox = $('#force')
+const mainForm = $('#mainForm')
 const startBtn = $('#startBtn')
 const resetBtn = $('#resetBtn')
 const progressSection = $('#progressSection')
@@ -122,7 +123,8 @@ ghTokenInput.addEventListener('change', () => {
 })
 
 // --- Start operation ---
-startBtn.addEventListener('click', async () => {
+mainForm.addEventListener('submit', async (e) => {
+  e.preventDefault()
   // Save settings first, ensuring token is only in local storage
   chrome.storage.sync.set({
     ghOwner: ghOwnerInput.value.trim().slice(0, MAX_OWNER_LEN)

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -45,7 +45,7 @@ function createMockElement(tag = 'div', attrs = {}) {
     dispatchEvent: (type) => {
       if (element.listeners?.[type]) {
         element.listeners[type].forEach((cb) => {
-          cb({ target: element })
+          cb({ target: element, preventDefault: () => {} })
         })
       }
     },
@@ -206,7 +206,8 @@ function setupPopupSandbox() {
     '#log': createMockElement('pre'),
     '#summary': createMockElement('div'),
     '.settings': createMockElement('section'),
-    '.setting-row': createMockElement('div')
+    '.setting-row': createMockElement('div'),
+    '#mainForm': createMockElement('form')
   }
 
   // Parent element for elements that use .parentElement in popup.js
@@ -376,7 +377,7 @@ describe('Initialization and Storage', () => {
 })
 
 describe('Button Event Handlers', () => {
-  it('should send START message when startBtn is clicked', async () => {
+  it('should send START message when form is submitted', async () => {
     const { sandbox, elements } = setupPopupSandbox()
     let sentMessage = null
     sandbox.chrome.runtime.sendMessage = (msg) => {
@@ -388,7 +389,7 @@ describe('Button Event Handlers', () => {
     elements['#ghOwner'].value = 'test-owner'
     elements['#ghToken'].value = 'test-token'
 
-    await elements['#startBtn'].dispatchEvent('click')
+    await elements['#mainForm'].dispatchEvent('submit')
 
     assert.strictEqual(sentMessage.action, 'START')
     assert.strictEqual(sentMessage.options.opMode, 'archive')


### PR DESCRIPTION
### 💡 What
Wrapped the settings and options inputs along with the primary action button in a semantic `<form>` element. Changed the primary button type to `"submit"` and updated the event listener in `popup.js` to listen for the `submit` event rather than `click`. Included test updates to reflect the new form structure and event handling.

### 🎯 Why
Native HTML5 validation attributes (like `pattern` and `maxlength`) and implicit 'Enter' key submission are bypassed if the primary action button is not inside a semantic `<form>` element. This change enables these native features, significantly improving keyboard accessibility and ensuring standard form behavior without adding custom keydown listeners.

### 📸 Before/After
*(Visuals remain identical, but functionality is enhanced)*

### ♿ Accessibility
* Enables implicit form submission (pressing "Enter" anywhere in the form to submit).
* Properly utilizes native HTML5 validation constraints.

---
*PR created automatically by Jules for task [14915630949852807561](https://jules.google.com/task/14915630949852807561) started by @n24q02m*