### PR TITLE
⚡ Bolt: Optimize trimLog with high-water mark buffer

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -7,3 +7,6 @@
 ## 2025-02-25 - Request Coalescing
 **Learning:** When fetching external data (like PRs) in parallel across multiple tabs, caching only the *resolved* result leads to thundering herd problems where multiple identical network requests are fired concurrently.
 **Action:** Cache the *Promise* of the fetch operation synchronously (request coalescing) so concurrent calls to the same resource wait on the same in-flight network request, saving API quota and time.
+## 2026-08-22 - High-Water Mark Array Buffer
+**Learning:** Calling `.splice(0, n)` on large arrays inside high-frequency paths (like `addLog` processing thousands of tasks) causes O(N^2) degradation as every element must be continuously shifted.
+**Action:** Implement a high-water mark buffer (`if (arr.length > MAX + BUFFER)`) to batch cleanup operations. This reduces CPU overhead significantly compared to enforcing the strict `MAX` length on every single insertion.

--- a/background.js
+++ b/background.js
@@ -902,12 +902,16 @@ const DEFAULT_STATE = {
 // stays bounded — otherwise the array grows without limit and every write
 // re-serializes the whole thing.
 const MAX_LOG_LINES = 2000
+const LOG_BUFFER = 500
 
 let state = { ...DEFAULT_STATE }
 let pendingFlush = null
 
+// ⚡ Bolt Optimization: Added LOG_BUFFER to create a high-water mark buffer.
+// Instead of splicing on every single task (which shifts the entire array and causes
+// O(N^2) CPU overhead), we batch cleanup operations only when the buffer overflows.
 function trimLog() {
-  if (state.log.length > MAX_LOG_LINES) {
+  if (state.log.length > MAX_LOG_LINES + LOG_BUFFER) {
     state.log.splice(0, state.log.length - MAX_LOG_LINES)
   }
 }

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -101,6 +101,7 @@ function setupEnvironment(initialStorage = {}) {
     globalThis.test_addLog = addLog;
     globalThis.test_trimLog = trimLog;
     globalThis.test_MAX_LOG_LINES = MAX_LOG_LINES;
+    globalThis.test_LOG_BUFFER = LOG_BUFFER;
     globalThis.test_buildBatchRequest = buildBatchRequest;
     globalThis.test_callBatchExecute = callBatchExecute;
     globalThis.test_runInPool = runInPool;
@@ -1346,13 +1347,16 @@ describe('state management', () => {
     assert.strictEqual(JSON.stringify(sessionSetData[0].archiveState.log), JSON.stringify(['Processing task 1']))
   })
 
-  it('caps the retained log at MAX_LOG_LINES, dropping the oldest lines', () => {
+  it('caps the retained log when it exceeds MAX_LOG_LINES + LOG_BUFFER', () => {
     const { sandbox } = setupEnvironment({})
-    for (let i = 0; i < 2500; i++) sandbox.test_addLog(`line ${i}`)
+    const max = sandbox.test_MAX_LOG_LINES
+    const buffer = sandbox.test_LOG_BUFFER
+    // Add exactly enough to trigger the first batch trim (max + buffer + 1)
+    for (let i = 0; i < max + buffer + 1; i++) sandbox.test_addLog(`line ${i}`)
     const log = sandbox.test_state().log
-    assert.strictEqual(log.length, 2000)
-    assert.strictEqual(log[log.length - 1], 'line 2499')
-    assert.strictEqual(log[0], 'line 500') // oldest 500 lines dropped
+    assert.strictEqual(log.length, max) // Trims down to max
+    assert.strictEqual(log[log.length - 1], `line ${max + buffer}`)
+    assert.strictEqual(log[0], `line ${buffer + 1}`) // oldest entries dropped
   })
 
   it('coalesces a storm of log writes into a single storage write', async () => {
@@ -2033,32 +2037,35 @@ describe('safeListSources', () => {
 })
 
 describe('trimLog Internal', () => {
-  it('should not trim if log length is equal to MAX_LOG_LINES', () => {
+  it('should not trim if log length is within high-water mark buffer (MAX_LOG_LINES + LOG_BUFFER)', () => {
     const { sandbox } = setupEnvironment()
     const max = sandbox.test_MAX_LOG_LINES
+    const buffer = sandbox.test_LOG_BUFFER
     const state = sandbox.test_state()
-    state.log = Array.from({ length: max }, (_, i) => `line ${i}`)
+    state.log = Array.from({ length: max + buffer }, (_, i) => `line ${i}`)
 
     sandbox.test_trimLog()
 
-    assert.strictEqual(state.log.length, max)
+    assert.strictEqual(state.log.length, max + buffer)
     assert.strictEqual(state.log[0], 'line 0')
-    assert.strictEqual(state.log[max - 1], `line ${max - 1}`)
+    assert.strictEqual(state.log[max + buffer - 1], `line ${max + buffer - 1}`)
   })
 
-  it('should trim oldest entries if log length exceeds MAX_LOG_LINES', () => {
+  it('should trim down to MAX_LOG_LINES if log exceeds MAX_LOG_LINES + LOG_BUFFER', () => {
     const { sandbox } = setupEnvironment()
     const max = sandbox.test_MAX_LOG_LINES
+    const buffer = sandbox.test_LOG_BUFFER
     const state = sandbox.test_state()
-    // Create max + 10 entries
-    state.log = Array.from({ length: max + 10 }, (_, i) => `line ${i}`)
+    // Create max + buffer + 10 entries
+    const extra = 10
+    state.log = Array.from({ length: max + buffer + extra }, (_, i) => `line ${i}`)
 
     sandbox.test_trimLog()
 
     assert.strictEqual(state.log.length, max)
-    // Should have removed the first 10 entries
-    assert.strictEqual(state.log[0], 'line 10')
-    assert.strictEqual(state.log[max - 1], `line ${max + 9}`)
+    // Should have removed the first buffer + extra entries
+    assert.strictEqual(state.log[0], `line ${buffer + extra}`)
+    assert.strictEqual(state.log[max - 1], `line ${max + buffer + extra - 1}`)
   })
 })
 


### PR DESCRIPTION
💡 **What:** Added a `LOG_BUFFER` (500) alongside `MAX_LOG_LINES` (2000) to create a high-water mark buffer in `trimLog()`. The log is now only spliced when its length exceeds `MAX_LOG_LINES + LOG_BUFFER`. Tests in `tests/background.test.js` were updated to insert `MAX_LOG_LINES + LOG_BUFFER + 1` entries to assert the correct batched cleanup logic.

🎯 **Why:** Previously, once the log reached `MAX_LOG_LINES`, every single new log entry inserted by `addLog()` triggered a `.splice(0, n)`. Splicing at the beginning of an array forces the JavaScript engine to shift every remaining element, causing an $O(N)$ operation per insert. Over thousands of tasks in a bulk run, this cascaded into an $O(N^2)$ performance bottleneck, tying up the CPU on the main thread.

📊 **Impact:** This optimization reduces the number of $O(N)$ shift operations by 500x. Cleanup is now batched, drastically reducing CPU overhead during high-frequency API batch processing.

🔬 **Measurement:** The tests in `tests/background.test.js` under the "trimLog Internal" describe block verify the batched behavior. You can also measure the main thread execution time of a large bulk archive run before and after this change.

---
*PR created automatically by Jules for task [17719941563684954271](https://jules.google.com/task/17719941563684954271) started by @n24q02m*