### PR TITLE
🎨 Palette: Enable native HTML5 validation and Enter key submission

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -37,3 +37,6 @@
 ## 2024-05-15 - Fix clipped focus rings with inset box-shadow
 **Learning:** When using inset box-shadow for focus rings to avoid clipping from overflow:hidden containers, ensure the shadow color contrasts with both active and inactive states. An inset shadow matching the background color becomes invisible.
 **Action:** Use outline: 2px solid transparent to retain Windows High Contrast Mode support, and select a contrasting inset shadow color (like #0f172a) for active states.
+## 2025-06-25 - Form Submission and Native Validation
+**Learning:** Native HTML5 validation attributes (like `pattern` and `maxlength`) and implicit "Enter" key submission are bypassed if the inputs and the primary action button are not wrapped in a semantic `<form>` element and do not listen to the `submit` event.
+**Action:** Always wrap form inputs and their corresponding action buttons in a semantic `<form>`, change the primary button to `type="submit"`, and handle the form's `submit` event (using `e.preventDefault()`) rather than listening to the button's `click` event.

--- a/popup.html
+++ b/popup.html
@@ -11,66 +11,68 @@
       <span class="version">v2.0</span>
     </header>
 
-    <section class="options">
-      <h2>Options</h2>
-      <div class="setting-row">
-        <fieldset style="border: none; padding: 0; margin: 0; display: contents;">
-          <legend id="opModeLabel">Operation</legend>
-          <div class="segmented" id="opMode">
-            <button type="button" data-value="archive" class="active" aria-pressed="true">Archive Tasks</button>
-            <button type="button" data-value="suggestions" aria-pressed="false">Start Suggestions</button>
-          </div>
-        </fieldset>
-      </div>
-      <div class="setting-row">
-        <fieldset style="border: none; padding: 0; margin: 0; display: contents;">
-          <legend id="execModeLabel">Execution Mode</legend>
-          <div class="radio-group">
-            <label><input type="radio" name="mode" value="dry" checked /> Dry Run</label>
-            <label><input type="radio" name="mode" value="run" /> Run</label>
-          </div>
-        </fieldset>
-      </div>
-      <div class="setting-row">
-        <label class="checkbox">
-          <input type="checkbox" id="force" aria-describedby="forceHint" />
-          Force
+    <form id="mainForm">
+      <section class="options">
+        <h2>Options</h2>
+        <div class="setting-row">
+          <fieldset style="border: none; padding: 0; margin: 0; display: contents;">
+            <legend id="opModeLabel">Operation</legend>
+            <div class="segmented" id="opMode">
+              <button type="button" data-value="archive" class="active" aria-pressed="true">Archive Tasks</button>
+              <button type="button" data-value="suggestions" aria-pressed="false">Start Suggestions</button>
+            </div>
+          </fieldset>
+        </div>
+        <div class="setting-row">
+          <fieldset style="border: none; padding: 0; margin: 0; display: contents;">
+            <legend id="execModeLabel">Execution Mode</legend>
+            <div class="radio-group">
+              <label><input type="radio" name="mode" value="dry" checked /> Dry Run</label>
+              <label><input type="radio" name="mode" value="run" /> Run</label>
+            </div>
+          </fieldset>
+        </div>
+        <div class="setting-row">
+          <label class="checkbox">
+            <input type="checkbox" id="force" aria-describedby="forceHint" />
+            Force
+          </label>
+          <span class="hint" id="forceHint" style="display: block; margin-left: 20px; margin-top: 2px;">Archive every task, ignoring state and matching open Pull Requests</span>
+        </div>
+        <div class="setting-row">
+          <fieldset style="border: none; padding: 0; margin: 0; display: contents;">
+            <legend id="scopeLabel">Scope</legend>
+            <div class="radio-group">
+              <label><input type="radio" name="scope" value="current" /> Current tab</label>
+              <label><input type="radio" name="scope" value="all" checked /> All Jules tabs</label>
+            </div>
+          </fieldset>
+        </div>
+      </section>
+
+      <section class="settings">
+        <h2>Settings</h2>
+        <label for="ghOwner">
+          GitHub Owner <span class="hint" id="ghOwnerHint">(optional, used for PR checks)</span>
+          <input type="text" id="ghOwner" placeholder="your-github-username" spellcheck="false" autocomplete="username" aria-describedby="ghOwnerHint" maxlength="39" pattern="^[a-zA-Z0-9-]+$" />
         </label>
-        <span class="hint" id="forceHint" style="display: block; margin-left: 20px; margin-top: 2px;">Archive every task, ignoring state and matching open Pull Requests</span>
-      </div>
-      <div class="setting-row">
-        <fieldset style="border: none; padding: 0; margin: 0; display: contents;">
-          <legend id="scopeLabel">Scope</legend>
-          <div class="radio-group">
-            <label><input type="radio" name="scope" value="current" /> Current tab</label>
-            <label><input type="radio" name="scope" value="all" checked /> All Jules tabs</label>
-          </div>
-        </fieldset>
-      </div>
-    </section>
+        <label for="ghToken">
+          GitHub Token <span class="hint" id="ghTokenHint">(optional, for private repos)</span>
+          <input
+            type="password"
+            id="ghToken"
+            placeholder="ghp_..."
+            spellcheck="false"
+            autocomplete="current-password"
+            aria-describedby="ghTokenHint"
+            maxlength="255"
+          />
+        </label>
+      </section>
 
-    <section class="settings">
-      <h2>Settings</h2>
-      <label for="ghOwner">
-        GitHub Owner <span class="hint" id="ghOwnerHint">(optional, used for PR checks)</span>
-        <input type="text" id="ghOwner" placeholder="your-github-username" spellcheck="false" autocomplete="username" aria-describedby="ghOwnerHint" maxlength="39" pattern="^[a-zA-Z0-9-]+$" />
-      </label>
-      <label for="ghToken">
-        GitHub Token <span class="hint" id="ghTokenHint">(optional, for private repos)</span>
-        <input
-          type="password"
-          id="ghToken"
-          placeholder="ghp_..."
-          spellcheck="false"
-          autocomplete="current-password"
-          aria-describedby="ghTokenHint"
-          maxlength="255"
-        />
-      </label>
-    </section>
-
-    <button type="button" id="startBtn" class="primary">Start Archiving</button>
-    <button type="button" id="resetBtn" class="secondary" style="display: none">Reset</button>
+      <button type="submit" id="startBtn" class="primary">Start Archiving</button>
+      <button type="button" id="resetBtn" class="secondary" style="display: none">Reset</button>
+    </form>
 
     <section id="progressSection" style="display: none">
       <h2>Progress</h2>

--- a/popup.js
+++ b/popup.js
@@ -13,6 +13,7 @@ const MAX_OWNER_LEN = 39
 const MAX_TOKEN_LEN = 255
 
 // --- DOM refs ---
+const mainForm = $('#mainForm')
 const ghOwnerInput = $('#ghOwner')
 const ghTokenInput = $('#ghToken')
 const forceCheckbox = $('#force')
@@ -122,7 +123,9 @@ ghTokenInput.addEventListener('change', () => {
 })
 
 // --- Start operation ---
-startBtn.addEventListener('click', async () => {
+mainForm.addEventListener('submit', async (e) => {
+  e.preventDefault()
+
   // Save settings first, ensuring token is only in local storage
   chrome.storage.sync.set({
     ghOwner: ghOwnerInput.value.trim().slice(0, MAX_OWNER_LEN)

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -45,7 +45,7 @@ function createMockElement(tag = 'div', attrs = {}) {
     dispatchEvent: (type) => {
       if (element.listeners?.[type]) {
         element.listeners[type].forEach((cb) => {
-          cb({ target: element })
+          cb({ target: element, preventDefault: () => {} })
         })
       }
     },
@@ -193,6 +193,7 @@ function setupPopupSandbox() {
   }
 
   const elements = {
+    '#mainForm': createMockElement('form'),
     '#ghOwner': createMockElement('input'),
     '#ghToken': createMockElement('input'),
     '#force': createMockElement('input', { type: 'checkbox' }),
@@ -376,7 +377,7 @@ describe('Initialization and Storage', () => {
 })
 
 describe('Button Event Handlers', () => {
-  it('should send START message when startBtn is clicked', async () => {
+  it('should send START message when mainForm is submitted', async () => {
     const { sandbox, elements } = setupPopupSandbox()
     let sentMessage = null
     sandbox.chrome.runtime.sendMessage = (msg) => {
@@ -388,7 +389,7 @@ describe('Button Event Handlers', () => {
     elements['#ghOwner'].value = 'test-owner'
     elements['#ghToken'].value = 'test-token'
 
-    await elements['#startBtn'].dispatchEvent('click')
+    await elements['#mainForm'].dispatchEvent('submit')
 
     assert.strictEqual(sentMessage.action, 'START')
     assert.strictEqual(sentMessage.options.opMode, 'archive')


### PR DESCRIPTION
**💡 What**
Wrapped the inputs and primary action buttons in `popup.html` inside a semantic `<form id="mainForm">`. Changed the primary start button from `type="button"` to `type="submit"`. Updated `popup.js` to listen for the `submit` event on the form (with `e.preventDefault()`) instead of the `click` event on the button. Updated corresponding tests and added a learning.

**🎯 Why**
Native HTML5 validation attributes (like the existing `pattern` and `maxlength` on the GitHub Owner/Token inputs) and implicit "Enter" key submission are bypassed if the inputs and the primary action button are not wrapped in a semantic `<form>` element. This change makes the UI much more accessible and intuitive by enabling standard form behaviors.

**📸 Before/After**
The layout and visuals are unchanged as the `<form>` acts purely as a semantic wrapper. Verified by generating a screenshot via Playwright.

**♿ Accessibility**
Improves keyboard accessibility by allowing users to submit the configuration and start the operation simply by pressing the "Enter" key while focused on any of the input fields, instead of forcing them to manually tab to or click the start button. It also ensures native validation features correctly alert the user if invalid input is provided.

---
*PR created automatically by Jules for task [5309112009737292503](https://jules.google.com/task/5309112009737292503) started by @n24q02m*