### PR TITLE
🎨 Palette: Use semantic <form> for inputs and submit validation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -37,3 +37,6 @@
 ## 2024-05-15 - Fix clipped focus rings with inset box-shadow
 **Learning:** When using inset box-shadow for focus rings to avoid clipping from overflow:hidden containers, ensure the shadow color contrasts with both active and inactive states. An inset shadow matching the background color becomes invisible.
 **Action:** Use outline: 2px solid transparent to retain Windows High Contrast Mode support, and select a contrasting inset shadow color (like #0f172a) for active states.
+## 2025-07-10 - Native Form Semantics for Validation and Key Binding
+**Learning:** Native HTML5 validation attributes (`pattern`, `maxlength`) and implicit "Enter" key submission are bypassed if the primary action button is not inside a semantic `<form>` element.
+**Action:** Always wrap form inputs and their corresponding action buttons in a semantic `<form>`, change the primary button to `type="submit"`, and handle the form's `submit` event (using `e.preventDefault()`) rather than listening to the button's `click` event.

--- a/popup.html
+++ b/popup.html
@@ -11,6 +11,7 @@
       <span class="version">v2.0</span>
     </header>
 
+    <form id="mainForm">
     <section class="options">
       <h2>Options</h2>
       <div class="setting-row">
@@ -69,8 +70,9 @@
       </label>
     </section>
 
-    <button type="button" id="startBtn" class="primary">Start Archiving</button>
+    <button type="submit" id="startBtn" class="primary">Start Archiving</button>
     <button type="button" id="resetBtn" class="secondary" style="display: none">Reset</button>
+    </form>
 
     <section id="progressSection" style="display: none">
       <h2>Progress</h2>

--- a/popup.js
+++ b/popup.js
@@ -15,6 +15,7 @@ const MAX_TOKEN_LEN = 255
 // --- DOM refs ---
 const ghOwnerInput = $('#ghOwner')
 const ghTokenInput = $('#ghToken')
+const mainForm = $('#mainForm')
 const forceCheckbox = $('#force')
 const startBtn = $('#startBtn')
 const resetBtn = $('#resetBtn')
@@ -122,7 +123,8 @@ ghTokenInput.addEventListener('change', () => {
 })
 
 // --- Start operation ---
-startBtn.addEventListener('click', async () => {
+mainForm.addEventListener('submit', async (e) => {
+  e.preventDefault()
   // Save settings first, ensuring token is only in local storage
   chrome.storage.sync.set({
     ghOwner: ghOwnerInput.value.trim().slice(0, MAX_OWNER_LEN)

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -42,10 +42,10 @@ function createMockElement(tag = 'div', attrs = {}) {
       if (!element.listeners[type]) element.listeners[type] = []
       element.listeners[type].push(cb)
     },
-    dispatchEvent: (type) => {
+    dispatchEvent: (type, payload = {}) => {
       if (element.listeners?.[type]) {
         element.listeners[type].forEach((cb) => {
-          cb({ target: element })
+          cb({ target: element, ...payload })
         })
       }
     },
@@ -201,6 +201,7 @@ function setupPopupSandbox() {
     '#resetBtn': createMockElement('button'),
     '#progressSection': createMockElement('section'),
     '#summarySection': createMockElement('section'),
+    '#mainForm': createMockElement('form'),
     '#currentInfo': createMockElement('div'),
     '#progressFill': createMockElement('div'),
     '#log': createMockElement('pre'),
@@ -376,7 +377,7 @@ describe('Initialization and Storage', () => {
 })
 
 describe('Button Event Handlers', () => {
-  it('should send START message when startBtn is clicked', async () => {
+  it('should send START message when mainForm is submitted', async () => {
     const { sandbox, elements } = setupPopupSandbox()
     let sentMessage = null
     sandbox.chrome.runtime.sendMessage = (msg) => {
@@ -388,8 +389,14 @@ describe('Button Event Handlers', () => {
     elements['#ghOwner'].value = 'test-owner'
     elements['#ghToken'].value = 'test-token'
 
-    await elements['#startBtn'].dispatchEvent('click')
+    let preventDefaultCalled = false
+    await elements['#mainForm'].dispatchEvent('submit', {
+      preventDefault: () => {
+        preventDefaultCalled = true
+      }
+    })
 
+    assert.strictEqual(preventDefaultCalled, true)
     assert.strictEqual(sentMessage.action, 'START')
     assert.strictEqual(sentMessage.options.opMode, 'archive')
     assert.strictEqual(elements['#startBtn'].disabled, true)


### PR DESCRIPTION
💡 **What:**
Wrapped the settings/options inputs and primary/secondary buttons in a semantic `<form id="mainForm">`, changed the `#startBtn` button to `type="submit"`, and updated `popup.js` to listen for the form's `submit` event (with `e.preventDefault()`) rather than the button's `click` event.

🎯 **Why:**
Native HTML5 form validation attributes (like `pattern` and `maxlength`) and implicit "Enter" key submission features are bypassed when standalone inputs and buttons are used without an enclosing semantic `<form>` element. Using a form improves usability (enter-to-submit) and relies on the browser for robust accessibility-friendly validation.

♿ **Accessibility:**
Enables native keyboard submission (pressing "Enter" inside an input field now triggers the form submission automatically) and allows screen readers to announce native validation constraints naturally.

📸 **Before/After:**
- Before: Pressing Enter in an input field did nothing. No native form validation was executed.
- After: Pressing Enter submits the form properly, and native validation alerts are surfaced to the user.

---
*PR created automatically by Jules for task [18188815995107063287](https://jules.google.com/task/18188815995107063287) started by @n24q02m*