### PR TITLE
🎨 Palette: [UX improvement] Wrap inputs in semantic form for Enter key submission

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -37,3 +37,6 @@
 ## 2024-05-15 - Fix clipped focus rings with inset box-shadow
 **Learning:** When using inset box-shadow for focus rings to avoid clipping from overflow:hidden containers, ensure the shadow color contrasts with both active and inactive states. An inset shadow matching the background color becomes invisible.
 **Action:** Use outline: 2px solid transparent to retain Windows High Contrast Mode support, and select a contrasting inset shadow color (like #0f172a) for active states.
+## 2025-06-30 - Native HTML5 Validation and Implicit Submission
+**Learning:** Native HTML5 validation attributes (`pattern`, `maxlength`) and implicit 'Enter' key submission are bypassed if the primary action button is not inside a semantic `<form>` element.
+**Action:** Always wrap form inputs and their corresponding action buttons in a semantic `<form>`, change the primary button to `type="submit"`, and handle the form's `submit` event (using `e.preventDefault()`) rather than listening to the button's `click` event.

--- a/popup.html
+++ b/popup.html
@@ -11,6 +11,7 @@
       <span class="version">v2.0</span>
     </header>
 
+    <form id="mainForm">
     <section class="options">
       <h2>Options</h2>
       <div class="setting-row">
@@ -69,8 +70,9 @@
       </label>
     </section>
 
-    <button type="button" id="startBtn" class="primary">Start Archiving</button>
+    <button type="submit" id="startBtn" class="primary">Start Archiving</button>
     <button type="button" id="resetBtn" class="secondary" style="display: none">Reset</button>
+    </form>
 
     <section id="progressSection" style="display: none">
       <h2>Progress</h2>

--- a/popup.js
+++ b/popup.js
@@ -13,6 +13,7 @@ const MAX_OWNER_LEN = 39
 const MAX_TOKEN_LEN = 255
 
 // --- DOM refs ---
+const mainForm = $('#mainForm')
 const ghOwnerInput = $('#ghOwner')
 const ghTokenInput = $('#ghToken')
 const forceCheckbox = $('#force')
@@ -122,7 +123,8 @@ ghTokenInput.addEventListener('change', () => {
 })
 
 // --- Start operation ---
-startBtn.addEventListener('click', async () => {
+mainForm.addEventListener('submit', async (e) => {
+  e.preventDefault()
   // Save settings first, ensuring token is only in local storage
   chrome.storage.sync.set({
     ghOwner: ghOwnerInput.value.trim().slice(0, MAX_OWNER_LEN)

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -45,7 +45,7 @@ function createMockElement(tag = 'div', attrs = {}) {
     dispatchEvent: (type) => {
       if (element.listeners?.[type]) {
         element.listeners[type].forEach((cb) => {
-          cb({ target: element })
+          cb({ target: element, preventDefault: () => {} })
         })
       }
     },
@@ -196,6 +196,7 @@ function setupPopupSandbox() {
     '#ghOwner': createMockElement('input'),
     '#ghToken': createMockElement('input'),
     '#force': createMockElement('input', { type: 'checkbox' }),
+    '#mainForm': createMockElement('form'),
     '#startBtn': createMockElement('button'),
     'input[name="mode"]:checked': createMockElement('input', { value: 'dry' }),
     '#resetBtn': createMockElement('button'),
@@ -388,7 +389,7 @@ describe('Button Event Handlers', () => {
     elements['#ghOwner'].value = 'test-owner'
     elements['#ghToken'].value = 'test-token'
 
-    await elements['#startBtn'].dispatchEvent('click')
+    await elements['#mainForm'].dispatchEvent('submit')
 
     assert.strictEqual(sentMessage.action, 'START')
     assert.strictEqual(sentMessage.options.opMode, 'archive')


### PR DESCRIPTION
💡 What: Wrapped the settings, options, and primary action buttons in `popup.html` inside a semantic `<form>` element. Changed the primary action button to `type="submit"` and updated `popup.js` to listen for the form's `submit` event instead of the button's `click` event.
🎯 Why: Native HTML5 validation attributes (`pattern`, `maxlength`) and implicit "Enter" key submission are bypassed if the primary action button and inputs are not wrapped in a semantic `<form>`. This change allows users to submit the form simply by pressing the Enter key while focused on an input, dramatically improving usability.
📸 Before/After: Before, pressing Enter in an input field did nothing. After, pressing Enter submits the form properly. Visually, the UI looks identical.
♿ Accessibility: The semantic `<form>` provides better context for screen readers navigating the popup.

---
*PR created automatically by Jules for task [15237388288526501073](https://jules.google.com/task/15237388288526501073) started by @n24q02m*