### PR TITLE
🛡️ Sentinel: [HIGH] Prevent token leakage via open redirects in fetch

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** The extension's Content Security Policy (CSP) in `manifest.json` lacked explicit `default-src 'none'` and broad network constraints, relying solely on script and object restrictions.
 **Learning:** A permissive CSP allows unexpected resource loading and potential data exfiltration if an XSS vulnerability occurs. A strict whitelist (`default-src 'none'`) provides a robust defense-in-depth layer.
 **Prevention:** Always define a strict CSP for extensions, setting `default-src 'none'` and explicitly allowing only required origins (e.g., `connect-src`).
+## 2024-08-22 - Prevent Token Leakage via Open Redirects
+**Vulnerability:** The custom `fetch` wrapper (`jFetch`) sends authorization tokens (like GitHub API keys) to authenticated endpoints but did not restrict the redirect behavior. If an endpoint is vulnerable to an open redirect, the browser could automatically follow it to an attacker-controlled domain, potentially leaking the authorization headers.
+**Learning:** By default, `fetch` follows redirects (`redirect: 'follow'`). When implementing network wrappers that transmit sensitive credentials, this default behavior poses a security risk if the destination endpoint cannot be fully trusted to never redirect to malicious origins.
+**Prevention:** Explicitly set `redirect: 'error'` or `redirect: 'manual'` in the `fetch` options for requests carrying sensitive credentials. This ensures the request will fail or can be manually inspected rather than automatically leaking headers to arbitrary domains.

--- a/background.js
+++ b/background.js
@@ -69,7 +69,8 @@ async function jFetch(url, options = {}) {
   const timeoutId = setTimeout(() => controller.abort(), timeout)
 
   try {
-    const res = await fetch(url, { headers, signal: controller.signal, ...rest })
+    // 🛡️ Sentinel: Prevent accidental token leakage via open redirects
+    const res = await fetch(url, { headers, signal: controller.signal, redirect: 'error', ...rest })
     if (!res.ok) {
       throw new Error(`HTTP ${res.status}`)
     }

--- a/tests/security.test.js
+++ b/tests/security.test.js
@@ -312,6 +312,23 @@ describe('jFetch SSRF Security', () => {
       message: /Security Error: Refusing to send GitHub token to non-GitHub origin/
     })
   })
+
+  it('should prevent token leakage via open redirects', async () => {
+    const { sandbox } = setupEnvironment()
+
+    let fetchOptions = null
+    sandbox.fetch = async (_url, options) => {
+      fetchOptions = options
+      return { ok: true, json: async () => [], text: async () => ")]}'\\n\\n4\\n[[]]" }
+    }
+
+    await sandbox.jFetch('https://api.github.com/repos/owner/repo', { token: 'secret-token' })
+    assert.strictEqual(
+      fetchOptions.redirect,
+      'error',
+      'fetch should be configured to error on redirects to prevent token leakage'
+    )
+  })
 })
 
 describe('getTabConfig Path Traversal Security', () => {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The custom `fetch` wrapper (`jFetch`) sends authorization tokens (like GitHub API keys) to authenticated endpoints but did not restrict the redirect behavior. If an endpoint is vulnerable to an open redirect, the browser could automatically follow it to an attacker-controlled domain, potentially leaking the authorization headers.
🎯 **Impact:** An attacker could potentially steal a user's GitHub Personal Access Token by exploiting an open redirect vulnerability on `api.github.com` or `jules.google.com`, granting them unauthorized access to the user's repositories.
🔧 **Fix:** Explicitly set `redirect: 'error'` in the default options for `jFetch` so that requests carrying sensitive credentials will fail on redirect rather than transparently following them.
✅ **Verification:** A new unit test was added to `tests/security.test.js` under the `jFetch SSRF Security` suite to ensure `redirect: 'error'` is explicitly passed to the underlying `fetch` call. The full test suite and linter pass.

---
*PR created automatically by Jules for task [14404742481262951704](https://jules.google.com/task/14404742481262951704) started by @n24q02m*