### PR TITLE
🎨 Palette: Wrap settings in semantic form to enable implicit submission

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -37,3 +37,6 @@
 ## 2024-05-15 - Fix clipped focus rings with inset box-shadow
 **Learning:** When using inset box-shadow for focus rings to avoid clipping from overflow:hidden containers, ensure the shadow color contrasts with both active and inactive states. An inset shadow matching the background color becomes invisible.
 **Action:** Use outline: 2px solid transparent to retain Windows High Contrast Mode support, and select a contrasting inset shadow color (like #0f172a) for active states.
+## 2025-07-01 - Semantic Forms for Validation and Implicit Submission
+**Learning:** Native HTML5 validation attributes (pattern, maxlength) and implicit 'Enter' key submission are bypassed if the primary action button is not inside a semantic `<form>` element.
+**Action:** Always wrap form inputs and their corresponding action buttons in a semantic `<form>`, change the primary button to `type="submit"`, and handle the form's `submit` event (using `e.preventDefault()`) rather than listening to the button's `click` event.

--- a/popup.html
+++ b/popup.html
@@ -11,6 +11,7 @@
       <span class="version">v2.0</span>
     </header>
 
+    <form id="mainForm">
     <section class="options">
       <h2>Options</h2>
       <div class="setting-row">
@@ -69,8 +70,9 @@
       </label>
     </section>
 
-    <button type="button" id="startBtn" class="primary">Start Archiving</button>
+    <button type="submit" id="startBtn" class="primary">Start Archiving</button>
     <button type="button" id="resetBtn" class="secondary" style="display: none">Reset</button>
+    </form>
 
     <section id="progressSection" style="display: none">
       <h2>Progress</h2>

--- a/popup.js
+++ b/popup.js
@@ -16,6 +16,7 @@ const MAX_TOKEN_LEN = 255
 const ghOwnerInput = $('#ghOwner')
 const ghTokenInput = $('#ghToken')
 const forceCheckbox = $('#force')
+const mainForm = $('#mainForm')
 const startBtn = $('#startBtn')
 const resetBtn = $('#resetBtn')
 const progressSection = $('#progressSection')
@@ -122,7 +123,8 @@ ghTokenInput.addEventListener('change', () => {
 })
 
 // --- Start operation ---
-startBtn.addEventListener('click', async () => {
+mainForm.addEventListener('submit', async (e) => {
+  e.preventDefault()
   // Save settings first, ensuring token is only in local storage
   chrome.storage.sync.set({
     ghOwner: ghOwnerInput.value.trim().slice(0, MAX_OWNER_LEN)

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -42,10 +42,10 @@ function createMockElement(tag = 'div', attrs = {}) {
       if (!element.listeners[type]) element.listeners[type] = []
       element.listeners[type].push(cb)
     },
-    dispatchEvent: (type) => {
+    dispatchEvent: (type, payload = {}) => {
       if (element.listeners?.[type]) {
         element.listeners[type].forEach((cb) => {
-          cb({ target: element })
+          cb({ target: element, preventDefault: () => {}, ...payload })
         })
       }
     },
@@ -196,6 +196,7 @@ function setupPopupSandbox() {
     '#ghOwner': createMockElement('input'),
     '#ghToken': createMockElement('input'),
     '#force': createMockElement('input', { type: 'checkbox' }),
+    '#mainForm': createMockElement('form'),
     '#startBtn': createMockElement('button'),
     'input[name="mode"]:checked': createMockElement('input', { value: 'dry' }),
     '#resetBtn': createMockElement('button'),
@@ -376,7 +377,7 @@ describe('Initialization and Storage', () => {
 })
 
 describe('Button Event Handlers', () => {
-  it('should send START message when startBtn is clicked', async () => {
+  it('should send START message when mainForm is submitted', async () => {
     const { sandbox, elements } = setupPopupSandbox()
     let sentMessage = null
     sandbox.chrome.runtime.sendMessage = (msg) => {
@@ -388,7 +389,7 @@ describe('Button Event Handlers', () => {
     elements['#ghOwner'].value = 'test-owner'
     elements['#ghToken'].value = 'test-token'
 
-    await elements['#startBtn'].dispatchEvent('click')
+    await elements['#mainForm'].dispatchEvent('submit')
 
     assert.strictEqual(sentMessage.action, 'START')
     assert.strictEqual(sentMessage.options.opMode, 'archive')

--- a/tests/security.test.js
+++ b/tests/security.test.js
@@ -103,7 +103,7 @@ describe('Security: ghToken Storage Cleanup', () => {
     assert.ok(syncRemoved.includes('ghToken'), "sync.remove('ghToken') should have been called")
   })
 
-  it('should ensure startBtn click handler removes ghToken from sync', async () => {
+  it('should ensure mainForm submit handler removes ghToken from sync', async () => {
     // This is harder to test without a full DOM mock, but we can verify the code intent
     assert.ok(
       popupJs.includes("chrome.storage.sync.remove('ghToken')"),


### PR DESCRIPTION
**💡 What**
Wrapped the inputs and primary action buttons in `popup.html` inside a semantic `<form>` element. Changed the primary button to `type="submit"` and refactored `popup.js` to handle the `submit` event rather than listening for raw `click` events on the button itself.

**🎯 Why**
Previously, native HTML5 validation and implicit form submission (pressing "Enter" to submit while focused on an input field) were bypassed because the elements were not encapsulated in a semantic form block. Users had to manually navigate back to and click the "Start Archiving" button to proceed.

**📸 Before/After**
Visually identical layout and styling. Interactive behavior improved.

**♿ Accessibility**
Improves keyboard navigation and discoverability by allowing implicit submissions standard in native HTML.

---
*PR created automatically by Jules for task [15041125475678388250](https://jules.google.com/task/15041125475678388250) started by @n24q02m*