### PR TITLE
🎨 Palette: Enable native form validation and Enter key submission

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -37,3 +37,6 @@
 ## 2024-05-15 - Fix clipped focus rings with inset box-shadow
 **Learning:** When using inset box-shadow for focus rings to avoid clipping from overflow:hidden containers, ensure the shadow color contrasts with both active and inactive states. An inset shadow matching the background color becomes invisible.
 **Action:** Use outline: 2px solid transparent to retain Windows High Contrast Mode support, and select a contrasting inset shadow color (like #0f172a) for active states.
+## 2025-06-26 - Semantic Forms for Validation and Enter Key Submission
+**Learning:** Native HTML5 validation attributes (`pattern`, `maxlength`) and implicit "Enter" key submission are completely bypassed if the primary action button is not inside a semantic `<form>` element.
+**Action:** Always wrap form inputs and their corresponding action buttons in a semantic `<form>`, change the primary button to `type="submit"`, and handle the form's `submit` event (using `e.preventDefault()`) rather than listening to the button's `click` event.

--- a/popup.html
+++ b/popup.html
@@ -11,6 +11,7 @@
       <span class="version">v2.0</span>
     </header>
 
+    <form id="mainForm">
     <section class="options">
       <h2>Options</h2>
       <div class="setting-row">
@@ -69,8 +70,9 @@
       </label>
     </section>
 
-    <button type="button" id="startBtn" class="primary">Start Archiving</button>
+    <button type="submit" id="startBtn" class="primary">Start Archiving</button>
     <button type="button" id="resetBtn" class="secondary" style="display: none">Reset</button>
+    </form>
 
     <section id="progressSection" style="display: none">
       <h2>Progress</h2>

--- a/popup.js
+++ b/popup.js
@@ -24,6 +24,7 @@ const currentInfo = $('#currentInfo')
 const progressFill = $('#progressFill')
 const logPre = $('#log')
 const summaryDiv = $('#summary')
+const mainForm = $('#mainForm')
 
 // --- Operation mode state ---
 let opMode = 'archive'
@@ -122,7 +123,8 @@ ghTokenInput.addEventListener('change', () => {
 })
 
 // --- Start operation ---
-startBtn.addEventListener('click', async () => {
+mainForm.addEventListener('submit', async (e) => {
+  e.preventDefault()
   // Save settings first, ensuring token is only in local storage
   chrome.storage.sync.set({
     ghOwner: ghOwnerInput.value.trim().slice(0, MAX_OWNER_LEN)

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -45,7 +45,7 @@ function createMockElement(tag = 'div', attrs = {}) {
     dispatchEvent: (type) => {
       if (element.listeners?.[type]) {
         element.listeners[type].forEach((cb) => {
-          cb({ target: element })
+          cb({ target: element, preventDefault: () => {} })
         })
       }
     },
@@ -206,7 +206,8 @@ function setupPopupSandbox() {
     '#log': createMockElement('pre'),
     '#summary': createMockElement('div'),
     '.settings': createMockElement('section'),
-    '.setting-row': createMockElement('div')
+    '.setting-row': createMockElement('div'),
+    '#mainForm': createMockElement('form')
   }
 
   // Parent element for elements that use .parentElement in popup.js
@@ -388,7 +389,7 @@ describe('Button Event Handlers', () => {
     elements['#ghOwner'].value = 'test-owner'
     elements['#ghToken'].value = 'test-token'
 
-    await elements['#startBtn'].dispatchEvent('click')
+    await elements['#mainForm'].dispatchEvent('submit')
 
     assert.strictEqual(sentMessage.action, 'START')
     assert.strictEqual(sentMessage.options.opMode, 'archive')


### PR DESCRIPTION
* 💡 What: Wrapped inputs and start button in a semantic `<form id="mainForm">`, changed start button to `type="submit"`, and migrated the click listener to a form submit listener.
* 🎯 Why: To enable implicit "Enter" key submission and ensure native HTML5 validation constraints (`maxlength`, `pattern`) are properly enforced before execution.
* 📸 Before/After: Visuals remain unchanged, but pressing Enter now triggers the action instead of doing nothing.
* ♿ Accessibility: Improved semantic structure enables screen readers to better identify the bounds and purpose of the input fields.

---
*PR created automatically by Jules for task [17352137506508081772](https://jules.google.com/task/17352137506508081772) started by @n24q02m*