### PR TITLE
🎨 Palette: Wrap settings in semantic form for Enter key submission and validation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -37,3 +37,6 @@
 ## 2024-05-15 - Fix clipped focus rings with inset box-shadow
 **Learning:** When using inset box-shadow for focus rings to avoid clipping from overflow:hidden containers, ensure the shadow color contrasts with both active and inactive states. An inset shadow matching the background color becomes invisible.
 **Action:** Use outline: 2px solid transparent to retain Windows High Contrast Mode support, and select a contrasting inset shadow color (like #0f172a) for active states.
+## 2025-07-20 - Native Form Validation and Submission
+**Learning:** Native HTML5 validation attributes (`pattern`, `maxlength`) and implicit "Enter" key submission are bypassed if form inputs and their primary action button are not wrapped in a semantic `<form>` element.
+**Action:** Always wrap form inputs and their corresponding action buttons in a semantic `<form>`, change the primary button to `type="submit"`, and handle the form`s `submit` event (using `e.preventDefault()`) rather than listening to the button`s `click` event.

--- a/popup.html
+++ b/popup.html
@@ -11,6 +11,7 @@
       <span class="version">v2.0</span>
     </header>
 
+    <form id="mainForm">
     <section class="options">
       <h2>Options</h2>
       <div class="setting-row">
@@ -69,8 +70,9 @@
       </label>
     </section>
 
-    <button type="button" id="startBtn" class="primary">Start Archiving</button>
+    <button type="submit" id="startBtn" class="primary">Start Archiving</button>
     <button type="button" id="resetBtn" class="secondary" style="display: none">Reset</button>
+    </form>
 
     <section id="progressSection" style="display: none">
       <h2>Progress</h2>

--- a/popup.js
+++ b/popup.js
@@ -16,6 +16,7 @@ const MAX_TOKEN_LEN = 255
 const ghOwnerInput = $('#ghOwner')
 const ghTokenInput = $('#ghToken')
 const forceCheckbox = $('#force')
+const mainForm = $('#mainForm')
 const startBtn = $('#startBtn')
 const resetBtn = $('#resetBtn')
 const progressSection = $('#progressSection')
@@ -122,7 +123,8 @@ ghTokenInput.addEventListener('change', () => {
 })
 
 // --- Start operation ---
-startBtn.addEventListener('click', async () => {
+mainForm.addEventListener('submit', async (e) => {
+  e.preventDefault()
   // Save settings first, ensuring token is only in local storage
   chrome.storage.sync.set({
     ghOwner: ghOwnerInput.value.trim().slice(0, MAX_OWNER_LEN)

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -42,10 +42,10 @@ function createMockElement(tag = 'div', attrs = {}) {
       if (!element.listeners[type]) element.listeners[type] = []
       element.listeners[type].push(cb)
     },
-    dispatchEvent: (type) => {
+    dispatchEvent: (type, event = {}) => {
       if (element.listeners?.[type]) {
         element.listeners[type].forEach((cb) => {
-          cb({ target: element })
+          cb({ target: element, ...event })
         })
       }
     },
@@ -193,6 +193,7 @@ function setupPopupSandbox() {
   }
 
   const elements = {
+    '#mainForm': createMockElement('form'),
     '#ghOwner': createMockElement('input'),
     '#ghToken': createMockElement('input'),
     '#force': createMockElement('input', { type: 'checkbox' }),
@@ -388,7 +389,7 @@ describe('Button Event Handlers', () => {
     elements['#ghOwner'].value = 'test-owner'
     elements['#ghToken'].value = 'test-token'
 
-    await elements['#startBtn'].dispatchEvent('click')
+    await elements['#mainForm'].dispatchEvent('submit', { preventDefault: () => {} })
 
     assert.strictEqual(sentMessage.action, 'START')
     assert.strictEqual(sentMessage.options.opMode, 'archive')


### PR DESCRIPTION
🎨 Palette: Wrap settings in semantic form for Enter key submission and validation

💡 What:
Wrapped the options and settings sections in `popup.html` inside a semantic `<form id="mainForm">` tag and updated the primary "Start Archiving" button to `type="submit"`. Changed `popup.js` to listen for the form's `submit` event (using `e.preventDefault()`) instead of the button's `click` event.

🎯 Why:
Wrapping inputs and action buttons in a semantic `<form>` allows browsers to enable implicit "Enter" key submission and respect native HTML5 validation attributes (like `pattern` and `maxlength`). Before this change, pressing Enter inside an input field would not trigger the primary action, and validation could be silently bypassed.

📸 Before/After:
Before: The primary action button had `type="button"` and listened for `click`.
After: The primary action button has `type="submit"` and the form listens for `submit`. Visually identical.

♿ Accessibility:
Improves keyboard navigation and accessibility by supporting standard browser behaviors for form submission.

---
*PR created automatically by Jules for task [10402981576311631235](https://jules.google.com/task/10402981576311631235) started by @n24q02m*